### PR TITLE
Install the most recent python dependecies in the docker image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -54,4 +54,4 @@ WORKDIR /opt/app
 ADD \
   source/requirements.txt \
   /tmp/packages/
-RUN python -m pip install --no-cache-dir -r /tmp/packages/requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade -r /tmp/packages/requirements.txt

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,13 @@
+This directory includes a Docker image necessary to run `syne_tune.remote.remote_launcher.RemoteLauncher`.
+
+The first time you use `RemoteLauncher` this image will be built automatically and uploaded/pushed to your AWS ECR (Elastic Container Registry).
+
+It might happen that for a once-built image, with time some dependencies will grow out of date. 
+For example, if not updated, AWS Python libraries like `botocore` or `boto3` might not offer the newest features of the 
+AWS API as [documented online](https://docs.aws.amazon.com/sagemaker/latest/APIReference/).
+In that case you need to rebuild the image, installing the most recent versions of all of the dependencies.
+To do that, run `build_syne_tune_container.sh` from within the `container/` directory:
+```
+cd container/
+bash build_syne_tune_container.sh
+```

--- a/container/build_syne_tune_container.sh
+++ b/container/build_syne_tune_container.sh
@@ -55,7 +55,9 @@ fi
 docker build -t ${image} . \
              --build-arg REGION=${region} \
              --build-arg DLAMI_REGISTRY_ID=${DLAMI_REGISTRY_ID} \
-             --build-arg CONTEXT=${CONTEXT}
+             --build-arg CONTEXT=${CONTEXT} \
+             --pull \
+             --no-cache
 
 # tag and push to ECR
 docker tag ${image} ${ECR_URL}/${image}


### PR DESCRIPTION
*Description of changes:*
Genesis: I had troubles running a SM job that was successfully started when run from my local environment, but wouldn't get started through the RemoteLauncher. The reason was out-of-date version of `botocore` in the docker image.
Simply rebuilding the image didn't solve an issues, a `pip install --upgrade` flag had to be added. (This is because this out-of-date version of `botocore` comes with the base image, so without `--upgrade` other dependencies in the `requirements.txt` were downgraded from the most recent versions, rather than existing dependencies being updated.)

Additionally, the changes to `build_syne_tune_container.sh` allow to rebuild an image easily by simply rerunning the script (no need to first delete an image via `docker image rm`).

`README.md` explains the need to rebuild the image, in case they face issues, to the users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
