### PR TITLE
Fix configuration space for nashpobench benchmark so that interpolati…

### DIFF
--- a/benchmarking/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/benchmarking/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -101,13 +101,13 @@ def convert_dataset(dataset_path: Path, max_rows: int = None):
     configuration_space = {
         "hp_activation_fn_1": sp.choice(["tanh", "relu"]),
         "hp_activation_fn_2": sp.choice(["tanh", "relu"]),
-        "hp_batch_size": sp.choice([8, 16, 32, 64]),
-        "hp_dropout_1": sp.choice([0.0, 0.3, 0.6]),
-        "hp_dropout_2": sp.choice([0.0, 0.3, 0.6]),
+        "hp_batch_size": sp.logfinrange(8, 64, 4, cast_int=True),
+        "hp_dropout_1": sp.finrange(0.0, 0.6, 3),
+        "hp_dropout_2": sp.finrange(0.0, 0.6, 3),
         "hp_init_lr": sp.choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
         'hp_lr_schedule': sp.choice(["cosine", "const"]),
-        'hp_n_units_1': sp.choice([16, 32, 64, 128, 256, 512]),
-        'hp_n_units_2': sp.choice([16, 32, 64, 128, 256, 512]),
+        'hp_n_units_1': sp.logfinrange(16, 512, 6, cast_int=True),
+        'hp_n_units_2': sp.logfinrange(16, 512, 6, cast_int=True),
     }
     fidelity_space = {
         RESOURCE_ATTR: sp.randint(lower=1, upper=100)

--- a/benchmarking/definitions/definition_nashpobench.py
+++ b/benchmarking/definitions/definition_nashpobench.py
@@ -23,13 +23,13 @@ from benchmarking.blackbox_repository.conversion_scripts.scripts.fcnet_import \
 _config_space = {
     "hp_activation_fn_1": choice(["tanh", "relu"]),
     "hp_activation_fn_2": choice(["tanh", "relu"]),
-    "hp_batch_size": logfinrange(8, 64, 4, is_int=True),
+    "hp_batch_size": logfinrange(8, 64, 4, cast_int=True),
     "hp_dropout_1": finrange(0.0, 0.6, 3),
     "hp_dropout_2": finrange(0.0, 0.6, 3),
     "hp_init_lr": choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
     'hp_lr_schedule': choice(["cosine", "const"]),
-    "hp_n_units_1": logfinrange(16, 512, 6, is_int=True),
-    "hp_n_units_2": logfinrange(16, 512, 6, is_int=True),
+    "hp_n_units_1": logfinrange(16, 512, 6, cast_int=True),
+    "hp_n_units_2": logfinrange(16, 512, 6, cast_int=True),
 }
 
 
@@ -67,6 +67,5 @@ def nashpobench_benchmark(params):
         'cost_model': None,
         'supports_simulated': True,
         'blackbox_name': BLACKBOX_NAME,
-        'surrogate': None,
         'time_this_resource_attr': METRIC_ELAPSED_TIME,
     }

--- a/benchmarking/definitions/definition_nashpobench.py
+++ b/benchmarking/definitions/definition_nashpobench.py
@@ -23,13 +23,13 @@ from benchmarking.blackbox_repository.conversion_scripts.scripts.fcnet_import \
 _config_space = {
     "hp_activation_fn_1": choice(["tanh", "relu"]),
     "hp_activation_fn_2": choice(["tanh", "relu"]),
-    "hp_batch_size": logfinrange(8, 64, 4),
+    "hp_batch_size": logfinrange(8, 64, 4, is_int=True),
     "hp_dropout_1": finrange(0.0, 0.6, 3),
     "hp_dropout_2": finrange(0.0, 0.6, 3),
     "hp_init_lr": choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
     'hp_lr_schedule': choice(["cosine", "const"]),
-    "hp_n_units_1": logfinrange(16, 512, 6),
-    "hp_n_units_2": logfinrange(16, 512, 6),
+    "hp_n_units_1": logfinrange(16, 512, 6, is_int=True),
+    "hp_n_units_2": logfinrange(16, 512, 6, is_int=True),
 }
 
 

--- a/docs/search_space.md
+++ b/docs/search_space.md
@@ -65,6 +65,12 @@ means, a basic component of many HPO algorithms. The following domains are curre
   finite range `log(lower), ..., log(upper)` of size `size`.  Note that both
   `lower` and `upper` are part of the value range.
 
+By default, the value type for `finrange` and `logfinrange` is `float`. It can
+be changed to `int` by the argument `is_int=True`. For example,
+`logfinrange(8, 256, 6, is_int=True)` results in `8, 16, 32, 64, 128, 256` and
+value type `int`, while `logfinrange(8, 256, 6)` results in
+`8.0, 16.0, 32.0, 64.0, 128.0, 256.0` and  value type `float`.
+
 
 ### Recommendations
 

--- a/docs/search_space.md
+++ b/docs/search_space.md
@@ -66,8 +66,8 @@ means, a basic component of many HPO algorithms. The following domains are curre
   `lower` and `upper` are part of the value range.
 
 By default, the value type for `finrange` and `logfinrange` is `float`. It can
-be changed to `int` by the argument `is_int=True`. For example,
-`logfinrange(8, 256, 6, is_int=True)` results in `8, 16, 32, 64, 128, 256` and
+be changed to `int` by the argument `cast_int=True`. For example,
+`logfinrange(8, 256, 6, cast_int=True)` results in `8, 16, 32, 64, 128, 256` and
 value type `int`, while `logfinrange(8, 256, 6)` results in
 `8.0, 16.0, 32.0, 64.0, 128.0, 256.0` and  value type `float`.
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Tuple, Dict, List, Any, Optional
+from typing import Tuple, Dict, List, Any, Optional, Union
 import numpy as np
 
 from syne_tune.search_space import Domain, is_log_space, FiniteRange, Categorical
@@ -197,7 +197,7 @@ class HyperparameterRangeInteger(HyperparameterRange):
 class HyperparameterRangeFiniteRange(HyperparameterRange):
     def __init__(
             self, name: str, lower_bound: float, upper_bound: float,
-            size: int, scaling: Scaling):
+            size: int, scaling: Scaling, is_int: bool = False):
         """
         See :class:`FiniteRange` in `search_space`. Internally, we use an int
         with linear scaling.
@@ -210,6 +210,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         assert size >= 2
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+        self.is_int = is_int
         self._scaling = scaling
         self._lower_internal = scaling.to_internal(lower_bound)
         self._upper_internal = scaling.to_internal(upper_bound)
@@ -223,12 +224,16 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
     def scaling(self) -> Scaling:
         return self._scaling
 
-    def _map_from_int(self, x: int) -> float:
+    def _map_from_int(self, x: int) -> Union[float, int]:
         y = x * self._step_internal + self._lower_internal
-        return np.clip(self._scaling.from_internal(y), self.lower_bound,
-                       self.upper_bound)
+        y = np.clip(self._scaling.from_internal(y), self.lower_bound,
+                    self.upper_bound)
+        if not self.is_int:
+            return float(y)
+        else:
+            return int(np.round(y))
 
-    def _map_to_int(self, y: float) -> int:
+    def _map_to_int(self, y: Union[float, int]) -> int:
         y_int = np.clip(self._scaling.to_internal(y), self._lower_internal,
                         self._upper_internal)
         return int(round((y_int - self._lower_internal) / self._step_internal))
@@ -241,9 +246,10 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         return self._map_from_int(int_val)
 
     def __repr__(self) -> str:
-        return "{}({}, {}, {}, {})".format(
+        return "{}({}, {}, {}, {}, {})".format(
             self.__class__.__name__, repr(self.name),
-            repr(self.scaling), repr(self.lower_bound), repr(self.upper_bound))
+            repr(self.scaling), repr(self.lower_bound), repr(self.upper_bound),
+            repr(self.is_int))
 
     def __eq__(self, other):
         if isinstance(other, HyperparameterRangeFiniteRange):
@@ -251,7 +257,8 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
                    and self.lower_bound == other.lower_bound \
                    and self.upper_bound == other.upper_bound \
                    and self._scaling == other._scaling \
-                   and self._range_int.upper_bound == other.   _range_int.upper_bound
+                   and self.is_int == other.is_int \
+                   and self._range_int.upper_bound == other._range_int.upper_bound
         return False
 
     def get_ndarray_bounds(self) -> List[Tuple[float, float]]:
@@ -372,7 +379,7 @@ class HyperparameterRangesImpl(HyperparameterRanges):
                     assert name not in self.active_config_space, \
                         f"Parameter '{name}' of type FiniteRange cannot be used in active_config_space"
                     hp_ranges.append(HyperparameterRangeFiniteRange(
-                        **kwargs, size=len(hp_range)))
+                        **kwargs, size=len(hp_range), is_int=hp_range.is_int))
                 else:
                     # Note: If `hp_range` is logarithmic, it has a base.
                     # Since both the loguniform distribution and the internal

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
@@ -197,7 +197,7 @@ class HyperparameterRangeInteger(HyperparameterRange):
 class HyperparameterRangeFiniteRange(HyperparameterRange):
     def __init__(
             self, name: str, lower_bound: float, upper_bound: float,
-            size: int, scaling: Scaling, is_int: bool = False):
+            size: int, scaling: Scaling, cast_int: bool = False):
         """
         See :class:`FiniteRange` in `search_space`. Internally, we use an int
         with linear scaling.
@@ -210,7 +210,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         assert size >= 2
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
-        self.is_int = is_int
+        self.cast_int = cast_int
         self._scaling = scaling
         self._lower_internal = scaling.to_internal(lower_bound)
         self._upper_internal = scaling.to_internal(upper_bound)
@@ -228,7 +228,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         y = x * self._step_internal + self._lower_internal
         y = np.clip(self._scaling.from_internal(y), self.lower_bound,
                     self.upper_bound)
-        if not self.is_int:
+        if not self.cast_int:
             return float(y)
         else:
             return int(np.round(y))
@@ -249,7 +249,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
         return "{}({}, {}, {}, {}, {})".format(
             self.__class__.__name__, repr(self.name),
             repr(self.scaling), repr(self.lower_bound), repr(self.upper_bound),
-            repr(self.is_int))
+            repr(self.cast_int))
 
     def __eq__(self, other):
         if isinstance(other, HyperparameterRangeFiniteRange):
@@ -257,7 +257,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
                    and self.lower_bound == other.lower_bound \
                    and self.upper_bound == other.upper_bound \
                    and self._scaling == other._scaling \
-                   and self.is_int == other.is_int \
+                   and self.cast_int == other.cast_int \
                    and self._range_int.upper_bound == other._range_int.upper_bound
         return False
 
@@ -379,7 +379,7 @@ class HyperparameterRangesImpl(HyperparameterRanges):
                     assert name not in self.active_config_space, \
                         f"Parameter '{name}' of type FiniteRange cannot be used in active_config_space"
                     hp_ranges.append(HyperparameterRangeFiniteRange(
-                        **kwargs, size=len(hp_range), is_int=hp_range.is_int))
+                        **kwargs, size=len(hp_range), cast_int=hp_range.cast_int))
                 else:
                     # Note: If `hp_range` is logarithmic, it has a base.
                     # Since both the loguniform distribution and the internal

--- a/syne_tune/search_space.py
+++ b/syne_tune/search_space.py
@@ -595,10 +595,11 @@ class FiniteRange(Domain):
     """
     Represents a finite range `[lower, ..., upper]` with `size` values
     equally spaced in linear or log domain.
+    If `is_int`, the value type is int (rounding after the transform).
 
     """
     def __init__(self, lower: float, upper: float, size: int,
-                 log_scale: bool = False):
+                 log_scale: bool = False, is_int: bool = False):
         assert lower < upper
         assert size >= 2
         if log_scale:
@@ -607,6 +608,7 @@ class FiniteRange(Domain):
         self.lower = lower
         self.upper = upper
         self.log_scale = log_scale
+        self.is_int = is_int
         if not log_scale:
             self._lower_internal = lower
             self._step_internal = (upper - lower) / (size - 1)
@@ -616,15 +618,19 @@ class FiniteRange(Domain):
             self._step_internal = \
                 (upper_internal - self._lower_internal) / (size - 1)
 
-    def _map_from_int(self, x: int) -> float:
+    def _map_from_int(self, x: int) -> Union[float, int]:
         y = x * self._step_internal + self._lower_internal
         if self.log_scale:
             y = np.exp(y)
-        return float(np.clip(y, self.lower, self.upper))
+        y = np.clip(y, self.lower, self.upper)
+        if not self.is_int:
+            return float(y)
+        else:
+            return int(np.round(y))
 
     @property
     def value_type(self):
-        return float
+        return float if not self.is_int else int
 
     def _map_to_int(self, value) -> int:
         int_value = np.clip(value, self.lower, self.upper)
@@ -665,7 +671,8 @@ class FiniteRange(Domain):
         return isinstance(other, FiniteRange) \
                and np.isclose(self.lower, other.lower) \
                and np.isclose(self.upper, other.upper) \
-               and self.log_scale == other.log_scale
+               and self.log_scale == other.log_scale \
+               and self.is_int == other.is_int
 
 
 def sample_from(func: Callable[[Dict], Any]):
@@ -816,7 +823,7 @@ def qrandn(mean: float, sd: float, q: float):
     return Float(None, None).normal(mean, sd).quantized(q)
 
 
-def finrange(lower: float, upper: float, size: int):
+def finrange(lower: float, upper: float, size: int, is_int: bool = False):
     """
     Finite range `[lower, ..., upper]` with `size` entries, which are
     equi-spaced. Finite alternative to `uniform`.
@@ -824,11 +831,12 @@ def finrange(lower: float, upper: float, size: int):
     :param lower: Smallest feasible value
     :param upper: Largest feasible value
     :param size: Size of (finite) domain, must be >= 2
+    :param is_int: Values rounded to int?
     """
-    return FiniteRange(lower, upper, size)
+    return FiniteRange(lower, upper, size, log_scale=False, is_int=is_int)
 
 
-def logfinrange(lower: float, upper: float, size: int):
+def logfinrange(lower: float, upper: float, size: int, is_int: bool = False):
     """
     Finite range `[lower, ..., upper]` with `size` entries, which are
     equi-spaced in the log domain. Finite alternative to `loguniform`.
@@ -836,8 +844,9 @@ def logfinrange(lower: float, upper: float, size: int):
     :param lower: Smallest feasible value (positive)
     :param upper: Largest feasible value (positive)
     :param size: Size of (finite) domain, must be >= 2
+    :param is_int: Values rounded to int?
     """
-    return FiniteRange(lower, upper, size, log_scale=True)
+    return FiniteRange(lower, upper, size, log_scale=True, is_int=is_int)
 
 
 def is_log_space(domain: Domain) -> bool:

--- a/syne_tune/search_space.py
+++ b/syne_tune/search_space.py
@@ -595,11 +595,11 @@ class FiniteRange(Domain):
     """
     Represents a finite range `[lower, ..., upper]` with `size` values
     equally spaced in linear or log domain.
-    If `is_int`, the value type is int (rounding after the transform).
+    If `cast_int`, the value type is int (rounding after the transform).
 
     """
     def __init__(self, lower: float, upper: float, size: int,
-                 log_scale: bool = False, is_int: bool = False):
+                 log_scale: bool = False, cast_int: bool = False):
         assert lower < upper
         assert size >= 2
         if log_scale:
@@ -608,7 +608,7 @@ class FiniteRange(Domain):
         self.lower = lower
         self.upper = upper
         self.log_scale = log_scale
-        self.is_int = is_int
+        self.cast_int = cast_int
         if not log_scale:
             self._lower_internal = lower
             self._step_internal = (upper - lower) / (size - 1)
@@ -623,14 +623,14 @@ class FiniteRange(Domain):
         if self.log_scale:
             y = np.exp(y)
         y = np.clip(y, self.lower, self.upper)
-        if not self.is_int:
+        if not self.cast_int:
             return float(y)
         else:
             return int(np.round(y))
 
     @property
     def value_type(self):
-        return float if not self.is_int else int
+        return float if not self.cast_int else int
 
     def _map_to_int(self, value) -> int:
         int_value = np.clip(value, self.lower, self.upper)
@@ -672,7 +672,7 @@ class FiniteRange(Domain):
                and np.isclose(self.lower, other.lower) \
                and np.isclose(self.upper, other.upper) \
                and self.log_scale == other.log_scale \
-               and self.is_int == other.is_int
+               and self.cast_int == other.cast_int
 
 
 def sample_from(func: Callable[[Dict], Any]):
@@ -823,7 +823,7 @@ def qrandn(mean: float, sd: float, q: float):
     return Float(None, None).normal(mean, sd).quantized(q)
 
 
-def finrange(lower: float, upper: float, size: int, is_int: bool = False):
+def finrange(lower: float, upper: float, size: int, cast_int: bool = False):
     """
     Finite range `[lower, ..., upper]` with `size` entries, which are
     equi-spaced. Finite alternative to `uniform`.
@@ -831,12 +831,12 @@ def finrange(lower: float, upper: float, size: int, is_int: bool = False):
     :param lower: Smallest feasible value
     :param upper: Largest feasible value
     :param size: Size of (finite) domain, must be >= 2
-    :param is_int: Values rounded to int?
+    :param cast_int: Values rounded to int?
     """
-    return FiniteRange(lower, upper, size, log_scale=False, is_int=is_int)
+    return FiniteRange(lower, upper, size, log_scale=False, cast_int=cast_int)
 
 
-def logfinrange(lower: float, upper: float, size: int, is_int: bool = False):
+def logfinrange(lower: float, upper: float, size: int, cast_int: bool = False):
     """
     Finite range `[lower, ..., upper]` with `size` entries, which are
     equi-spaced in the log domain. Finite alternative to `loguniform`.
@@ -844,9 +844,9 @@ def logfinrange(lower: float, upper: float, size: int, is_int: bool = False):
     :param lower: Smallest feasible value (positive)
     :param upper: Largest feasible value (positive)
     :param size: Size of (finite) domain, must be >= 2
-    :param is_int: Values rounded to int?
+    :param cast_int: Values rounded to int?
     """
-    return FiniteRange(lower, upper, size, log_scale=True, is_int=is_int)
+    return FiniteRange(lower, upper, size, log_scale=True, cast_int=cast_int)
 
 
 def is_log_space(domain: Domain) -> bool:

--- a/tst/test_searchspace.py
+++ b/tst/test_searchspace.py
@@ -116,7 +116,11 @@ def test_search_space_size():
     (logfinrange(np.exp(0.1), np.exp(1.0), 10),
      np.exp(np.arange(0.1, 1.1, 0.1))),
     (logfinrange(0.0001, 1.0, 5),
-     np.array([0.0001, 0.001, 0.01, 0.1, 1.0]))
+     np.array([0.0001, 0.001, 0.01, 0.1, 1.0])),
+    (finrange(0, 8, 5, is_int=True),
+     np.array([0, 2, 4, 6, 8])),
+    (logfinrange(8, 512, 7, is_int=True),
+     np.array([8, 16, 32, 64, 128, 256, 512])),
 ])
 def test_finrange_domain(domain, value_set):
     seed = 31415927
@@ -136,7 +140,9 @@ def test_finrange_domain(domain, value_set):
     (randint(0, 10), int),
     (lograndint(1, 10), int),
     (finrange(0.1, 1.0, 10), float),
-    (logfinrange(np.exp(0.1), np.exp(1.0), 10), float)
+    (logfinrange(np.exp(0.1), np.exp(1.0), 10), float),
+    (finrange(0, 8, 5, is_int=True), int),
+    (logfinrange(8, 512, 7, is_int=True), int),
 ])
 def test_type_of_sample(domain, tp):
     num_samples = 5

--- a/tst/test_searchspace.py
+++ b/tst/test_searchspace.py
@@ -117,9 +117,9 @@ def test_search_space_size():
      np.exp(np.arange(0.1, 1.1, 0.1))),
     (logfinrange(0.0001, 1.0, 5),
      np.array([0.0001, 0.001, 0.01, 0.1, 1.0])),
-    (finrange(0, 8, 5, is_int=True),
+    (finrange(0, 8, 5, cast_int=True),
      np.array([0, 2, 4, 6, 8])),
-    (logfinrange(8, 512, 7, is_int=True),
+    (logfinrange(8, 512, 7, cast_int=True),
      np.array([8, 16, 32, 64, 128, 256, 512])),
 ])
 def test_finrange_domain(domain, value_set):
@@ -141,8 +141,8 @@ def test_finrange_domain(domain, value_set):
     (lograndint(1, 10), int),
     (finrange(0.1, 1.0, 10), float),
     (logfinrange(np.exp(0.1), np.exp(1.0), 10), float),
-    (finrange(0, 8, 5, is_int=True), int),
-    (logfinrange(8, 512, 7, is_int=True), int),
+    (finrange(0, 8, 5, cast_int=True), int),
+    (logfinrange(8, 512, 7, cast_int=True), int),
 ])
 def test_type_of_sample(domain, tp):
     num_samples = 5


### PR DESCRIPTION
…on (surrogate) is not required

*Issue #, if available:*
The code in main right now does not work. It uses a surrogate, which needs fixes as proposed in #159 

*Description of changes:*
This is a small part of #159 . It sets the config space for nashpobench such that a surrogate is not needed. This is still not the best for BO, because one parameter remains categorical. But it is better than having all of them categorical.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
