### PR TITLE
Remove state_dict, load_state_dict from TrialScheduler

### DIFF
--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -212,26 +212,6 @@ class TrialScheduler(object):
         call `on_trial_complete`."""
         pass
 
-    def state_dict(self) -> Dict:
-        """
-        Returns a dictionary containing the inner state of the scheduler. This
-        dictionary can be pickled.
-
-        :return: Scheduler state
-        """
-        return dict()
-
-    def load_state_dict(self, state_dict):
-        """
-        Load from the saved state dict. This can be used to resume an
-        experiment from a checkpoint.
-
-        This method must only be called as part of scheduler construction.
-        Calling it in the middle of an experiment can lead to an undefined
-        inner state of scheduler or searcher.
-        """
-        pass
-
     def metric_names(self) -> List[str]:
         """
         :return: List of metric names. The first one is the target

--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -13,7 +13,6 @@
 from typing import Dict, Optional, List
 import logging
 import os
-import pickle
 import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
@@ -386,17 +385,6 @@ class FIFOScheduler(ResourceLevelsScheduler):
             config = self._preprocess_config(trial.config)
             self.searcher.on_trial_result(
                 str(trial.trial_id), config, result=result, update=True)
-
-    def state_dict(self) -> Dict:
-        record = super().state_dict()
-        # The result of searcher.get_state can always be pickled
-        record['searcher'] = pickle.dumps(self.searcher.get_state())
-        return record
-
-    def load_state_dict(self, state_dict):
-        super().load_state_dict(state_dict)
-        self.searcher = self.searcher.clone_from_state(pickle.loads(
-            state_dict['searcher']))
 
     def metric_names(self) -> List[str]:
         return [self.metric]

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -13,7 +13,6 @@
 from typing import Optional, Dict, List
 from dataclasses import dataclass
 import logging
-import pickle
 import numpy as np
 
 from syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager \

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -372,32 +372,6 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
                 self.metric: np.NAN}
             self._on_trial_result(trial, result, call_searcher=False)
 
-    _STANDARD_MEMBERS = (
-        '_job_queue', '_phase', '_num_collected', '_trial_to_write_back',
-        '_bracket_to_results', '_trial_to_config')
-
-    def state_dict(self) -> Dict:
-        record = super().state_dict()
-        # The result of searcher.get_state can always be pickled
-        record.update({
-            'searcher': pickle.dumps(self.searcher.get_state()),
-            'bracket_rungs': pickle.dumps(self.bracket_manager.bracket_rungs)
-        })
-        obj_dict = vars()
-        for name in self._STANDARD_MEMBERS:
-            record[name] = pickle.dumps(obj_dict[name])
-        return record
-
-    def load_state_dict(self, state_dict):
-        super().load_state_dict(state_dict)
-        self.searcher = self.searcher.clone_from_state(pickle.loads(
-            state_dict['searcher']))
-        self.bracket_manager = SynchronousHyperbandBracketManager(
-            pickle.loads(state_dict['bracket_rungs']), mode=self.mode)
-        obj_dict = vars()
-        for name in self._STANDARD_MEMBERS:
-            obj_dict[name] = pickle.loads(state_dict[name])
-
     def metric_names(self) -> List[str]:
         return [self.metric]
 


### PR DESCRIPTION
*Issue #, if available:*
Removing unused methods

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
