### PR TITLE
Predictive marginals for GP additive models at (x, r), not just at (x…

### DIFF
--- a/benchmarks/launch_utils.py
+++ b/benchmarks/launch_utils.py
@@ -14,6 +14,8 @@ import argparse
 import logging
 
 from benchmarks.benchmark_factory import supported_benchmarks, benchmark_factory
+from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import \
+    SUPPORTED_RESOURCE_FOR_ACQUISITION
 
 logger = logging.getLogger(__name__)
 
@@ -209,9 +211,10 @@ def parse_args(allow_lists_as_values=True):
     parser.add_argument('--searcher_num_fantasy_samples', type=int,
                         help='Number of fantasy samples',
                         **allow_list)
+    help_str = "Rule for resource level at which acquisition function is used " +\
+        f"[{SUPPORTED_RESOURCE_FOR_ACQUISITION}]"
     parser.add_argument('--searcher_resource_acq', type=str,
-                        help='Determines how EI acquisition function is used '
-                             '[bohb, first]',
+                        help=help_str,
                         **allow_list)
     parser.add_argument('--searcher_resource_acq_bohb_threshold', type=int,
                         help='Parameter for resource_acq == bohb',

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Set
 import numpy as np
 import logging
 
@@ -22,8 +22,6 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model \
     import CostModel
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state \
     import TuningJobState
-from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges \
-    import HyperparameterRanges
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes \
     import SurrogateModel
 
@@ -49,33 +47,23 @@ class CostFixedResourceSurrogateModel(BaseSurrogateModel):
     """
     def __init__(
             self, state: TuningJobState, model: CostModel,
-            fixed_resource: int, num_samples: int = 1,
-            hp_ranges_for_prediction: Optional[HyperparameterRanges] = None):
+            fixed_resource: int, num_samples: int = 1):
         """
         :param state: TuningJobSubState
         :param model: CostModel. Model parameters must have been fit
         :param fixed_resource: c(x, r) is predicted for this resource level r
         :param num_samples: Number of samples drawn in `predict`. Use this for
             random cost models only
-        :param hp_ranges_for_prediction: Overrides
-            `hp_ranges_for_prediction`
 
         """
         super().__init__(state, active_metric=model.cost_metric_name)
         self._model = model
         self._fixed_resource = fixed_resource
         self._num_samples = num_samples
-        self._hp_ranges_for_prediction = hp_ranges_for_prediction
 
     @staticmethod
     def keys_predict() -> Set[str]:
         return {'mean'}
-
-    def hp_ranges_for_prediction(self) -> HyperparameterRanges:
-        if self._hp_ranges_for_prediction is None:
-            return super().hp_ranges_for_prediction()
-        else:
-            return self._hp_ranges_for_prediction
 
     def predict(self, inputs: np.ndarray) -> List[Dict[str, np.ndarray]]:
         # Inputs are encoded. For cost models, need to decode them back
@@ -118,8 +106,7 @@ class CostFixedResourceSurrogateModel(BaseSurrogateModel):
 
 class CostSurrogateModelFactory(TransformerModelFactory):
     def __init__(
-            self, model: CostModel, fixed_resource: int, num_samples: int = 1,
-            hp_ranges_for_prediction: Optional[HyperparameterRanges] = None):
+            self, model: CostModel, fixed_resource: int, num_samples: int = 1):
         """
         The name of the cost metric is `model.cost_metric_name`.
 
@@ -127,14 +114,12 @@ class CostSurrogateModelFactory(TransformerModelFactory):
         :param fixed_resource: c(x, r) is predicted for this resource level r
         :param num_samples: Number of samples drawn in `predict`. Use this for
             random cost models only
-        :param hp_ranges_for_prediction: Overrides
-            `CostFixedResourceSurrogateModel.hp_ranges_for_prediction`
 
         """
         self._model = model
         self._num_samples = num_samples
+        self._fixed_resource = None
         self.set_fixed_resource(fixed_resource)
-        self._hp_ranges_for_prediction = hp_ranges_for_prediction
 
     def get_params(self):
         return dict()
@@ -160,5 +145,4 @@ class CostSurrogateModelFactory(TransformerModelFactory):
         return CostFixedResourceSurrogateModel(
             state=state, model=self._model,
             fixed_resource=self._fixed_resource,
-            num_samples=self._num_samples,
-            hp_ranges_for_prediction=self._hp_ranges_for_prediction)
+            num_samples=self._num_samples)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -79,16 +79,6 @@ class TransformerModelFactory(object):
     def profiler(self) -> Optional[SimpleProfiler]:
         return None
 
-    def predictions_use_extended_configs(self) -> bool:
-        """
-        Relevant only for surrogate models supporting multi-fidelity
-        scheduling (e.g., learning curve models).
-
-        :return: Predictions are based on extended configs (where resource
-            level is appended)? If not, they are based on normal configs
-        """
-        return True
-
 
 # Convenience types allowing for multi-output HPO. These are used for methods that work both in the standard case
 # of a single output model and in the multi-output case

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
@@ -107,10 +107,6 @@ class SurrogateModel(ABC):
         pass
 
     def hp_ranges_for_prediction(self) -> HyperparameterRanges:
-        """
-        :return: HyperparameterRanges to be used for predictions. By default,
-            this is self.state.hp_ranges
-        """
         return self.state.hp_ranges
 
     def predict_candidates(self, candidates: Iterable[Configuration]) -> \
@@ -198,7 +194,9 @@ class AcquisitionFunction(ScoringFunction):
         self.active_metric = active_metric
 
     @abstractmethod
-    def compute_acq(self, inputs: np.ndarray, model: Optional[SurrogateOutputModel] = None) -> np.ndarray:
+    def compute_acq(
+            self, inputs: np.ndarray,
+            model: Optional[SurrogateOutputModel] = None) -> np.ndarray:
         """
         Note: If inputs has shape (d,), it is taken to be (1, d)
 
@@ -210,7 +208,9 @@ class AcquisitionFunction(ScoringFunction):
 
     @abstractmethod
     def compute_acq_with_gradient(
-            self, input: np.ndarray, model: Optional[SurrogateOutputModel] = None) -> Tuple[float, np.ndarray]:
+            self, input: np.ndarray,
+            model: Optional[SurrogateOutputModel] = None) \
+            -> Tuple[float, np.ndarray]:
         """
         For a single input point x, compute acquisition function value f(x)
         and gradient nabla_x f.
@@ -221,7 +221,8 @@ class AcquisitionFunction(ScoringFunction):
         """
         pass
 
-    def score(self, candidates: Iterable[Configuration], model: Optional[SurrogateOutputModel] = None) -> List[float]:
+    def score(self, candidates: Iterable[Configuration],
+              model: Optional[SurrogateOutputModel] = None) -> List[float]:
         if model is None:
             model = self.model
         if isinstance(model, dict):

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -174,8 +174,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
             assert isinstance(self.resource_for_acquisition,
                               ResourceForAcquisitionMap)
         self.configspace_ext = kwargs_int.pop('configspace_ext')
-        self._predictions_use_extended_configs = \
-            kwargs_int['model_factory'].predictions_use_extended_configs()
         self._create_internal(**kwargs_int)
 
     def configure_scheduler(self, scheduler):
@@ -196,12 +194,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
 
     def _hp_ranges_in_state(self):
         return self.configspace_ext.hp_ranges_ext
-
-    def _hp_ranges_for_prediction(self):
-        if self._predictions_use_extended_configs:
-            return self.configspace_ext.hp_ranges_ext
-        else:
-            return self.configspace_ext.hp_ranges
 
     def _config_ext_update(self, config, result):
         resource = int(result[self._resource_attr])


### PR DESCRIPTION
…, r_max)

*Issue #, if available:*

*Description of changes:*
Second part of changes needed to use the GP additive models in the same way as gp_multitask (including fantasizing).
Here, marginal distributions are computed at (x, r), not always at (x, r_max). This implies a simplification of the code
as well.
I will run before/after tests combining this one with #117 . But the test coverage is already good.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
