### PR TITLE
Sets the tuner_name field to be set inside Backend object.

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -99,7 +99,7 @@ class Tuner:
 
         # inform the backend to the folder of the Tuner. This allows the local backend
         # to store the logs and tuner results in the same folder.
-        self.backend.set_path(results_root=self.tuner_path)
+        self.backend.set_path(results_root=self.tuner_path, tuner_name=self.name)
         self.callbacks = callbacks if callbacks is not None else [self._default_callback()]
 
         self.tuning_status = None


### PR DESCRIPTION
*Description of changes:*
Sets the tuner_name field to be set inside the `Backend` object.  
This was necessary for me to be able to rerun `docs/tutorials/basics/scripts/launch_sagemaker_backend.py` multiple times, because of SM Training instance non-unique name clashes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
