### PR TITLE
Tuner: handle the scenario when the trial is stopped externally, i.e. independently of the Scheduler

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -368,8 +368,7 @@ class Tuner:
         Trials can be finished because:
          1) the scheduler decided to stop or pause.
          2) the trial failed.
-         3) the trial was stopped independently of the scheduler, e.g. due to max_run argument, the timeout setting of
-            the SM Estimator, or manually via the AWS console.
+         3) the trial was stopped independently of the scheduler, e.g. due to a timeout argument or a manual interruption.
          4) the trial completed.
         """
         # gets the list of jobs from running_jobs that are done

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -259,8 +259,7 @@ class Tuner:
         # Gets list of trials that are done with the new results.
         # The trials can be finished for different reasons:
         # - they completed,
-        # - they were stopped independently of the scheduler, e.g. due to max_run argument, the timeout setting of
-        #   the SM Estimator, or manually via the AWS console,
+        # - they were stopped independently of the scheduler, e.g. due to a timeout argument or a manual interruption
         # - scheduler decided to interrupt them.
         # Note: `done_trials` includes trials which are paused.
         done_trials_statuses = self._update_running_trials(trial_status_dict, new_results, callbacks=self.callbacks)


### PR DESCRIPTION
*Description of changes:*
Hello!
This patch handles the scenario when the trial is stopped externally, i.e. independently of the Scheduler, e.g. due to max_run argument (the timeout setting of the SM Estimator) or manually via the AWS console.
I encountered this issue when my individual trials had `max_run=10min`, and when they were stopped (by themselves), the `running_trials_ids` in `Tuner.run()` was not updated and hence the Tuner wouldn't start more trials.

The proposed solution is the best I could do at first glance, but there might be a more elegant way to handle this.
This logic of the proposed solution should be carefully reviewed by someone with a good understanding of the Tuner class, because I'm not 100% certain if it's fully consistent with other logic of this class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
