### PR TITLE
Callbacks which also store surrogate model parameters and cumulative …

### DIFF
--- a/syne_tune/backend/simulator_backend/simulator_callback.py
+++ b/syne_tune/backend/simulator_backend/simulator_callback.py
@@ -80,7 +80,7 @@ class SimulatorCallback(StoreResultsCallback):
                 max_num_trials_completed=stop_criterion.max_num_trials_completed,
                 max_cost=stop_criterion.max_cost,
                 max_num_trials_finished=stop_criterion.max_num_trials_finished,
-                max_metric_value = {ST_TUNER_TIME: max_wallclock_time})
+                max_metric_value={ST_TUNER_TIME: max_wallclock_time})
             tuner.stop_criterion = new_stop_criterion
 
     def on_tuning_start(self, tuner: "Tuner"):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -173,6 +173,10 @@ class ModelStateTransformer(object):
             return x
 
     @property
+    def use_single_model(self) -> bool:
+        return self._use_single_model
+
+    @property
     def model_factory(self) -> TransformerOutputModelFactory:
         return self._unwrap_from_dict(self._model_factory)
 

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -14,6 +14,7 @@ import numpy as np
 from typing import Type, Optional, Dict, List
 import logging
 import copy
+import time
 
 from syne_tune.optimizer.schedulers.searchers.searcher import \
     SearcherWithRandomSeed, RandomSearcher
@@ -132,6 +133,8 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
         self._resource_attr = resource_attr
         self._filter_observed_data = filter_observed_data
         self._random_searcher = None
+        # Tracks the cumulative time spent in `get_config` calls
+        self.cumulative_get_config_time = 0
         if model_factory.debug_log is not None:
             deb_msg = "[ModelBasedSearcher.__init__]\n"
             deb_msg += ("- acquisition_class = {}\n".format(acquisition_class))
@@ -276,6 +279,7 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
 
         :return: Next config to evaluate at
         """
+        start_time = time.time()
         state = self.state_transformer.state
         if self.do_profile:
             # Start new profiler block
@@ -318,6 +322,7 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
         if self.do_profile:
             self.profiler.stop('all')
             self.profiler.clear()
+        self.cumulative_get_config_time += (time.time() - start_time)
 
         return config
 

--- a/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
@@ -1,0 +1,107 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import Dict
+import logging
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.tuner_callback import StoreResultsCallback
+from syne_tune.backend.simulator_backend.simulator_callback import \
+    SimulatorCallback
+from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
+from syne_tune.optimizer.schedulers.searchers.gp_fifo_searcher import \
+    ModelBasedSearcher
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer \
+    import ModelStateTransformer
+
+logger = logging.getLogger(__name__)
+
+
+def _get_model_based_searcher(tuner):
+    searcher = None
+    scheduler = tuner.scheduler
+    if isinstance(scheduler, FIFOScheduler):
+        if isinstance(scheduler.searcher, ModelBasedSearcher):
+            searcher = scheduler.searcher
+            state_transformer = searcher.state_transformer
+            if state_transformer is not None:
+                if not isinstance(state_transformer, ModelStateTransformer):
+                    searcher = None
+                elif not state_transformer.use_single_model:
+                    logger.warning(
+                        "StoreResultsAndModelParamsCallback does not currently "
+                        "support multi-model setups. Model parameters sre "
+                        "not logged.")
+                    searcher = None
+            else:
+                searcher = None
+    return searcher
+
+
+def _extended_result(searcher, result):
+    if searcher is not None:
+        kwargs = dict()
+        # Append surrogate model parameters to `result`
+        params = searcher.state_transformer.get_params()
+        if params:
+            prefix = 'model_'
+            kwargs = {prefix + k: v for k, v in params.items()}
+        kwargs['cumulative_get_config_time'] = searcher.cumulative_get_config_time
+        result = dict(result, **kwargs)
+    return result
+
+
+class StoreResultsAndModelParamsCallback(StoreResultsCallback):
+    """
+    Extends :class:`StoreResultsCallback` by also storing the current
+    surrogate model parameters in `on_trial_result`. This works for
+    schedulers with model-based searchers. For other schedulers, this
+    callback behaves the same as the superclass.
+
+    """
+    def __init__(
+            self,
+            add_wallclock_time: bool = True,
+    ):
+        super().__init__(add_wallclock_time)
+        self._searcher = None
+
+    def on_tuning_start(self, tuner):
+        super().on_tuning_start(tuner)
+        self._searcher = _get_model_based_searcher(tuner)
+
+    def on_trial_result(
+            self, trial: Trial, status: str, result: Dict, decision: str):
+        result = _extended_result(self._searcher, result)
+        super().on_trial_result(trial, status, result, decision)
+
+
+class SimulatorAndModelParamsCallback(SimulatorCallback):
+    """
+    Extends :class:`SimulatorCallback` by also storing the current
+    surrogate model parameters in `on_trial_result`. This works for
+    schedulers with model-based searchers. For other schedulers, this
+    callback behaves the same as the superclass.
+
+    """
+    def __init__(self):
+        super().__init__()
+        self._searcher = None
+
+    def on_tuning_start(self, tuner):
+        super().on_tuning_start(tuner)
+        self._searcher = _get_model_based_searcher(tuner)
+
+    def on_trial_result(
+            self, trial: Trial, status: str, result: Dict, decision: str):
+        result = _extended_result(self._searcher, result)
+        super().on_trial_result(trial, status, result, decision)


### PR DESCRIPTION
…get_config time alongside results

*Issue #, if available:*

*Description of changes:*
New callbacks which write additional information into the result dataframe:
- surrogate model parameters
- cumulative time spent in get_config so far
Both are needed to generate plots for the submission.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
