### PR TITLE
Allow to skip local optimization of acquisition function, and just se…

### DIFF
--- a/benchmarking/cli/launch_utils.py
+++ b/benchmarking/cli/launch_utils.py
@@ -245,6 +245,9 @@ def parse_args(allow_lists_as_values=True):
                         help='Scoring function to rank initial candidates '
                              'for seeding search [thompson_indep, acq_func]',
                         **allow_list)
+    parser.add_argument('--searcher_skip_local_optimization', action='store_true',
+                        help='Skip local optimization of acquisition function '
+                             'and just pick top-scorer of initial candidates')
     parser.add_argument('--searcher_issm_gamma_one', action='store_true',
                         help='Fix gamma parameter of ISSM to one?')
     parser.add_argument('--searcher_exponent_cost', type=float,
@@ -374,6 +377,7 @@ def make_searcher_and_scheduler(params) -> (dict, dict):
             ('opt_nstarts', int, False),
             ('opt_maxiter', int, False),
             ('initial_scoring', str, False),
+            ('skip_local_optimization', bool, False),
             ('issm_gamma_one', bool, False),
             ('exponent_cost', float, False),
             ('expdecay_normalize_inputs', bool, False),

--- a/syne_tune/optimizer/schedulers/searchers/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/constrained_gp_fifo_searcher.py
@@ -83,22 +83,11 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
         output_model_factory = self.state_transformer.model_factory
         # Call internal constructor
         new_searcher = ConstrainedGPFIFOSearcher(
-            configspace=self.configspace,
-            metric=self._metric,
-            clone_from_state=True,
-            hp_ranges=self.hp_ranges,
+            **self._new_searcher_kwargs_for_clone(),
             output_model_factory=output_model_factory,
-            acquisition_class=self.acquisition_class,
-            map_reward=self.map_reward,
             init_state=init_state,
-            local_minimizer_class=self.local_minimizer_class,
             output_skip_optimization=output_skip_optimization,
-            num_initial_candidates=self.num_initial_candidates,
-            num_initial_random_choices=self.num_initial_random_choices,
-            initial_scoring=self.initial_scoring,
-            cost_attr=self._cost_attr,
-            constraint_attr=self._constraint_attr,
-            resource_attr=self._resource_attr)
+            constraint_attr=self._constraint_attr)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)
         self.state_transformer = None

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_fifo_searcher.py
@@ -100,21 +100,10 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
         output_model_factory = self.state_transformer.model_factory
         # Call internal constructor
         new_searcher = CostAwareGPFIFOSearcher(
-            configspace=self.configspace,
-            metric=self._metric,
-            clone_from_state=True,
-            hp_ranges=self.hp_ranges,
+            **self._new_searcher_kwargs_for_clone(),
             output_model_factory=output_model_factory,
-            acquisition_class=self.acquisition_class,
-            map_reward=self.map_reward,
             init_state=init_state,
-            local_minimizer_class=self.local_minimizer_class,
-            output_skip_optimization=output_skip_optimization,
-            num_initial_candidates=self.num_initial_candidates,
-            num_initial_random_choices=self.num_initial_random_choices,
-            initial_scoring=self.initial_scoring,
-            cost_attr=self._cost_attr,
-            resource_attr=self._resource_attr)
+            output_skip_optimization=output_skip_optimization)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)
         self.state_transformer = None

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_multifidelity_searcher.py
@@ -105,23 +105,12 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
         output_model_factory = self.state_transformer.model_factory
         # Call internal constructor
         new_searcher = CostAwareGPMultiFidelitySearcher(
-            configspace=self.configspace,
-            metric=self._metric,
-            clone_from_state=True,
-            hp_ranges=self.hp_ranges,
-            configspace_ext=self.configspace_ext,
+            **self._new_searcher_kwargs_for_clone(),
             output_model_factory=output_model_factory,
-            acquisition_class=self.acquisition_class,
-            map_reward=self.map_reward,
-            resource_for_acquisition=self.resource_for_acquisition,
             init_state=init_state,
-            local_minimizer_class=self.local_minimizer_class,
             output_skip_optimization=output_skip_optimization,
-            num_initial_candidates=self.num_initial_candidates,
-            num_initial_random_choices=self.num_initial_random_choices,
-            initial_scoring=self.initial_scoring,
-            cost_attr=self._cost_attr,
-            resource_attr=self._resource_attr)
+            configspace_ext=self.configspace_ext,
+            resource_for_acquisition=self.resource_for_acquisition)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)
         self.state_transformer = None

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -104,6 +104,8 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         See :class:`GPFIFOSearcher`
     initial_scoring : str
         See :class:`GPFIFOSearcher`
+    skip_local_optimization : str
+        See :class:`GPFIFOSearcher`
     opt_nstarts : int
         See :class:`GPFIFOSearcher`
     opt_maxiter : int
@@ -295,23 +297,12 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         model_factory = self.state_transformer.model_factory
         # Call internal constructor
         new_searcher = GPMultiFidelitySearcher(
-            configspace=self.configspace,
-            metric=self._metric,
-            clone_from_state=True,
-            hp_ranges=self.hp_ranges,
-            configspace_ext=self.configspace_ext,
+            **self._new_searcher_kwargs_for_clone(),
             model_factory=model_factory,
-            acquisition_class=self.acquisition_class,
-            map_reward=self.map_reward,
-            resource_for_acquisition=self.resource_for_acquisition,
             init_state=init_state,
-            local_minimizer_class=self.local_minimizer_class,
             skip_optimization=skip_optimization,
-            num_initial_candidates=self.num_initial_candidates,
-            num_initial_random_choices=self.num_initial_random_choices,
-            initial_scoring=self.initial_scoring,
-            cost_attr=self._cost_attr,
-            resource_attr=self._resource_attr)
+            configspace_ext=self.configspace_ext,
+            resource_for_acquisition=self.resource_for_acquisition)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)
         self.state_transformer = None

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -276,16 +276,13 @@ def _create_common_objects(model=None, **kwargs):
             random_seed=random_seed,
             configspace_ext=result['configspace_ext'],
             **_kwargs))
+    result['num_initial_candidates'] = kwargs['num_init_candidates']
+    result['num_initial_random_choices'] = kwargs['num_init_random']
+    for k in ('initial_scoring', 'cost_attr', 'skip_local_optimization'):
+        result[k] = kwargs[k]
 
     return result
 
-
-def _kwargs_int_common(kwargs) -> Dict:
-    return dict(
-        num_initial_candidates=kwargs['num_init_candidates'],
-        num_initial_random_choices=kwargs['num_init_random'],
-        initial_scoring=kwargs['initial_scoring'],
-        cost_attr=kwargs['cost_attr'])
 
 def gp_fifo_searcher_factory(**kwargs) -> Dict:
     """
@@ -310,9 +307,7 @@ def gp_fifo_searcher_factory(**kwargs) -> Dict:
     # Common objects
     result = _create_common_objects(**kwargs)
 
-    return dict(result,
-                **_kwargs_int_common(kwargs),
-                acquisition_class=EIAcquisitionFunction)
+    return dict(**result, acquisition_class=EIAcquisitionFunction)
 
 
 def gp_multifidelity_searcher_factory(**kwargs) -> Dict:
@@ -337,7 +332,6 @@ def gp_multifidelity_searcher_factory(**kwargs) -> Dict:
     result = _create_common_objects(**kwargs)
 
     kwargs_int = dict(result,
-                      **_kwargs_int_common(kwargs),
                       resource_attr=kwargs['resource_attr'],
                       acquisition_class=EIAcquisitionFunction)
     if kwargs['model'] == 'gp_multitask':
@@ -383,7 +377,6 @@ def constrained_gp_fifo_searcher_factory(**kwargs) -> Dict:
                                 INTERNAL_CONSTRAINT_NAME: skip_optimization_constraint}
 
     return dict(result,
-                **_kwargs_int_common(kwargs),
                 output_model_factory=output_model_factory,
                 output_skip_optimization=output_skip_optimization,
                 acquisition_class=CEIAcquisitionFunction)
@@ -431,7 +424,6 @@ def cost_aware_coarse_gp_fifo_searcher_factory(**kwargs) -> Dict:
                                 INTERNAL_COST_NAME: skip_optimization_cost}
 
     return dict(result,
-                **_kwargs_int_common(kwargs),
                 output_model_factory=output_model_factory,
                 output_skip_optimization=output_skip_optimization,
                 acquisition_class=acquisition_class)
@@ -485,7 +477,6 @@ def cost_aware_fine_gp_fifo_searcher_factory(**kwargs) -> Dict:
                                 INTERNAL_COST_NAME: skip_optimization_cost}
 
     return dict(result,
-                **_kwargs_int_common(kwargs),
                 output_model_factory=output_model_factory,
                 output_skip_optimization=output_skip_optimization,
                 acquisition_class=acquisition_class,
@@ -536,7 +527,6 @@ def cost_aware_gp_multifidelity_searcher_factory(**kwargs) -> Dict:
     resource_for_acquisition = resource_for_acquisition_factory(
         kwargs, result['hp_ranges'])
     return dict(result,
-                **_kwargs_int_common(kwargs),
                 resource_attr=kwargs['resource_attr'],
                 output_model_factory=output_model_factory,
                 output_skip_optimization=output_skip_optimization,
@@ -561,6 +551,7 @@ def _common_defaults(is_hyperband: bool, is_multi_output: bool) -> (Set[str], di
         'num_init_random': DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
         'num_init_candidates': DEFAULT_NUM_INITIAL_CANDIDATES,
         'initial_scoring': DEFAULT_INITIAL_SCORING,
+        'skip_local_optimization': False,
         'debug_log': True,
         'cost_attr': 'elapsed_time',
         'normalize_targets': True,
@@ -574,7 +565,7 @@ def _common_defaults(is_hyperband: bool, is_multi_output: bool) -> (Set[str], di
         default_options['num_init_random'] = 6
         default_options['issm_gamma_one'] = False
         default_options['expdecay_normalize_inputs'] = False
-        default_options['use_new_code'] = True  # DEBUG
+        default_options['use_new_code'] = True
     if is_multi_output:
         default_options['initial_scoring'] = 'acq_func'
         default_options['exponent_cost'] = 1.0
@@ -594,6 +585,7 @@ def _common_defaults(is_hyperband: bool, is_multi_output: bool) -> (Set[str], di
         'num_init_candidates': Integer(5, None),
         'initial_scoring': Categorical(
             choices=tuple(SUPPORTED_INITIAL_SCORING)),
+        'skip_local_optimization': Boolean(),
         'debug_log': Boolean(),
         'normalize_targets': Boolean()}
 


### PR DESCRIPTION
…lect the top-scorer of initial candidates

*Issue #, if available:*

*Description of changes:*
This has been asked for several times (Cedric I think), and also would allow us to test bayesopt decisions (local optimization is nondeterministic, but the initial scoring is not)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
