### PR TITLE
add NAS-HPO-Bench

### DIFF
--- a/benchmarks/benchmark_factory.py
+++ b/benchmarks/benchmark_factory.py
@@ -14,6 +14,8 @@ import logging
 
 from benchmarks.definitions.nasbench201 import nasbench201_benchmark, \
     nasbench201_default_params
+from benchmarks.definitions.nas_hpo_bench import nashpobench_benchmark, nashpobench_default_params
+
 from examples.training_scripts.mlp_on_fashion_mnist.mlp_on_fashion_mnist \
     import mlp_fashionmnist_benchmark, mlp_fashionmnist_default_params
 from examples.training_scripts.resnet_cifar10.resnet_cifar10 import \
@@ -42,6 +44,14 @@ BENCHMARKS = {
         resnet_cifar10_benchmark, resnet_cifar10_default_params),
     'lstm_wikitext2': (
         lstm_wikitext2_benchmark, lstm_wikitext2_default_params),
+    'nashpobench_protein_structure': (
+        nashpobench_benchmark, nashpobench_default_params),
+    'nashpobench_naval_propulsion': (
+        nashpobench_benchmark, nashpobench_default_params),
+    'nashpobench_parkinsons_telemonitoring': (
+        nashpobench_benchmark, nashpobench_default_params),
+    'nashpobench_slice_localization': (
+        nashpobench_benchmark, nashpobench_default_params),
 }
 
 
@@ -53,9 +63,15 @@ def benchmark_factory(params):
     name = params['benchmark_name']
     assert name in supported_benchmarks(), \
         f"benchmark_name = {name} not supported, choose from:\n{supported_benchmarks()}"
+
     if name.startswith('nasbench201_'):
         dataset_name = name[len('nasbench201_'):]
         params['dataset_name'] = dataset_name
+
+    if name.startswith('nashpobench_'):
+        dataset_name = name[len('nashpobench_'):]
+        params['dataset_name'] = dataset_name
+
     benchmark, default_params = BENCHMARKS[name]
     # We want to use `default_params` of the benchmark as input if not in
     # `params`

--- a/benchmarks/benchmark_factory.py
+++ b/benchmarks/benchmark_factory.py
@@ -14,7 +14,7 @@ import logging
 
 from benchmarks.definitions.nasbench201 import nasbench201_benchmark, \
     nasbench201_default_params
-from benchmarks.definitions.nas_hpo_bench import nashpobench_benchmark, nashpobench_default_params
+from benchmarks.definitions.nashpobench import nashpobench_benchmark, nashpobench_default_params
 
 from examples.training_scripts.mlp_on_fashion_mnist.mlp_on_fashion_mnist \
     import mlp_fashionmnist_benchmark, mlp_fashionmnist_default_params

--- a/benchmarks/definitions/nashpobench.py
+++ b/benchmarks/definitions/nashpobench.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from pathlib import Path
+
+from syne_tune.search_space import choice, randint
+from blackbox_repository.conversion_scripts.scripts.fcnet_import import \
+    METRIC_ELAPSED_TIME, METRIC_VALID_LOSS, RESOURCE_ATTR, BLACKBOX_NAME
+
+
+_config_space = {
+        "hp_activation_fn_1": choice(["tanh", "relu"]),
+        "hp_activation_fn_2": choice(["tanh", "relu"]),
+        "hp_batch_size": randint(0, 4),
+        "hp_dropout_1": randint(0, 3),
+        "hp_dropout_2": randint(0, 3),
+        "hp_init_lr": randint(0, 5),
+        'hp_lr_schedule': choice(["cosine", "const"]),
+        'hp_n_units_1': randint(0, 5),
+        'hp_n_units_2': randint(0, 5),
+    }
+
+
+def nashpobench_default_params(params=None):
+    dont_sleep = str(
+        params is not None and params.get('backend') == 'simulated')
+    return {
+        'max_resource_level': 100,
+        'grace_period': 1,
+        'reduction_factor': 3,
+        'instance_type': 'ml.m5.large',
+        'num_workers': 4,
+        'framework': 'PyTorch',
+        'framework_version': '1.6',
+        'dataset_name': 'protein_structure',
+        'dont_sleep': dont_sleep,
+        'cost_model_type': 'linear',
+    }
+
+
+def nashpobench_benchmark(params):
+    """
+    The underlying tabulated blackbox does not have an `elapsed_time_attr`,
+    but only a `time_this_resource_attr`.
+
+    """
+    config_space = dict(
+        _config_space,
+        epochs=params['max_resource_level'],
+        dataset_name=params['dataset_name'],
+        dont_sleep=params['dont_sleep'],
+        blackbox_repo_s3_root=params.get('blackbox_repo_s3_root'))
+    return {
+        'script': Path(__file__).parent.parent.parent / "examples" / "training_scripts" / "nas_hpo_bench" / "nas_hpo_bench.py",
+        'metric': METRIC_VALID_LOSS,
+        'mode': 'min',
+        'resource_attr': RESOURCE_ATTR,
+        'elapsed_time_attr': METRIC_ELAPSED_TIME,
+        'max_resource_attr': 'epochs',
+        'config_space': config_space,
+        'cost_model': None,
+        'supports_simulated': True,
+        'blackbox_name': BLACKBOX_NAME,
+        'time_this_resource_attr': METRIC_ELAPSED_TIME,
+    }
+

--- a/benchmarks/definitions/nashpobench.py
+++ b/benchmarks/definitions/nashpobench.py
@@ -12,12 +12,14 @@
 # permissions and limitations under the License.
 from pathlib import Path
 import numpy as np
-
-from syne_tune.search_space import choice, randint, uniform, loguniform
-from blackbox_repository.conversion_scripts.scripts.fcnet_import import \
-    METRIC_ELAPSED_TIME, METRIC_VALID_LOSS, RESOURCE_ATTR, BLACKBOX_NAME
+from random import shuffle
 
 from sklearn.ensemble import RandomForestRegressor
+
+from syne_tune.search_space import choice, randint, uniform, loguniform
+
+from blackbox_repository.conversion_scripts.scripts.fcnet_import import \
+    METRIC_ELAPSED_TIME, METRIC_VALID_LOSS, RESOURCE_ATTR, BLACKBOX_NAME
 
 
 class SubsamplingSurrogate(object):
@@ -28,7 +30,7 @@ class SubsamplingSurrogate(object):
     def fit(self, X, y):
         n = int(X.shape[0] * self.ratio)
         idx = [i for i in range(X.shape[0])]
-        from random import shuffle
+
         shuffle(idx)
         idx = idx[:n]
         X_train = X[idx]

--- a/benchmarks/definitions/nashpobench.py
+++ b/benchmarks/definitions/nashpobench.py
@@ -12,22 +12,24 @@
 # permissions and limitations under the License.
 from pathlib import Path
 
-from syne_tune.search_space import choice, randint
+from syne_tune.search_space import choice, randint, uniform, loguniform
 from blackbox_repository.conversion_scripts.scripts.fcnet_import import \
     METRIC_ELAPSED_TIME, METRIC_VALID_LOSS, RESOURCE_ATTR, BLACKBOX_NAME
 
+from sklearn.ensemble import RandomForestRegressor
+
 
 _config_space = {
-        "hp_activation_fn_1": choice(["tanh", "relu"]),
-        "hp_activation_fn_2": choice(["tanh", "relu"]),
-        "hp_batch_size": randint(0, 4),
-        "hp_dropout_1": randint(0, 3),
-        "hp_dropout_2": randint(0, 3),
-        "hp_init_lr": randint(0, 5),
-        'hp_lr_schedule': choice(["cosine", "const"]),
-        'hp_n_units_1': randint(0, 5),
-        'hp_n_units_2': randint(0, 5),
-    }
+    "hp_activation_fn_1": choice(["tanh", "relu"]),
+    "hp_activation_fn_2": choice(["tanh", "relu"]),
+    "hp_batch_size": randint(8, 64),
+    "hp_dropout_1": uniform(0.0, 0.6),
+    "hp_dropout_2": uniform(0.0, 0.6),
+    "hp_init_lr": loguniform(0.0005, 0.1),
+    'hp_lr_schedule': choice(["cosine", "const"]),
+    'hp_n_units_1': randint(16, 512),
+    'hp_n_units_2': randint(16, 512),
+}
 
 
 def nashpobench_default_params(params=None):
@@ -60,7 +62,7 @@ def nashpobench_benchmark(params):
         dont_sleep=params['dont_sleep'],
         blackbox_repo_s3_root=params.get('blackbox_repo_s3_root'))
     return {
-        'script': Path(__file__).parent.parent.parent / "examples" / "training_scripts" / "nas_hpo_bench" / "nas_hpo_bench.py",
+        'script': Path(__file__).parent.parent.parent / "examples" / "training_scripts" / "nashpobench" / "nashpobench.py",
         'metric': METRIC_VALID_LOSS,
         'mode': 'min',
         'resource_attr': RESOURCE_ATTR,
@@ -70,6 +72,7 @@ def nashpobench_benchmark(params):
         'cost_model': None,
         'supports_simulated': True,
         'blackbox_name': BLACKBOX_NAME,
+        'surrogate': RandomForestRegressor(),
         'time_this_resource_attr': METRIC_ELAPSED_TIME,
     }
 

--- a/benchmarks/launch_hpo.py
+++ b/benchmarks/launch_hpo.py
@@ -275,6 +275,7 @@ if __name__ == '__main__':
                 backend_kwargs.update({
                     'blackbox_name': blackbox_name,
                     'dataset': params.get('dataset_name'),
+                    'surrogate': benchmark.get('surrogate'),
                     'time_this_resource_attr': benchmark.get(
                         'time_this_resource_attr'),
                     'max_resource_attr': benchmark.get('max_resource_attr'),

--- a/blackbox_repository/blackbox_surrogate.py
+++ b/blackbox_repository/blackbox_surrogate.py
@@ -79,14 +79,20 @@ class BlackboxSurrogate(Blackbox):
         # gets hyperparameters types, categorical for CategoricalHyperparameter, numeric for everything else
         numeric = []
         categorical = []
-        features = list(self.configuration_space.keys())
-        if self.fidelity_space is not None:
-            features += self.fidelity_space.keys()
-        for hp in features:
+        for hp_name in self.configuration_space:
+            hp = self.configuration_space[hp_name]
             if isinstance(hp, sp.Categorical):
-                categorical.append(hp)
+                categorical.append(hp_name)
             else:
-                numeric.append(hp)
+                numeric.append(hp_name)
+
+        if self.fidelity_space is not None:
+            for fideltiy_name in self.fidelity_space:
+                hp = self.fidelity_space[fideltiy_name]
+                if isinstance(hp, sp.Categorical):
+                    categorical.append(fideltiy_name)
+                else:
+                    numeric.append(fideltiy_name)
 
         # apply transformation to columns according its type
         print(f"fitting surrogate predicting {self.y.columns} given numerical cols {numeric} and "

--- a/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -29,6 +29,18 @@ METRIC_ELAPSED_TIME = 'metric_elapsed_time'
 
 RESOURCE_ATTR = 'hp_epoch'
 
+CONFIG_SPACE = {
+    "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
+    "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
+    "hp_batch_size": sp.choice([8, 16, 32, 64]),
+    "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
+    "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
+    "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
+    'hp_lr_schedule': sp.choice(["cosine", "const"]),
+    'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
+    'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
+}
+
 
 def convert_dataset(dataset_path: Path, max_rows: int = None):
     data = h5py.File(dataset_path, "r")
@@ -98,17 +110,6 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
             np.stack([data[key][m][:].astype('float32') for key in tqdm(keys)])
         )
 
-    configuration_space = {
-        "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
-        "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
-        "hp_batch_size": sp.choice([8, 16, 32, 64]),
-        "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
-        "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
-        "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
-        'hp_lr_schedule': sp.choice(["cosine", "const"]),
-        'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
-        'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
-    }
     fidelity_space = {
         RESOURCE_ATTR: sp.randint(lower=1, upper=100)
     }
@@ -119,7 +120,7 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
     assert objective_names[4] == METRIC_ELAPSED_TIME
     return BlackboxTabular(
         hyperparameters=hyperparameters,
-        configuration_space=configuration_space,
+        configuration_space=CONFIG_SPACE,
         fidelity_space=fidelity_space,
         objectives_evaluations=objective_evaluations,
         fidelity_values=fidelity_values,

--- a/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -16,10 +16,9 @@ import h5py
 from tqdm import tqdm as tqdm
 
 from blackbox_repository.blackbox_tabular import serialize, BlackboxTabular
+import syne_tune.search_space as sp
 from blackbox_repository.conversion_scripts.utils import repository_path
-
 from syne_tune.util import catchtime
-from syne_tune.search_space import choice, randint, loguniform, uniform
 
 
 BLACKBOX_NAME = 'fcnet'
@@ -29,30 +28,6 @@ METRIC_VALID_LOSS = 'metric_valid_loss'
 METRIC_ELAPSED_TIME = 'metric_elapsed_time'
 
 RESOURCE_ATTR = 'hp_epoch'
-
-# CONFIG_SPACE = {
-#     "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
-#     "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
-#     "hp_batch_size": sp.choice([8, 16, 32, 64]),
-#     "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
-#     "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
-#     "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
-#     'hp_lr_schedule': sp.choice(["cosine", "const"]),
-#     'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
-#     'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
-# }
-
-CONFIG_SPACE = {
-    "hp_activation_fn_1": choice(["tanh", "relu"]),
-    "hp_activation_fn_2": choice(["tanh", "relu"]),
-    "hp_batch_size": randint(8, 64),
-    "hp_dropout_1": uniform(0.0, 0.6),
-    "hp_dropout_2": uniform(0.0, 0.6),
-    "hp_init_lr": loguniform(0.0005, 0.1),
-    'hp_lr_schedule': choice(["cosine", "const"]),
-    'hp_n_units_1': randint(16, 512),
-    'hp_n_units_2': randint(16, 512),
-}
 
 
 def convert_dataset(dataset_path: Path, max_rows: int = None):
@@ -123,8 +98,19 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
             np.stack([data[key][m][:].astype('float32') for key in tqdm(keys)])
         )
 
+    configuration_space = {
+        "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
+        "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
+        "hp_batch_size": sp.choice([8, 16, 32, 64]),
+        "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
+        "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
+        "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
+        'hp_lr_schedule': sp.choice(["cosine", "const"]),
+        'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
+        'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
+    }
     fidelity_space = {
-        RESOURCE_ATTR: randint(lower=1, upper=100)
+        RESOURCE_ATTR: sp.randint(lower=1, upper=100)
     }
 
     objective_names = [f"metric_{m}" for m in objective_names]
@@ -133,7 +119,7 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
     assert objective_names[4] == METRIC_ELAPSED_TIME
     return BlackboxTabular(
         hyperparameters=hyperparameters,
-        configuration_space=CONFIG_SPACE,
+        configuration_space=configuration_space,
         fidelity_space=fidelity_space,
         objectives_evaluations=objective_evaluations,
         fidelity_values=fidelity_values,

--- a/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -16,9 +16,10 @@ import h5py
 from tqdm import tqdm as tqdm
 
 from blackbox_repository.blackbox_tabular import serialize, BlackboxTabular
-import syne_tune.search_space as sp
 from blackbox_repository.conversion_scripts.utils import repository_path
+
 from syne_tune.util import catchtime
+from syne_tune.search_space import choice, randint, loguniform, uniform
 
 
 BLACKBOX_NAME = 'fcnet'
@@ -29,16 +30,28 @@ METRIC_ELAPSED_TIME = 'metric_elapsed_time'
 
 RESOURCE_ATTR = 'hp_epoch'
 
+# CONFIG_SPACE = {
+#     "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
+#     "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
+#     "hp_batch_size": sp.choice([8, 16, 32, 64]),
+#     "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
+#     "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
+#     "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
+#     'hp_lr_schedule': sp.choice(["cosine", "const"]),
+#     'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
+#     'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
+# }
+
 CONFIG_SPACE = {
-    "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
-    "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
-    "hp_batch_size": sp.choice([8, 16, 32, 64]),
-    "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
-    "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
-    "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
-    'hp_lr_schedule': sp.choice(["cosine", "const"]),
-    'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
-    'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
+    "hp_activation_fn_1": choice(["tanh", "relu"]),
+    "hp_activation_fn_2": choice(["tanh", "relu"]),
+    "hp_batch_size": randint(8, 64),
+    "hp_dropout_1": uniform(0.0, 0.6),
+    "hp_dropout_2": uniform(0.0, 0.6),
+    "hp_init_lr": loguniform(0.0005, 0.1),
+    'hp_lr_schedule': choice(["cosine", "const"]),
+    'hp_n_units_1': randint(16, 512),
+    'hp_n_units_2': randint(16, 512),
 }
 
 
@@ -111,7 +124,7 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
         )
 
     fidelity_space = {
-        RESOURCE_ATTR: sp.randint(lower=1, upper=100)
+        RESOURCE_ATTR: randint(lower=1, upper=100)
     }
 
     objective_names = [f"metric_{m}" for m in objective_names]

--- a/examples/training_scripts/nashpobench/nashpobench.py
+++ b/examples/training_scripts/nashpobench/nashpobench.py
@@ -16,7 +16,6 @@ import logging
 import time
 
 from syne_tune.report import Reporter
-from syne_tune.search_space import Categorical
 
 from benchmarks.checkpoint import resume_from_checkpointed_model, \
     checkpoint_model_at_rung_level, add_checkpointing_to_argparse

--- a/examples/training_scripts/nashpobench/nashpobench.py
+++ b/examples/training_scripts/nashpobench/nashpobench.py
@@ -39,7 +39,7 @@ def objective(config):
     for k in CONFIG_SPACE:
         if k in ["hp_batch_size", "hp_dropout_1", "hp_dropout_2",
                  "hp_init_lr", 'hp_n_units_1', 'hp_n_units_2']:
-            config[k] = CONFIG_SPACE[k].categories[config[k]]
+            essential_config[k] = CONFIG_SPACE[k].categories[config[k]]
 
     fidelity_range = (1, config['epochs'])
     all_metrics = metrics_for_configuration(

--- a/examples/training_scripts/nashpobench/nashpobench.py
+++ b/examples/training_scripts/nashpobench/nashpobench.py
@@ -1,0 +1,126 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import os
+import argparse
+import logging
+import time
+
+from syne_tune.report import Reporter
+from syne_tune.search_space import Categorical
+
+from benchmarks.checkpoint import resume_from_checkpointed_model, \
+    checkpoint_model_at_rung_level, add_checkpointing_to_argparse
+from benchmarks.utils import parse_bool
+from blackbox_repository.conversion_scripts.scripts.fcnet_import import \
+    METRIC_VALID_LOSS, METRIC_ELAPSED_TIME, RESOURCE_ATTR,  BLACKBOX_NAME, CONFIG_SPACE
+
+
+def objective(config):
+    dont_sleep = parse_bool(config['dont_sleep'])
+
+    ts_start = time.time()
+    s3_root = config.get('blackbox_repo_s3_root')
+    blackbox = load_blackbox(
+        BLACKBOX_NAME, s3_root=s3_root)[config['dataset_name']]
+    # We load metric values for all epochs required here
+    essential_config = {
+        k: config[k] for k in CONFIG_SPACE}
+
+    # cast integers back to categoricals
+    for k in CONFIG_SPACE:
+        if k in ["hp_batch_size", "hp_dropout_1", "hp_dropout_2",
+                 "hp_init_lr", 'hp_n_units_1', 'hp_n_units_2']:
+            config[k] = CONFIG_SPACE[k].categories[config[k]]
+
+    fidelity_range = (1, config['epochs'])
+    all_metrics = metrics_for_configuration(
+        blackbox=blackbox,
+        config=essential_config,
+        resource_attr=RESOURCE_ATTR,
+        fidelity_range=fidelity_range)
+    startup_overhead = time.time() - ts_start
+
+    report = Reporter()
+
+    # Checkpointing
+    # Since this is a tabular benchmark, checkpointing is not really needed.
+    # Still, we use a "checkpoint" file in order to store the epoch at which
+    # the evaluation was paused, since this information is not passed
+
+    def load_model_fn(local_path: str) -> int:
+        local_filename = os.path.join(local_path, 'checkpoint.json')
+        try:
+            with open(local_filename, 'r') as f:
+                data = json.load(f)
+                resume_from = int(data['epoch'])
+        except Exception:
+            resume_from = 0
+        return resume_from
+
+    def save_model_fn(local_path: str, epoch: int):
+        os.makedirs(local_path, exist_ok=True)
+        local_filename = os.path.join(local_path, 'checkpoint.json')
+        with open(local_filename, 'w') as f:
+            json.dump({'epoch': str(epoch)}, f)
+
+    resume_from = resume_from_checkpointed_model(config, load_model_fn)
+
+    # Loop over epochs
+    elapsed_time = 0
+    for epoch in range(resume_from + 1, config['epochs'] + 1):
+        metrics_this_epoch = all_metrics[epoch - 1]
+        time_this_epoch = metrics_this_epoch[METRIC_ELAPSED_TIME]
+        valid_error = metrics_this_epoch[METRIC_VALID_LOSS]
+        elapsed_time += time_this_epoch
+
+        if not dont_sleep:
+            if epoch == resume_from + 1:
+                # Subtract startup overhead of loading the table
+                time_this_epoch = max(time_this_epoch - startup_overhead, 0.0)
+            time.sleep(time_this_epoch)
+
+        report_dict = {
+            RESOURCE_ATTR: epoch,
+            METRIC_VALID_LOSS: valid_error,
+            METRIC_ELAPSED_TIME: elapsed_time}
+        report(**report_dict)
+
+        # Write checkpoint (optional)
+        if (not dont_sleep) or epoch == config['epochs']:
+            checkpoint_model_at_rung_level(config, save_model_fn, epoch)
+
+
+if __name__ == '__main__':
+    # Benchmark-specific imports are done here, in order to avoid import
+    # errors if the dependencies are not installed (such errors should happen
+    # only when the code is really called)
+    import json
+
+    from blackbox_repository import load as load_blackbox
+    from blackbox_repository.utils import metrics_for_configuration
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--epochs', type=int, required=True)
+    parser.add_argument('--dataset_name', type=str, required=True)
+    parser.add_argument('--dont_sleep', type=str, required=True)
+    parser.add_argument('--blackbox_repo_s3_root', type=str)
+    for name in CONFIG_KEYS:
+        parser.add_argument(f"--{name}", type=str, required=True)
+    add_checkpointing_to_argparse(parser)
+
+    args, _ = parser.parse_known_args()
+
+    objective(config=vars(args))

--- a/examples/training_scripts/nashpobench/requirements.txt
+++ b/examples/training_scripts/nashpobench/requirements.txt
@@ -1,0 +1,1 @@
+filelock


### PR DESCRIPTION
Add NAS-HPO-Bench Benchmark. We use a surrogate model, trained on a subset of the data, to project hyperparameters from integer to categorical values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
