### PR TITLE
Allow BlackboxOffline _objective_function to return all fidelities when fidelity=None

### DIFF
--- a/benchmarking/blackbox_repository/blackbox_offline.py
+++ b/benchmarking/blackbox_repository/blackbox_offline.py
@@ -84,12 +84,9 @@ class BlackboxOffline(Blackbox):
         key_dict = configuration
         if self.seed_col is not None:
             key_dict[self.seed_col] = seed
-        if fidelity is not None:
-            if self.fidelity_space is not None:
-                key_dict.update(fidelity)
-            else:
-                raise ValueError("fidelity is not None and self.fidelity_space is None.")
-        if fidelity is None and self.fidelity_space is not None:
+        if self.fidelity_space is not None and fidelity is not None:
+            key_dict.update(fidelity)
+        if self.fidelity_space is not None and fidelity is None:
             keys = tuple(set(self.index_cols) - set(self.fidelity_space.keys()))
         else:
             keys = self.index_cols
@@ -99,12 +96,12 @@ class BlackboxOffline(Blackbox):
                 f"the hyperparameter {configuration} is not present in available evaluations. Use `add_surrogate(blackbox)` if"
                 f" you want to add interpolation or a surrogate model that support querying any configuration."
             )
-        if fidelity is not None:
+        if fidelity is not None or self.fidelity_space is None:
             return output.iloc[0].to_dict()
         else:
             # TODO select only the fidelity values in the self.fidelity_space, since it might be the case there are more
             #  values in the dataframe. Then the output tensor has larger number of elements than expected num_fidelities.
-            return output
+            return output.to_numpy()
 
     def __str__(self):
         stats = {

--- a/tst/blackbox_repository/test_blackbox.py
+++ b/tst/blackbox_repository/test_blackbox.py
@@ -127,6 +127,31 @@ def test_blackbox_offline_serialization():
             assert res['metric_rmse'] == u * v
 
 
+def test_blackbox_offline_fidelities():
+    data = np.concatenate(
+        [np.stack([x1, x2,       x1 * x2,   np.ones_like(x1, dtype=np.int)], axis=1),
+         np.stack([x1, x2, 0.5 * x1 * x2, 2*np.ones_like(x1, dtype=np.int)], axis=1)],
+        axis=0)
+    df = pd.DataFrame(data=data, columns=["hp_x1", "hp_x2", "metric_rmse", "step"])
+
+    blackbox = BlackboxOffline(df_evaluations=df, configuration_space=cs,
+                               fidelity_space=dict(step=sp.randint(1, 2)))
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        print(f"serializing and deserializing blackbox in folder {tmpdirname}")
+        for u, v in zip(x1, x2):
+            res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=1)
+            assert res['metric_rmse'] == u * v
+        for u, v in zip(x1, x2):
+            res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=2)
+            assert res['metric_rmse'] == 0.5 * u * v
+        for u, v in zip(x1, x2):
+            res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=None)
+            # Returns a tensor with shape (num_fidelities, num_objectives)
+            assert res.shape == (2, 1)
+            assert (res == np.array([u * v, 0.5 * u * v]).reshape(2, 1)).all()
+
+
 def test_blackbox_tabular_serialization():
     hyperparameters = pd.DataFrame(data=np.stack([x1, x2]).T, columns=["hp_x1", "hp_x2"])
     num_seeds = 1

--- a/tst/blackbox_repository/test_blackbox.py
+++ b/tst/blackbox_repository/test_blackbox.py
@@ -142,10 +142,10 @@ def test_blackbox_offline_fidelities():
         for u, v in zip(x1, x2):
             res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=1)
             assert res['metric_rmse'] == u * v
-        for u, v in zip(x1, x2):
+            
             res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=2)
             assert res['metric_rmse'] == 0.5 * u * v
-        for u, v in zip(x1, x2):
+            
             res = blackbox.objective_function({"hp_x1": u, "hp_x2": v}, fidelity=None)
             # Returns a tensor with shape (num_fidelities, num_objectives)
             assert res.shape == (2, 1)


### PR DESCRIPTION
*Description of changes:*
Allow BlackboxOffline _objective_function to return all fidelities when fidelity=None, since that's the API assumed by Blackbox.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
