### PR TITLE
Make sure BB surrogates work with serialization, and change config_sp…

### DIFF
--- a/benchmarking/blackbox_repository/requirements.txt
+++ b/benchmarking/blackbox_repository/requirements.txt
@@ -4,3 +4,4 @@ fastparquet
 s3fs
 sklearn
 h5py # note: only needed for fcnet
+scikit-learn>0.21.3

--- a/benchmarking/cli/launch_hpo.py
+++ b/benchmarking/cli/launch_hpo.py
@@ -283,10 +283,20 @@ if __name__ == '__main__':
                 seed = params.get('blackbox_seed')
                 if seed is not None:
                     logger.info(f"Using blackbox with blackbox_seed = {seed}")
+                surrogate = benchmark.get('surrogate')
+                if surrogate is not None:
+                    # If a surrogate is given, it interpolates the tabulated
+                    # blackbox to the configuration space of the benchmark,
+                    # which often has numerical domains where the tabulated
+                    # benchmark has categorical ones
+                    config_space_surrogate = benchmark['config_space']
+                else:
+                    config_space_surrogate = None
                 backend_kwargs.update({
                     'blackbox_name': blackbox_name,
                     'dataset': params.get('dataset_name'),
-                    'surrogate': benchmark.get('surrogate'),
+                    'surrogate': surrogate,
+                    'config_space_surrogate': config_space_surrogate,
                     'time_this_resource_attr': benchmark.get(
                         'time_this_resource_attr'),
                     'max_resource_attr': benchmark.get('max_resource_attr'),

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -151,7 +151,7 @@ class RemoteLauncher:
             pass
         endpoint_requirements = self.tuner.trial_backend.entrypoint_path().parent / "requirements.txt"
         if endpoint_requirements.exists():
-            logger.info(f"copy endpoint script requirements to {self.remote_script_dir()}")
+            logger.info(f"copy endpoint script requirements {endpoint_requirements} to {self.remote_script_dir()}")
             shutil.copy(endpoint_requirements, tgt_requirement)
             pass
 


### PR DESCRIPTION
…ace of nashpobench (log spacing)

*Issue #, if available:*
Ensures that surrogates in BBs are not serialized as fitted estimators, but either just as names or as unfitted estimators. This makes sure this works with RemoteLauncher (I had issues with different scikit-learn versions), and the dill files stored at the end are of reasonable size (they were so large before that we could not run many experiments).

I also changed the type for some HPs from randint to lograndint. The reason is that their grid is logarithmic, so I feel this points to logarithmic scaling as well: lograndint is closer to choice over the grid than randint.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
