### PR TITLE
Allow default region to be configured in the AWS CLI in addition to AWS_DEFAULT_REGION

### DIFF
--- a/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
@@ -238,7 +238,7 @@ class SagemakerBackend(Backend):
             self.sm_estimator.dependencies = [Path(dep).name for dep in self.sm_estimator.dependencies]
 
     def initialize_sagemaker_session(self):
-        if 'AWS_DEFAULT_REGION' not in os.environ:
+        if boto3.Session().region_name is None:
             # avoids error "Must setup local AWS configuration with a region supported by SageMaker."
             # in case no region is explicitely configured
             os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -108,7 +108,7 @@ class RemoteLauncher:
         """
         self.prepare_upload()
 
-        if 'AWS_DEFAULT_REGION' not in os.environ:
+        if boto3.Session().region_name is None:
             # launching in this is needed to send a default configuration on the tuning loop running on Sagemaker
             # todo restore the env variable if present to avoid a side effect
             os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -231,7 +231,8 @@ class RemoteLauncher:
         """
         docker_image_name = "syne-tune-cpu-py36"
         account_id = boto3.client("sts").get_caller_identity()["Account"]
-        image_uri = f"{account_id}.dkr.ecr.us-west-2.amazonaws.com/{docker_image_name}"
+        region_name = boto3.Session().region_name
+        image_uri = f"{account_id}.dkr.ecr.{region_name}.amazonaws.com/{docker_image_name}"
         try:
             logging.info(f"Fetching Syne Tune image {image_uri}")
             boto3.client("ecr").list_images(repositoryName=docker_image_name)

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -194,6 +194,7 @@ class RemoteLauncher:
             "tuner_path": f"{self.upload_dir().name}/",
             "store_logs": self.store_logs_localbackend,
             "no_tuner_logging": self.no_tuner_logging,
+            "region_name": boto3.Session().region_name,
         }
         if self.log_level is not None:
             hyperparameters['log_level'] = self.log_level

--- a/syne_tune/remote/remote_main.py
+++ b/syne_tune/remote/remote_main.py
@@ -14,6 +14,7 @@
 Entrypoint script that allows to launch a tuning job remotely.
 It loads the tuner from a specified path then runs it.
 """
+import os
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
@@ -27,10 +28,13 @@ if __name__ == '__main__':
     parser.add_argument('--store_logs', dest='store_logs', action='store_true', default=False)
     parser.add_argument('--log_level', type=int, default=logging.INFO)
     parser.add_argument('--no_tuner_logging', type=str, default='False')
+    parser.add_argument('--region_name', type=str, default='us-west-2')
     args, _ = parser.parse_known_args()
 
     root = logging.getLogger()
     root.setLevel(args.log_level)
+
+    os.environ['AWS_DEFAULT_REGION'] = args.region_name
 
     tuner_path = Path(args.tuner_path)
     logging.info(f"load tuner from path {args.tuner_path}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Default AWS region can be specified in the AWS CLI config (`~/.aws/config`) in addition to environment variables. `boto3.Session()` provides an interface to both.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
