### PR TITLE
Doc: install instructions, move setup in How to run on SM upfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Syne Tune
 
+[![Release](https://img.shields.io/badge/release-0.11-brightgreen.svg)](https://pypi.org/project/syne-tune/)
+[![Python Version](https://img.shields.io/badge/python-3.8-brightgreen.svg)](https://pypi.org/project/syne-tune/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 This package provides state-of-the-art distributed hyperparameter optimizers (HPO) where trials 
  can be evaluated with several backend options (local backend to evaluate them locally; SageMaker to evaluate them as 
  separate SageMaker training jobs; another backend with fast startup times is also in the making).

--- a/release.sh
+++ b/release.sh
@@ -10,6 +10,8 @@
 
 set -e
 
+rm -rf dist/*
+
 version=$1
 version_file=version.py
 
@@ -22,6 +24,6 @@ git push
 
 # requires a test Pypi and a Pypi account
 # checks upload on testpypi first
-twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+# twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
 
 twine upload --verbose dist/*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This updates install instructions now now that the library is registered in pypi. Also:
* fixes some remaining naming issues
* put all installation instructions at the begining of the How to run on SageMaker section


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
