### PR TITLE
Add best_config method, enrich metadata automatically generated.

### DIFF
--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -12,10 +12,8 @@
 # permissions and limitations under the License.
 import logging
 from pathlib import Path
-import matplotlib.pyplot as plt
 
 from syne_tune.backend.local_backend import LocalBackend
-from syne_tune.constants import ST_TUNER_TIME
 from syne_tune.experiments import load_experiment
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune.tuner import Tuner

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
         metric=metric,
         random_seed=random_seed)
 
-    stop_criterion = StoppingCriterion(max_wallclock_time=60)
+    stop_criterion = StoppingCriterion(max_wallclock_time=20)
     tuner = Tuner(
         backend=backend,
         scheduler=scheduler,
@@ -66,9 +66,7 @@ if __name__ == '__main__':
 
     tuning_experiment = load_experiment(tuner.name)
     print(tuning_experiment)
-    df = tuning_experiment.results.sort_values(ST_TUNER_TIME)
-    df.loc[:, 'best'] = df.loc[:, metric].cummin()
-    df.plot(x=ST_TUNER_TIME, y="best")
-    plt.xlabel("wallclock time")
-    plt.ylabel(metric)
-    plt.show()
+
+    print(f"best result found: {tuning_experiment.best_config()}")
+
+    tuning_experiment.plot()

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -39,9 +39,6 @@ class ExperimentResult:
         res = f"Experiment {self.name}"
         if self.results is not None:
             res += f" contains {len(self.results)} evaluations from {len(self.results.trial_id.unique())} trials"
-        if self.tuner is not None:
-            metrics = ", ".join(self.tuner.scheduler.metric_names())
-            res += f" when tuning {metrics} on {self.entrypoint_name()} with {self.scheduler_name()}."
         return res
 
     def creation_date(self):
@@ -50,8 +47,7 @@ class ExperimentResult:
     def plot(self, **plt_kwargs):
         import matplotlib.pyplot as plt
 
-        scheduler = self.tuner.scheduler
-        metric = self.metric_name()
+        metric = self.metric_names()[0]
         df = self.results
         df = df.sort_values(ST_TUNER_TIME)
         x = df.loc[:, ST_TUNER_TIME]
@@ -59,20 +55,42 @@ class ExperimentResult:
         plt.plot(x, y, **plt_kwargs)
         plt.xlabel("wallclock time")
         plt.ylabel(metric)
-        plt.title(self.entrypoint_name() + "-" + scheduler.__class__.__name__)
+        plt.title(self.entrypoint_name() + " " + self.name)
+        plt.legend()
+        plt.show()
 
-    def metric_mode(self):
-        return self.tuner.scheduler.metric_mode()
+    def metric_mode(self) -> str:
+        return self.metadata['metric_mode']
 
-    def metric_name(self) -> str:
-        return self.tuner.scheduler.metric_names()[0]
+    def metric_names(self) -> List[str]:
+        return self.metadata['metric_names']
 
     def entrypoint_name(self) -> str:
-        return Path(self.tuner.backend.entrypoint_path()).stem
+        return self.metadata['entrypoint']
 
-    def scheduler_name(self) -> str:
-        return self.tuner.scheduler.__class__.__name__
+    def best_config(self) -> Dict:
+        """
+        Return the best config found for the first metric defined in the scheduler.
+        :param self:
+        :return:
+        """
+        metric_names = self.metric_names()
+        metric_mode = self.metric_mode()
 
+        if len(metric_names) > 1:
+            logging.warning("Several metrics exists so the best is not defined, this will return the best other the"
+                            f"first metric {metric_names}.")
+        metric_name = metric_names[0]
+
+        # locate best result
+        if metric_mode == 'min':
+            best_index = self.results.loc[:, metric_name].argmin()
+        else:
+            best_index = self.results.loc[:, metric_name].argmax()
+        res = dict(self.results.loc[best_index])
+
+        # dont include internal fields
+        return {k: v for k, v in res.items() if not k.startswith("st_")}
 
 def download_single_experiment(
         tuner_name: str,

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -13,7 +13,6 @@
 import json
 import logging
 from datetime import datetime
-from pathlib import Path
 from typing import List, Dict, Callable, Optional
 
 import boto3


### PR DESCRIPTION
*Issue #87:*

*Description of changes:* enable doing `experiment.best_config()` as recommended in #87 . Also avoid accessing the tuner for plotting and getting best results.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
