### PR TITLE
Fix path in sagemaker backend

### DIFF
--- a/syne_tune/backend/backend.py
+++ b/syne_tune/backend/backend.py
@@ -196,12 +196,12 @@ class Backend(object):
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         """
-        :param results_root: the parent that should contains the results of the tuning experiment.
+        :param results_root: the local folder that should contains the results of the tuning experiment.
         Used by Tuner to indicate a desired path where the results should be written to. This is used
          to unify the location of backend files and Tuner results when possible (in the local backend).
          By default, the backend does not do anything since not all backends may be able to unify their files
          locations.
-        :param tuner_name: name of the tuner
+        :param tuner_name: name of the tuner can be used for instance to save checkpoints on remote storage.
         """
         pass
 

--- a/syne_tune/backend/backend.py
+++ b/syne_tune/backend/backend.py
@@ -196,7 +196,7 @@ class Backend(object):
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         """
-        :param results_root: the parent that should contains the results of all experiments
+        :param results_root: the parent that should contains the results of the tuning experiment.
         Used by Tuner to indicate a desired path where the results should be written to. This is used
          to unify the location of backend files and Tuner results when possible (in the local backend).
          By default, the backend does not do anything since not all backends may be able to unify their files

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -279,9 +279,6 @@ class LocalBackend(Backend):
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         self.local_path = Path(results_root)
-        if tuner_name is not None:
-            self.local_path = self.local_path / tuner_name
-        return self
 
     def entrypoint_path(self) -> Path:
         return Path(self.entry_point)

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -99,7 +99,7 @@ class Tuner:
 
         # inform the backend to the folder of the Tuner. This allows the local backend
         # to store the logs and tuner results in the same folder.
-        self.backend.set_path(results_root=self.tuner_path)
+        self.backend.set_path(results_root=self.tuner_path, tuner_name=self.name)
         self.callbacks = callbacks if callbacks is not None else [self._default_callback()]
 
         self.tuning_status = None

--- a/tst/util_test.py
+++ b/tst/util_test.py
@@ -21,4 +21,6 @@ def temporary_local_backend(entry_point: str):
     :return: a backend whose files are deleted after finishing to avoid side-effects. This is used in unit-tests.
     """
     with tempfile.TemporaryDirectory() as local_path:
-        return LocalBackend(entry_point=entry_point).set_path(results_root=local_path)
+        backend = LocalBackend(entry_point=entry_point)
+        backend.set_path(results_root=local_path)
+        return backend


### PR DESCRIPTION
*Issue #115*

*Description of changes:* fix the issue of not setting sagemaker jobs uniquely. 
It works as intended on sagemaker backend. The small difference with #112 is that it also avoid having a path `{syne_tune_path}/{tuner_name}/{tuner_name}` when running with the local backend (e.g. it does not change how path are stored when running with local backend locally or remotely).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
