### PR TITLE
Clean up matching of configurations for (approximate) equality. Avoid…

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.random import RandomState
 
 from syne_tune.search_space import Domain, Categorical, \
-    non_constant_hyperparameter_keys, is_log_space
+    non_constant_hyperparameter_keys, is_log_space, config_to_match_string
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \
     import Hyperparameter, Configuration
 
@@ -229,3 +229,24 @@ class HyperparameterRanges(ABC):
             if skip_last and self.name_last_pos is not None:
                 keys = keys[:-1]  # Skip last pos
         return dict(zip(keys, config_tpl))
+
+    def config_to_match_string(
+            self, config: Configuration, keys=None,
+            skip_last: bool = False) -> str:
+        """
+        Maps configuration to  match string, used to compare for approximate
+        equality. Two configurations are considered to be different if their
+        match strings are not the same.
+
+        :param config: Configuration
+        :param keys: Overrides `_internal_keys`
+        :param skip_last: If True and `name_last_pos` is used, the
+            corresponding attribute is skipped, so that config and
+            tuple are non-extended
+        :return: Match string
+        """
+        if keys is None:
+            keys = self.internal_keys
+            if skip_last and self.name_last_pos is not None:
+                keys = keys[:-1]  # Skip last pos
+        return config_to_match_string(config, self.config_space, keys)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/tuning_job_state.py
@@ -58,8 +58,8 @@ class TuningJobState(object):
     def _config_key(self, config: Configuration) -> str:
         # If self.hp_ranges serves extended configs, the resource attribute
         # is skipped, so that `config` is always non-extended
-        return str(self.hp_ranges.config_to_tuple(
-            config, skip_last=True))
+        return self.hp_ranges.config_to_match_string(
+            config, skip_last=True)
 
     @property
     def config_pos(self) -> Dict[str, int]:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
@@ -280,7 +280,7 @@ class UnivariateSplineCostModel(NonLinearCostModel):
         weight_lst = [1] * num_data0
         data_config = dict()
         for config, target in dataset[num_data0:]:
-            config_key = str(self.hp_ranges.config_to_tuple(config))
+            config_key = self.hp_ranges.config_to_match_string(config)
             if config_key in data_config:
                 data_config[config_key][1].append(target)
             else:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -228,14 +228,14 @@ class ModelStateTransformer(object):
     # Note: Comparison by x.candidate == candidate does not work
     # here.
     def _find_candidate(self, candidate: Configuration, lst: List):
-        def _to_tuple(config):
-            return self._state.hp_ranges.config_to_tuple(config)
+        def _to_matchstr(config):
+            return self._state.hp_ranges.config_to_match_string(config)
 
-        cand_tpl = _to_tuple(candidate)
+        cand_tpl = _to_matchstr(candidate)
         try:
             pos = next(
                 i for i, x in enumerate(lst)
-                if _to_tuple(x.candidate) == cand_tpl)
+                if _to_matchstr(x.candidate) == cand_tpl)
         except StopIteration:
             pos = -1
         return pos

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
@@ -96,21 +96,21 @@ class ExclusionList(object):
                 self.keys = keys[:pos] + keys[(pos + 1):]
             _elist = [x.candidate for x in state.candidate_evaluations] + \
                      state.pending_candidates + state.failed_candidates
-            self.excl_set = set([self._to_tuple(x) for x in _elist])
+            self.excl_set = set([self._to_matchstr(x) for x in _elist])
         else:
             self.hp_ranges = state['hp_ranges']
             self.excl_set = state['excl_set']
             self.keys = state['keys']
         self.configspace_size = search_space_size(self.hp_ranges.config_space)
 
-    def _to_tuple(self, config) -> tuple:
-        return self.hp_ranges.config_to_tuple(config, keys=self.keys)
+    def _to_matchstr(self, config) -> str:
+        return self.hp_ranges.config_to_match_string(config, keys=self.keys)
 
     def contains(self, config: Configuration) -> bool:
-        return self._to_tuple(config) in self.excl_set
+        return self._to_matchstr(config) in self.excl_set
 
     def add(self, config: Configuration):
-        self.excl_set.add(self._to_tuple(config))
+        self.excl_set.add(self._to_matchstr(config))
 
     def copy(self) -> 'ExclusionList':
         return ExclusionList(

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
@@ -33,16 +33,13 @@ def _to_key(
         (str, Optional[int]):
     if configspace_ext is None:
         resource = None
-        config_tpl = tuple(
-            v for _, v in sorted(config.items(), key=lambda x: x[0]))
+        config_key = str(tuple(
+            v for _, v in sorted(config.items(), key=lambda x: x[0])))
     else:
-        attr = configspace_ext.resource_attr_name
-        resource = config.get(attr)
-        if resource is not None:
-            config = config.copy()
-            del config[attr]
-        config_tpl = configspace_ext.hp_ranges.config_to_tuple(config)
-    return config_tpl, resource
+        resource = config.get(configspace_ext.resource_attr_name)
+        config_key = configspace_ext.hp_ranges.config_to_match_string(
+            config, skip_last=True)
+    return config_key, resource
 
 
 def _param_dict_to_str(params: dict) -> str:

--- a/tst/schedulers/bayesopt/test_common.py
+++ b/tst/schedulers/bayesopt/test_common.py
@@ -95,18 +95,18 @@ def _map_pending_evaluations(lst, hp_ranges: HyperparameterRanges):
 
 @pytest.mark.parametrize('candidate_evaluations,failed_candidates,pending_candidates,expected', [
     ([], [], [], set()),
-    ([((123, 'a'), 9.87)], [], [], {(123, 'a')}),
-    ([], [(123, 'a')], [], {(123, 'a')}),
-    ([], [], [(123, 'a')], {(123, 'a')}),
+    ([((123, 'a'), 9.87)], [], [], {'hp1:123,hp2:0'}),
+    ([], [(123, 'a')], [], {'hp1:123,hp2:0'}),
+    ([], [], [(123, 'a')], {'hp1:123,hp2:0'}),
     ([((1, 'a'), 9.87)], [(2, 'b')], [(3, 'c')],
-     {(1, 'a'), (2, 'b'), (3, 'c')})
+     {'hp1:1,hp2:0', 'hp1:2,hp2:1', 'hp1:3,hp2:2'})
 ])
 def test_compute_blacklisted_candidates(
         hp_ranges: HyperparameterRanges,
         candidate_evaluations: List[Tuple],
         failed_candidates: List[Tuple],
         pending_candidates: List[Tuple],
-        expected: Set[Tuple]):
+        expected: Set[str]):
     state = TuningJobState(
         hp_ranges,
         candidate_evaluations=_map_candidate_evaluations(
@@ -120,7 +120,7 @@ def test_compute_blacklisted_candidates(
 
 def _assert_no_duplicates(
         candidates: List[Configuration], hp_ranges: HyperparameterRanges):
-    cands_tpl = [hp_ranges.config_to_tuple(x) for x in candidates]
+    cands_tpl = [hp_ranges.config_to_match_string(x) for x in candidates]
     assert len(candidates) == len(set(cands_tpl))
 
 


### PR DESCRIPTION
…s errors with categorical HPs with float values

*Issue #, if available:*

*Description of changes:*
Fixes the issues we had (David, Aaron) with duplicate configs being suggested, but only detected later. This PR is also making sure we can use str, int, float as value type for categorical everywhere.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
