### PR TITLE
Refactor remote launcher to remove the `region_name` argument

### DIFF
--- a/syne_tune/remote/remote_main.py
+++ b/syne_tune/remote/remote_main.py
@@ -14,7 +14,6 @@
 Entrypoint script that allows to launch a tuning job remotely.
 It loads the tuner from a specified path then runs it.
 """
-import os
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
@@ -28,13 +27,10 @@ if __name__ == '__main__':
     parser.add_argument('--store_logs', dest='store_logs', action='store_true', default=False)
     parser.add_argument('--log_level', type=int, default=logging.INFO)
     parser.add_argument('--no_tuner_logging', type=str, default='False')
-    parser.add_argument('--region_name', type=str, default='us-west-2')
     args, _ = parser.parse_known_args()
 
     root = logging.getLogger()
     root.setLevel(args.log_level)
-
-    os.environ['AWS_DEFAULT_REGION'] = args.region_name
 
     tuner_path = Path(args.tuner_path)
     logging.info(f"load tuner from path {args.tuner_path}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Simplifying the remote launcher code as suggested in the [previous PR](https://github.com/awslabs/syne-tune/pull/54#discussion_r760158592).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
