### PR TITLE
Fix AssertionError of RealTimeKeeper 

### DIFF
--- a/benchmarks/launch_hpo.py
+++ b/benchmarks/launch_hpo.py
@@ -343,7 +343,7 @@ if __name__ == '__main__':
             max_failures=params['max_failures'],
             asynchronous_scheduling=not params['synchronous'],
             print_update_interval=params['print_update_interval'],
-            callbacks=[SimulatorCallback()] if params['local_tuner'] and backend_name == 'simulated' else None
+            callbacks=[SimulatorCallback()] if backend_name == 'simulated' else None
         )
         last_tuner_name = local_tuner.name
         if exp_id == 0:


### PR DESCRIPTION
This PR fixes the following error that we get if we call launch_hpo.py

`AssertionError: RealTimeKeeper needs to be started, by calling start_of_time`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
