### PR TITLE
More consistent path in remote instances

### DIFF
--- a/examples/launch_simulated_benchmark.py
+++ b/examples/launch_simulated_benchmark.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     n_workers = 4
 
     ## example of loading nasbench201 and then simulating tuning
-    blackbox_name, dataset, metric = "nasbench201", "cifar100", "metric_error"
+    blackbox_name, dataset, metric = "nasbench201", "cifar100", "metric_valid_error"
     # Note: The nasbench201 blackbox does not have an `elapsed_time_attr`,
     # but only a `time_this_resource_attr`. The former is appended as the
     # cumulative sum of the latter in the backend implementation.

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -279,6 +279,8 @@ class LocalBackend(Backend):
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         self.local_path = Path(results_root)
+        if tuner_name is not None:
+            self.local_path = self.local_path / tuner_name
         return self
 
     def entrypoint_path(self) -> Path:

--- a/syne_tune/remote/remote_main.py
+++ b/syne_tune/remote/remote_main.py
@@ -31,9 +31,9 @@ def decode_bool(hp: str):
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--tuner_path', type=str, default="tuner/")
-    parser.add_argument('--store_logs', type=str, default="false")
+    parser.add_argument('--store_logs', type=str, default="False")
     parser.add_argument('--log_level', type=int, default=logging.INFO)
-    parser.add_argument('--no_tuner_logging', type=str, default="false")
+    parser.add_argument('--no_tuner_logging', type=str, default="False")
     args, _ = parser.parse_known_args()
 
     root = logging.getLogger()

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -97,11 +97,9 @@ class Tuner:
         self.last_seen_result_per_trial = {}
         self.tuner_path = Path(experiment_path(tuner_name=self.name))
 
-        logger.info(f"results of trials will be saved on {self.tuner_path}")
-
-        # inform the backend to the name of the tuner. This allows the local backend
+        # inform the backend to the folder of the Tuner. This allows the local backend
         # to store the logs and tuner results in the same folder.
-        self.backend.set_path(results_root=self.tuner_path, tuner_name=self.name)
+        self.backend.set_path(results_root=self.tuner_path)
         self.callbacks = callbacks if callbacks is not None else [self._default_callback()]
 
         self.tuning_status = None
@@ -112,6 +110,8 @@ class Tuner:
         :return: the tuning status when finished
         """
         try:
+            logger.info(f"results of trials will be saved on {self.tuner_path}")
+
             if self.tuning_status is None:
                 self.tuning_status = TuningStatus(
                     metric_names=self.scheduler.metric_names(),

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -61,7 +61,7 @@ def experiment_path(
     if is_sagemaker:
         # if SM_MODEL_DIR is present in the environment variable, this means that we are running on Sagemaker
         # we use this path to store results as it is persisted by Sagemaker.
-        return Path('/opt/ml/checkpoints/')
+        return Path('/opt/ml/checkpoints') / tuner_name
     else:
         # means we are running on a local machine, we store results in a local path
         if local_path is None:


### PR DESCRIPTION
Improves consistency of paths and information display to users. 
* we now display "results of trials will be saved on ..." on the remote machine rather than the local one
* change the remote tuner path to be consistent with the path used locally e.g. `{syne-tune-root}/{tuner-name}`.
* fix boolean handling of remote arguments and use the same approach for both flags

The behavior is unchanged when running locally and the same s3 paths are used with the remote launcher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
