### PR TITLE
Report last metric in tuning statuses

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -113,14 +113,11 @@ class Tuner:
             logger.info(f"results of trials will be saved on {self.tuner_path}")
 
             if self.tuning_status is None:
-                self.tuning_status = TuningStatus(
-                    metric_names=self.scheduler.metric_names(),
-                    metric_mode=self.scheduler.metric_mode()
-                )
+                self.tuning_status = TuningStatus(metric_names=self.scheduler.metric_names())
             # prints the status every print_update_interval seconds
             self.status_printer = RegularCallback(
                 call_seconds_frequency=self.print_update_interval,
-                callback=lambda tuning_status: logger.info("tuning status\n" + str(tuning_status)),
+                callback=lambda tuning_status: logger.info("tuning status (last metric is reported)\n" + str(tuning_status)),
             )
             # saves the tuner every results_update_interval seconds
             self.tuner_saver = RegularCallback(

--- a/tst/test_status.py
+++ b/tst/test_status.py
@@ -16,7 +16,7 @@ from syne_tune.tuning_status import TuningStatus, print_best_metric_found
 
 def test_status():
     metric_names = ['NLL', 'time']
-    status = TuningStatus(metric_names=metric_names, metric_mode='min')
+    status = TuningStatus(metric_names=metric_names)
 
     trial0 = Trial(trial_id=0, config={"x": 1.0}, creation_time=None)
     trial1 = Trial(trial_id=1, config={"x": 5.0}, creation_time=None)
@@ -52,6 +52,7 @@ def test_status():
     assert status.trial_metric_statistics[0].max_metrics == {'NLL': 2.0, 'time': 20.0}
     assert status.trial_metric_statistics[0].min_metrics == {'NLL': 0.0, 'time': 10.0}
     assert status.trial_metric_statistics[0].sum_metrics == {'NLL': 3.0, 'time': 42.0}
+    assert status.trial_metric_statistics[0].last_metrics == {'NLL': 0.0, 'time': 20.0}
 
     print(str(status))
 


### PR DESCRIPTION
*Description of changes:* Some users reported that having status report min/max of metrics depending on the mode is a bit counter-intuitive. This change makes the status report the last metric which is more intuitive, it also makes this explicit.


Before

```
Resource summary:
 trial_id     status  iter  steps  width  height  step  mean_loss  epoch  worker-time
        0  Completed   100    100     10       0     0   0.100000      1    10.189253
        1  Completed   100    100     13      96     0   9.677101      1    10.188962
```

After

```
Resource summary (last result is reported):
 trial_id     status  iter  steps  width  height  step  mean_loss  epoch  worker-time
        0  Completed   100    100     10       0    99   0.100000    100    10.165935
        1  Completed   100    100     13      96    99   9.677101    100    10.168060
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
