### PR TITLE
Allow to fix seed when querying blackbox

### DIFF
--- a/benchmarks/launch_hpo.py
+++ b/benchmarks/launch_hpo.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
                     'time_this_resource_attr': benchmark.get(
                         'time_this_resource_attr'),
                     'max_resource_attr': benchmark.get('max_resource_attr'),
-                    'fixed_seed': params.get('blackbox_fixed_seed'),
+                    'seed': params.get('blackbox_fixed_seed'),
                 })
                 backend = BlackboxRepositoryBackend(**backend_kwargs)
         else:

--- a/benchmarks/launch_hpo.py
+++ b/benchmarks/launch_hpo.py
@@ -272,13 +272,16 @@ if __name__ == '__main__':
                 # Tabulated benchmark from the blackbox repository (simulation
                 # runs faster)
                 logger.info(f"Using 'simulated' back-end with blackbox_name = {blackbox_name}")
+                seed = params.get('blackbox_seed')
+                if seed is not None:
+                    logger.info(f"Using blackbox with blackbox_seed = {seed}")
                 backend_kwargs.update({
                     'blackbox_name': blackbox_name,
                     'dataset': params.get('dataset_name'),
                     'time_this_resource_attr': benchmark.get(
                         'time_this_resource_attr'),
                     'max_resource_attr': benchmark.get('max_resource_attr'),
-                    'seed': params.get('blackbox_fixed_seed'),
+                    'seed': seed,
                 })
                 backend = BlackboxRepositoryBackend(**backend_kwargs)
         else:

--- a/benchmarks/launch_hpo.py
+++ b/benchmarks/launch_hpo.py
@@ -278,6 +278,7 @@ if __name__ == '__main__':
                     'time_this_resource_attr': benchmark.get(
                         'time_this_resource_attr'),
                     'max_resource_attr': benchmark.get('max_resource_attr'),
+                    'fixed_seed': params.get('blackbox_fixed_seed'),
                 })
                 backend = BlackboxRepositoryBackend(**backend_kwargs)
         else:

--- a/benchmarks/launch_utils.py
+++ b/benchmarks/launch_utils.py
@@ -155,6 +155,10 @@ def parse_args(allow_lists_as_values=True):
     parser.add_argument('--blackbox_repo_s3_root', type=str,
                         help='S3 root directory for blackbox repository. '
                              'Defaults to default bucket of session')
+    parser.add_argument('--blackbox_fixed_seed', type=int,
+                        help='Fixed seeds of blackbox queries to this value '
+                             '(0 is safe), so that they return the same '
+                             'metric values for the same config')
     # Arguments for scheduler
     parser.add_argument('--brackets', type=int,
                         help='Number of brackets in HyperbandScheduler',

--- a/benchmarks/launch_utils.py
+++ b/benchmarks/launch_utils.py
@@ -155,7 +155,7 @@ def parse_args(allow_lists_as_values=True):
     parser.add_argument('--blackbox_repo_s3_root', type=str,
                         help='S3 root directory for blackbox repository. '
                              'Defaults to default bucket of session')
-    parser.add_argument('--blackbox_fixed_seed', type=int,
+    parser.add_argument('--blackbox_seed', type=int,
                         help='Fixed seeds of blackbox queries to this value '
                              '(0 is safe), so that they return the same '
                              'metric values for the same config')

--- a/blackbox_repository/blackbox_tabular.py
+++ b/blackbox_repository/blackbox_tabular.py
@@ -86,7 +86,7 @@ class BlackboxTabular(Blackbox):
             seed: Optional[int] = None
     ) -> Dict:
         if seed is not None:
-            assert seed < self.num_seeds
+            assert 0 <= seed < self.num_seeds
         try:
             key = tuple([configuration[key] for key in self._hp_cols])
             matching_index = self.hyperparameters_index.loc[key].values

--- a/blackbox_repository/tabulated_benchmark.py
+++ b/blackbox_repository/tabulated_benchmark.py
@@ -29,7 +29,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
     def __init__(self, elapsed_time_attr: str,
                  time_this_resource_attr: Optional[str] = None,
                  max_resource_attr: Optional[str] = None,
-                 fixed_seed: Optional[int] = None,
+                 seed: Optional[int] = None,
                  **simulatorbackend_kwargs):
         """
         Allows to simulate any blackbox from blackbox-repository, can be either a blackbox from a registered
@@ -57,7 +57,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         resource. This is used by schedulers which limit each evaluation by
         setting this argument (e.g., promotion-based Hyperband).
 
-        If `fixed_seed` is given, entries of the blackbox are queried for this
+        If `seed` is given, entries of the blackbox are queried for this
         seed. Otherwise, a seed is drawn at random for every trial, but the
         same seed is used for all `_run_job_and_collect_results` calls for the
         same trial. This is important for pause and resume scheduling.
@@ -65,7 +65,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         :param elapsed_time_attr: See above
         :param time_this_resource_attr: See above
         :param max_resource_attr: See above
-        :param fixed_seed: See above
+        :param seed: See above
         """
         super().__init__(
             # TODO we feed a dummy value for entry_point since they are not required
@@ -76,7 +76,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         self._time_this_resource_attr = time_this_resource_attr
         self._max_resource_attr = max_resource_attr
         self.simulatorbackend_kwargs = simulatorbackend_kwargs
-        self._fixed_seed = fixed_seed
+        self._seed = seed
         self._seed_for_trial = dict()
 
     @property
@@ -93,7 +93,7 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         return metrics_for_configuration(
             blackbox=self.blackbox, config=config,
             resource_attr=self.resource_attr, fidelity_range=fidelity_range,
-            fixed_seed=seed)
+            seed=seed)
 
     def _run_job_and_collect_results(
             self, trial_id: int,
@@ -110,8 +110,8 @@ class _BlackboxSimulatorBackend(SimulatorBackend):
         # Seed for query to blackbox. It is important to use the same
         # seed for all queries for the same `trial_id`
         seed = None
-        if self._fixed_seed is not None:
-            seed = self._fixed_seed
+        if self._seed is not None:
+            seed = self._seed
         elif isinstance(self.blackbox, BlackboxTabular):
             seed = self._seed_for_trial.get(trial_id)
             if seed is None:
@@ -152,7 +152,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             elapsed_time_attr: str,
             time_this_resource_attr: Optional[str] = None,
             max_resource_attr: Optional[str] = None,
-            fixed_seed: Optional[int] = None,
+            seed: Optional[int] = None,
             dataset: Optional[str] = None,
             surrogate=None,
             **simulatorbackend_kwargs,
@@ -178,7 +178,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             elapsed_time_attr=elapsed_time_attr,
             time_this_resource_attr=time_this_resource_attr,
             max_resource_attr=max_resource_attr,
-            fixed_seed=fixed_seed,
+            seed=seed,
             **simulatorbackend_kwargs)
         self.blackbox_name = blackbox_name
         self.dataset = dataset
@@ -234,7 +234,7 @@ class UserBlackboxBackend(_BlackboxSimulatorBackend):
             elapsed_time_attr: str,
             time_this_resource_attr: Optional[str] = None,
             max_resource_attr: Optional[str] = None,
-            fixed_seed: Optional[int] = None,
+            seed: Optional[int] = None,
             **simulatorbackend_kwargs,
     ):
         """
@@ -250,6 +250,6 @@ class UserBlackboxBackend(_BlackboxSimulatorBackend):
             elapsed_time_attr=elapsed_time_attr,
             time_this_resource_attr=time_this_resource_attr,
             max_resource_attr=max_resource_attr,
-            fixed_seed=fixed_seed,
+            seed=seed,
             **simulatorbackend_kwargs)
         self.blackbox = blackbox

--- a/blackbox_repository/utils.py
+++ b/blackbox_repository/utils.py
@@ -17,7 +17,8 @@ from blackbox_repository.blackbox import Blackbox
 
 def metrics_for_configuration(
         blackbox: Blackbox, config: dict, resource_attr: str,
-        fidelity_range: Optional[Tuple[float, float]] = None) -> List[dict]:
+        fidelity_range: Optional[Tuple[float, float]] = None,
+        fixed_seed: Optional[int] = None) -> List[dict]:
     """
     Returns all results for configuration `config` at fidelities in range
     `fidelity_range`.
@@ -27,6 +28,8 @@ def metrics_for_configuration(
     :param resource_attr: Name of resource attribute
     :param fidelity_range: Range [min_f, max_f], only fidelities in this range
         (both ends inclusive) are returned. Default is no filtering
+    :param fixed_seed: Seed for queries to blackbox. Drawn at random if not
+        given
     :return: List of result dicts
 
     """
@@ -40,7 +43,7 @@ def metrics_for_configuration(
         assert len(fidelity_range) == 2 \
                and fidelity_range[0] <= fidelity_range[1], \
         f"fidelity_range = {fidelity_range} must be tuple (min, max), min <= max"
-    objective_values = blackbox._objective_function(config)
+    objective_values = blackbox._objective_function(config, seed=fixed_seed)
     for fidelity, value in enumerate(all_fidelities):
         if value >= fidelity_range[0] and value <= fidelity_range[1]:
             res_dict = dict(zip(blackbox.objectives_names,

--- a/blackbox_repository/utils.py
+++ b/blackbox_repository/utils.py
@@ -18,7 +18,7 @@ from blackbox_repository.blackbox import Blackbox
 def metrics_for_configuration(
         blackbox: Blackbox, config: dict, resource_attr: str,
         fidelity_range: Optional[Tuple[float, float]] = None,
-        fixed_seed: Optional[int] = None) -> List[dict]:
+        seed: Optional[int] = None) -> List[dict]:
     """
     Returns all results for configuration `config` at fidelities in range
     `fidelity_range`.
@@ -28,7 +28,7 @@ def metrics_for_configuration(
     :param resource_attr: Name of resource attribute
     :param fidelity_range: Range [min_f, max_f], only fidelities in this range
         (both ends inclusive) are returned. Default is no filtering
-    :param fixed_seed: Seed for queries to blackbox. Drawn at random if not
+    :param seed: Seed for queries to blackbox. Drawn at random if not
         given
     :return: List of result dicts
 
@@ -43,7 +43,7 @@ def metrics_for_configuration(
         assert len(fidelity_range) == 2 \
                and fidelity_range[0] <= fidelity_range[1], \
         f"fidelity_range = {fidelity_range} must be tuple (min, max), min <= max"
-    objective_values = blackbox._objective_function(config, seed=fixed_seed)
+    objective_values = blackbox._objective_function(config, seed=seed)
     for fidelity, value in enumerate(all_fidelities):
         if value >= fidelity_range[0] and value <= fidelity_range[1]:
             res_dict = dict(zip(blackbox.objectives_names,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/debug_log.py
@@ -240,10 +240,10 @@ class DebugLogPrinter(object):
             for name in ('state', 'targets', 'params'):
                 v = info.get(name)
                 if v is not None:
-                    if name == 'params':
-                        parts.append(v)
-                    else:
+                    if name == 'targets':
                         debug_parts.append(v)
+                    else:
+                        parts.append(v)
                 else:
                     logger.info(
                         "debug_log.write_block: '{}' part is missing!".format(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows seed for blackbox queries to be fixed, so that these queries become deterministic. This is needed if a blackbox is used for testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
