### PR TITLE
use a fix version for gluonts example rather than mainline

### DIFF
--- a/examples/training_scripts/gluonts/requirements.txt
+++ b/examples/training_scripts/gluonts/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/awslabs/gluon-ts.git
+gluonts==0.8.1


### PR DESCRIPTION
*Description of changes:* we were using mainline before as callbacks were not in a published gluonts version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
