### PR TITLE
Joint posterior sampling for gp_expdecay models

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
@@ -384,7 +384,6 @@ def sample_posterior_marginals(
     return anp.multiply(post_stds, n01_mat) + _colvec(post_means)
 
 
-# TODO!! Use precomputation and `issm_likelihood_computations` !!
 def sample_posterior_joint(
         poster_state: Dict, mean, kernel, feature, targets: List,
         issm_params: Dict, r_min: int, r_max: int, random_state: RandomState,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code for sampling the unobserved part of a learning curve, given the observed part (and everything else). This is an important missing piece for simulation-based scoring. It is also useful to plot learning curve probabilistic predictions. Code for the ISS learning curve model was already present.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
