### PR TITLE
Config space

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Below is a minimal example showing how to tune a script `train_height.py` with R
 
 ```python
 from pathlib import Path
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune.backend.local_backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune.stopping_criterion import StoppingCriterion

--- a/benchmarking/blackbox_repository/blackbox_surrogate.py
+++ b/benchmarking/blackbox_repository/blackbox_surrogate.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.base import BaseEstimator, TransformerMixin
 import numpy as np
 
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 from benchmarking.blackbox_repository.blackbox import Blackbox
 
 

--- a/benchmarking/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
+++ b/benchmarking/blackbox_repository/conversion_scripts/scripts/fcnet_import.py
@@ -18,7 +18,7 @@ from benchmarking.blackbox_repository.blackbox_tabular import serialize, Blackbo
 from benchmarking.blackbox_repository.conversion_scripts.utils import repository_path
 
 from syne_tune.util import catchtime
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 
 BLACKBOX_NAME = 'fcnet'

--- a/benchmarking/blackbox_repository/conversion_scripts/scripts/icml2020_import.py
+++ b/benchmarking/blackbox_repository/conversion_scripts/scripts/icml2020_import.py
@@ -9,7 +9,7 @@ import pandas as pd
 import numpy as np
 from benchmarking.blackbox_repository.blackbox_offline import serialize, BlackboxOffline
 from benchmarking.blackbox_repository.conversion_scripts.utils import repository_path, upload
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 
 def download(blackbox: str):

--- a/benchmarking/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
+++ b/benchmarking/blackbox_repository/conversion_scripts/scripts/nasbench201_import.py
@@ -8,7 +8,7 @@ import logging
 from benchmarking.blackbox_repository.blackbox_tabular import serialize, BlackboxTabular
 from benchmarking.blackbox_repository.conversion_scripts.utils import repository_path
 
-from syne_tune import search_space
+from syne_tune.config_space import randint, choice
 from syne_tune.util import catchtime
 
 logger = logging.getLogger(__name__)
@@ -141,12 +141,12 @@ def convert_dataset(data, dataset):
     save_objective_values_helper('params', params)
 
     configuration_space = {
-        node: search_space.choice(['avg_pool_3x3', 'nor_conv_3x3', 'skip_connect', 'nor_conv_1x1', 'none'])
+        node: choice(['avg_pool_3x3', 'nor_conv_3x3', 'skip_connect', 'nor_conv_1x1', 'none'])
         for node in hp_cols
     }
 
     fidelity_space = {
-        RESOURCE_ATTR: search_space.randint(lower=1, upper=201)
+        RESOURCE_ATTR: randint(lower=1, upper=201)
     }
 
     objective_names = [f"metric_{m}" for m in objective_names]
@@ -224,7 +224,7 @@ def generate_nasbench201(s3_root: Optional[str] = None):
         serialize(bb_dict=bb_dict, path=repository_path / BLACKBOX_NAME)
 
     with catchtime("uploading to S3"):
-        from benchmarking.blackbox_repository.conversion_scripts import upload
+        from benchmarking.blackbox_repository.conversion_scripts.utils import upload
         upload(BLACKBOX_NAME, s3_root=s3_root)
 
 
@@ -232,7 +232,7 @@ if __name__ == '__main__':
     generate_nasbench201()
 
     # plot one learning-curve for sanity-check
-    from blackbox_repository import load
+    from benchmarking.blackbox_repository import load
 
     bb_dict = load(BLACKBOX_NAME)
 

--- a/benchmarking/blackbox_repository/serialize.py
+++ b/benchmarking/blackbox_repository/serialize.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Dict
 import json
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 def serialize_configspace(
     path: str,

--- a/benchmarking/definitions/definition_nasbench201.py
+++ b/benchmarking/definitions/definition_nasbench201.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from syne_tune.search_space import choice
+from syne_tune.config_space import choice
 from benchmarking.blackbox_repository.conversion_scripts.scripts.nasbench201_import import \
     CONFIG_KEYS, METRIC_VALID_ERROR, METRIC_TIME_THIS_RESOURCE, \
     RESOURCE_ATTR, BLACKBOX_NAME

--- a/benchmarking/definitions/definition_nashpobench.py
+++ b/benchmarking/definitions/definition_nashpobench.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from syne_tune.search_space import choice, logfinrange, finrange
+from syne_tune.config_space import choice, logfinrange, finrange
 
 from benchmarking.blackbox_repository.conversion_scripts.scripts.fcnet_import \
     import METRIC_ELAPSED_TIME, METRIC_VALID_LOSS, RESOURCE_ATTR, BLACKBOX_NAME

--- a/benchmarking/nursery/lstm_wikitext2/lstm_wikitext2.py
+++ b/benchmarking/nursery/lstm_wikitext2/lstm_wikitext2.py
@@ -20,7 +20,7 @@ import time
 import math
 
 from syne_tune import Reporter
-from syne_tune.search_space import randint, uniform, loguniform, \
+from syne_tune.config_space import randint, uniform, loguniform, \
     add_to_argparse
 from benchmarking.utils import resume_from_checkpointed_model, \
     checkpoint_model_at_rung_level, add_checkpointing_to_argparse, \

--- a/benchmarking/training_scripts/distilbert_on_imdb/distilbert_on_imdb.py
+++ b/benchmarking/training_scripts/distilbert_on_imdb/distilbert_on_imdb.py
@@ -18,7 +18,7 @@ import logging
 import time
 
 from syne_tune import Reporter
-from syne_tune.search_space import loguniform, add_to_argparse
+from syne_tune.config_space import loguniform, add_to_argparse
 
 
 METRIC_ACCURACY = 'accuracy'

--- a/benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
+++ b/benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
@@ -19,7 +19,7 @@ import logging
 import time
 
 from syne_tune import Reporter
-from syne_tune.search_space import randint, uniform, loguniform, \
+from syne_tune.config_space import randint, uniform, loguniform, \
     add_to_argparse
 from benchmarking.utils import resume_from_checkpointed_model, \
     checkpoint_model_at_rung_level, add_checkpointing_to_argparse, \

--- a/benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
+++ b/benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
@@ -16,7 +16,7 @@ import logging
 import time
 
 from syne_tune import Reporter
-from syne_tune.search_space import randint, uniform, loguniform, \
+from syne_tune.config_space import randint, uniform, loguniform, \
     add_to_argparse
 from benchmarking.utils import resume_from_checkpointed_model, \
     checkpoint_model_at_rung_level, add_checkpointing_to_argparse, \

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -138,17 +138,17 @@ The simplest HPO baseline is **random search**, which you obtain with
 configuration is chosen by sampling attribute values at random, from
 distributions specified in `config_space`:
 
-* `search_space.uniform(lower, upper)`: Real-valued uniform in `[lower, upper]`
-* `search_space.loguniform(lower, upper)`: Real-valued log-uniform in
+* `config_space.uniform(lower, upper)`: Real-valued uniform in `[lower, upper]`
+* `config_space.loguniform(lower, upper)`: Real-valued log-uniform in
   `[lower, upper]`. More precisely, the value is `exp(x)`, where `x` is drawn
   uniformly in `[log(lower), log(upper)]`
-* `search_space.randint(lower, upper)`: Integer uniform in `lower, ..., upper`.
+* `config_space.randint(lower, upper)`: Integer uniform in `lower, ..., upper`.
   The value range includes both `lower` and `upper` (difference to Python range
   convention)
-* `search_space.lograndint(lower, upper)`: Integer log-uniform in
+* `config_space.lograndint(lower, upper)`: Integer log-uniform in
   `lower, ..., upper`. More precisely, the value is `int(round(exp(x)))`, where
   `x` is drawn uniformly in `[log(lower - 0.5), log(upper + 0.5)]`
-* `search_space.choice(categories)`: Uniform from the finite list `categories`
+* `config_space.choice(categories)`: Uniform from the finite list `categories`
   of `str` values
 
 If `points_to_evaluate` is specified, configurations are first taken from this

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -322,7 +322,7 @@ above, the rung levels would be 1, 3, 9, 27, 56.
 If `max_t` is not given as argument to `HyperbandScheduler`, the value may be
 inferred from `config_space`. Namely, `config_space['epochs']`,
 `config_space['max-t']`, `config_space['max-epochs']` are checked in this order.
-In the example above, `configspace['epochs']` contains the correct value, so we
+In the example above, `config_space['epochs']` contains the correct value, so we
 could have dropped `max_t`.
 
 Given such a rung level spacing, stop/go decisions are done by comparing

--- a/docs/search_space.md
+++ b/docs/search_space.md
@@ -9,10 +9,10 @@ this tutorial you will learn about the basics and some gotchas.
 ### Introduction
 
 Here is an example for a configuration space:
-```python
-from syne_tune.search_space import randint, uniform, loguniform, \
-    choice
 
+```python
+from syne_tune.config_space import randint, uniform, loguniform, \
+    choice
 
 config_space = {
     'n_units': randint(4, 1024),

--- a/docs/tutorials/basics/basics_bayesopt.md
+++ b/docs/tutorials/basics/basics_bayesopt.md
@@ -125,11 +125,11 @@ While our running example does not have any, hyperparameters of categorical type
 are often used. For example:
 
 ```python
-from syne_tune.search_space import randint, choice
+from syne_tune.config_space import randint, choice
 
 config_space = {
     'n_units_1': randint(4, 1024),
-     # ...
+    # ...
     'activation': choice(['ReLU', 'LeakyReLU', 'Softplus']),
 }
 ```

--- a/docs/tutorials/basics/basics_randomsearch.md
+++ b/docs/tutorials/basics/basics_randomsearch.md
@@ -38,7 +38,7 @@ is chosen by sampling independently from the hyperparameter domain. Recall
 our search space:
 
 ```python
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 
 config_space = {
     'n_units_1': randint(4, 1024),

--- a/docs/tutorials/basics/basics_setup.md
+++ b/docs/tutorials/basics/basics_setup.md
@@ -73,11 +73,11 @@ to be tuned by Syne Tune: [traincode_report_end.py](scripts/traincode_report_end
   we report the validation accuracy as `report(accuracy=accuracy)`.
 
 
-## Step 2: Defining the Search Space
+## Step 2: Defining the Configuration Space
 
 Having defined the objective, we still need to specify the space we would like
 to search over. The most flexible way to run HPO experiments in Syne Tune is
-by writing a *launcher script*, and to define the search space in there.
+by writing a *launcher script*, and to define the configuration space in there.
 Please have a look at [launch_configspace_only.py](scripts/launch_configspace_only.py),
 the first part of a launcher script.
 * [1] First, we make some basic choices, which will only become fully clear once
@@ -87,17 +87,17 @@ the first part of a launcher script.
   mode of optimization (in `mode`). For our example, we maximize the metric
   `'accuracy'`. Here, `metric` needs to be the parameter name used in the
   `report` call in our training script.
-* [3] Most importantly, we need to define the search space for our problem,
+* [3] Most importantly, we need to define the configuration space for our problem,
   which we do with `config_space`.
 
-The search space is a dictionary with key names corresponding to command line
+The configuration space is a dictionary with key names corresponding to command line
 input parameters of our training script. For each parameter you would like to
-tune, you need to specify a `Domain`, imported from `syne_tune.search_space`.
+tune, you need to specify a `Domain`, imported from `syne_tune.config_space`.
 A domain consists of a type (float, int, categorical), a range (inclusive on
 both ends), and an encoding (linear or logarithmic).
 
 ```python
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 
 config_space = {
     'n_units_1': randint(4, 1024),
@@ -116,7 +116,7 @@ and `learning_rate`, `weight_decay` are float with logarithmic encoding (`loguni
 We also need to specify upper and lower bounds: `n_units_1` lies between 4 and 1024,
 the range includes both boundary values.
 
-Choosing a good search space for a given problem may require some iterations.
+Choosing a good configuration space for a given problem may require some iterations.
 Parameters like learning rate or regularization constants are often log-encoded, as
 best values may vary over several orders of magnitude and may be close to 0. On
 the other hand, probabilities are linearly encoded. Search ranges need to be chosen
@@ -124,15 +124,15 @@ wide enough not to discount potentially useful values up front, but setting them
 overly large risks a long tuning time. In general, the range definitions are more
 critical for methods based on random exploration than for model-based HPO methods.
 
-More details on choosing the search space are provided [here](../../search_space.md),
+More details on choosing the configuration space are provided [here](../../search_space.md),
 where you will also learn about two more types: categorical and finite range.
 
 Finally, you can also tune only a subset of the hyperparameters of your training
 script, providing fixed (default) values for the remaining ones. For example, the
-following search space fixes the model architecture:
+following configuration space fixes the model architecture:
 
 ```python
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 
 config_space = {
     'n_units_1': 512,

--- a/docs/tutorials/basics/scripts/launch_asha_promotion.py
+++ b/docs/tutorials/basics/scripts/launch_asha_promotion.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_asha_stopping.py
+++ b/docs/tutorials/basics/scripts/launch_asha_stopping.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_bayesopt.py
+++ b/docs/tutorials/basics/scripts/launch_bayesopt.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_configspace_only.py
+++ b/docs/tutorials/basics/scripts/launch_configspace_only.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 
 
 if __name__ == '__main__':

--- a/docs/tutorials/basics/scripts/launch_mobster_promotion.py
+++ b/docs/tutorials/basics/scripts/launch_mobster_promotion.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_mobster_stopping.py
+++ b/docs/tutorials/basics/scripts/launch_mobster_stopping.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_randomsearch.py
+++ b/docs/tutorials/basics/scripts/launch_randomsearch.py
@@ -24,7 +24,7 @@
 import logging
 from pathlib import Path
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner

--- a/docs/tutorials/basics/scripts/launch_sagemaker_backend.py
+++ b/docs/tutorials/basics/scripts/launch_sagemaker_backend.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from sagemaker.pytorch import PyTorch
 
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import SageMakerBackend
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler

--- a/examples/launch_bayesopt_constrained.py
+++ b/examples/launch_bayesopt_constrained.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_height_baselines.py
+++ b/examples/launch_height_baselines.py
@@ -19,7 +19,7 @@ from syne_tune.optimizer.baselines import PASHA, BORE  # noqa: F401
 from syne_tune.optimizer.schedulers.synchronous.hyperband_impl import \
     SynchronousGeometricHyperbandScheduler  # noqa: F401
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 if __name__ == '__main__':

--- a/examples/launch_height_baselines.py
+++ b/examples/launch_height_baselines.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization, ASHA, MOBSTER
-from syne_tune.optimizer.baselines import PASHA, BORE  # noqa: F401
-from syne_tune.optimizer.schedulers.synchronous.hyperband_impl import \
-    SynchronousGeometricHyperbandScheduler  # noqa: F401
+# from syne_tune.optimizer.baselines import PASHA, BORE  # noqa: F401
+# from syne_tune.optimizer.schedulers.synchronous.hyperband_impl import \
+#    SynchronousGeometricHyperbandScheduler  # noqa: F401
 from syne_tune import Tuner
 from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion

--- a/examples/launch_height_moasha.py
+++ b/examples/launch_height_moasha.py
@@ -21,7 +21,7 @@ import numpy as np
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.multiobjective.moasha import MOASHA
 from syne_tune import Tuner
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_height_ray.py
+++ b/examples/launch_height_ray.py
@@ -20,7 +20,7 @@ import numpy as np
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.ray_scheduler import RayTuneScheduler
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 if __name__ == '__main__':

--- a/examples/launch_height_sagemaker.py
+++ b/examples/launch_height_sagemaker.py
@@ -22,7 +22,7 @@ from syne_tune.backend import SageMakerBackend
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_height_sagemaker_custom_image.py
+++ b/examples/launch_height_sagemaker_custom_image.py
@@ -21,7 +21,7 @@ from syne_tune.backend import SageMakerBackend
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_height_sagemaker_remotely.py
+++ b/examples/launch_height_sagemaker_remotely.py
@@ -24,7 +24,7 @@ from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_ro
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune.remote.remote_launcher import RemoteLauncher
 from syne_tune.backend import SageMakerBackend
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 from syne_tune import Tuner
 

--- a/examples/launch_height_standalone_scheduler.py
+++ b/examples/launch_height_standalone_scheduler.py
@@ -24,7 +24,7 @@ from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import TrialScheduler, \
     SchedulerDecision, TrialSuggestion
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_moasha_instance_tuning.py
+++ b/examples/launch_moasha_instance_tuning.py
@@ -26,7 +26,7 @@ from syne_tune.optimizer.schedulers.multiobjective.moasha import MOASHA
 from syne_tune.remote.remote_launcher import RemoteLauncher
 from syne_tune import StoppingCriterion
 from syne_tune import Tuner
-from syne_tune.search_space import loguniform, choice
+from syne_tune.config_space import loguniform, choice
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)

--- a/examples/launch_pbt.py
+++ b/examples/launch_pbt.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.pbt import PopulationBasedTraining
 from syne_tune import Tuner
-from syne_tune.search_space import loguniform
+from syne_tune.config_space import loguniform
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -17,7 +17,7 @@ from syne_tune.backend import LocalBackend
 from syne_tune.experiments import load_experiment
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion
 
 

--- a/examples/launch_rl_tuning.py
+++ b/examples/launch_rl_tuning.py
@@ -10,7 +10,7 @@ import numpy as np
 from syne_tune.backend import LocalBackend
 from syne_tune.experiments import load_experiment
 from syne_tune.optimizer.baselines import ASHA
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 from syne_tune import Tuner
 
 if __name__ == '__main__':

--- a/examples/launch_simulated_benchmark.py
+++ b/examples/launch_simulated_benchmark.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import pandas as pd
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 from benchmarking.blackbox_repository import load, add_surrogate
 from benchmarking.blackbox_repository.blackbox_tabular import BlackboxTabular

--- a/examples/launch_tuning_gluonts.py
+++ b/examples/launch_tuning_gluonts.py
@@ -26,7 +26,7 @@ from syne_tune.backend import SageMakerBackend
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
 from syne_tune.optimizer.baselines import ASHA
 from syne_tune import Tuner, StoppingCriterion
-from syne_tune.search_space import loguniform, lograndint
+from syne_tune.config_space import loguniform, lograndint
 
 
 if __name__ == '__main__':

--- a/examples/training_scripts/height_with_cost/train_height_with_cost.py
+++ b/examples/training_scripts/height_with_cost/train_height_with_cost.py
@@ -20,7 +20,7 @@ import time
 import math
 
 from syne_tune import Reporter
-from syne_tune.search_space import randint, add_to_argparse
+from syne_tune.config_space import randint, add_to_argparse
 from benchmarking.utils import resume_from_checkpointed_model, \
     checkpoint_model_at_rung_level, add_checkpointing_to_argparse, parse_bool
 

--- a/syne_tune/__init__.py
+++ b/syne_tune/__init__.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 try:
-    __all__ = ['search_space', 'StoppingCriterion', 'Tuner', 'Reporter']
+    __all__ = ['config_space.py', 'StoppingCriterion', 'Tuner', 'Reporter']
     from pathlib import Path
     from syne_tune.stopping_criterion import StoppingCriterion
     from syne_tune.report import Reporter

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -450,7 +450,7 @@ class Categorical(Domain):
             f"All entries in categories = {self.categories} must have the same type"
         if isinstance(self.value_type, float):
             logger.warning(
-                "The search space contains a categorical value with float type. "
+                "The configuration space contains a categorical value with float type. "
                 "When performing remote execution, floats are converted to string which can cause rounding "
                 "issues. In case of problem, consider using string to represent the float."
             )
@@ -898,9 +898,9 @@ def non_constant_hyperparameter_keys(config_space: Dict) -> List[str]:
             if isinstance(domain, Domain)]
 
 
-def search_space_size(config_space: Dict, upper_limit: int = 2 ** 20) -> Optional[int]:
+def config_space_size(config_space: Dict, upper_limit: int = 2 ** 20) -> Optional[int]:
     """
-    Counts the number of distinct configurations in the search space
+    Counts the number of distinct configurations in the configuration space
     `config_space`. If this is infinite (due to real-valued parameters) or
     larger than `upper_limit`, None is returned.
     """

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -190,7 +190,7 @@ class REA(FIFOScheduler):
             config_space=config_space,
             metric=metric,
             searcher=RegularizedEvolution(
-                configspace=config_space, metric=metric,
+                config_space=config_space, metric=metric,
                 population_size=population_size, sample_size=sample_size,
                 **kwargs),
             **kwargs,

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -15,7 +15,7 @@ from typing import Optional, Dict, List
 import logging
 
 from syne_tune.backend.trial_status import Trial
-from syne_tune.search_space import non_constant_hyperparameter_keys, \
+from syne_tune.config_space import non_constant_hyperparameter_keys, \
     cast_config_values
 
 logger = logging.getLogger(__name__)

--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -201,7 +201,7 @@ class FIFOScheduler(ResourceLevelsScheduler):
             else:
                 search_options = search_options.copy()
             search_options.update({
-                'configspace': self.config_space.copy(),
+                'config_space': self.config_space.copy(),
                 'metric': self.metric,
                 'points_to_evaluate': kwargs.get('points_to_evaluate'),
                 'scheduler_mode': kwargs['mode'],

--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -27,7 +27,7 @@ from syne_tune.optimizer.scheduler import TrialScheduler, \
     SchedulerDecision, TrialSuggestion
 from syne_tune.backend.time_keeper import TimeKeeper, RealTimeKeeper
 from syne_tune.backend.trial_status import Trial
-from syne_tune.search_space import cast_config_values
+from syne_tune.config_space import cast_config_values
 
 __all__ = ['FIFOScheduler',
            'ResourceLevelsScheduler']

--- a/syne_tune/optimizer/schedulers/pbt.py
+++ b/syne_tune/optimizer/schedulers/pbt.py
@@ -19,11 +19,11 @@ from dataclasses import dataclass
 from collections import deque
 from typing import Callable, Dict, List, Optional, Tuple
 
-from syne_tune.search_space import Domain, Integer, Float, FiniteRange
+from syne_tune.config_space import Domain, Integer, Float, FiniteRange
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import SchedulerDecision, TrialSuggestion
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
-from syne_tune.search_space import cast_config_values
+from syne_tune.config_space import cast_config_values
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments \
     import check_and_merge_defaults, Integer as DA_Integer, \
     Boolean as DA_Boolean, filter_by_key, String as DA_String, \

--- a/syne_tune/optimizer/schedulers/pbt.py
+++ b/syne_tune/optimizer/schedulers/pbt.py
@@ -300,7 +300,7 @@ class PopulationBasedTraining(FIFOScheduler):
             config['elapsed_time'] = self._elapsed_time()
             config = cast_config_values(
                 config=config,
-                config_space=self.searcher.configspace)
+                config_space=self.searcher.config_space)
             config['trial_id'] = trial_id
             return TrialSuggestion.start_suggestion(config=config,
                                                     checkpoint_trial_id=trial_id_to_continue)

--- a/syne_tune/optimizer/schedulers/ray_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ray_scheduler.py
@@ -16,7 +16,7 @@ import logging
 from syne_tune.optimizer.scheduler import TrialScheduler, \
     TrialSuggestion
 from syne_tune.backend.trial_status import Trial
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 __all__ = ['RayTuneScheduler']
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/config_ext.py
@@ -13,7 +13,7 @@
 from typing import Tuple
 import copy
 
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges \
     import HyperparameterRanges
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
@@ -15,7 +15,7 @@ from typing import Tuple, List, Iterable, Dict, Optional
 import numpy as np
 from numpy.random import RandomState
 
-from syne_tune.search_space import Domain, Categorical, \
+from syne_tune.config_space import Domain, Categorical, \
     non_constant_hyperparameter_keys, is_log_space, config_to_match_string
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \
     import Hyperparameter, Configuration

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple, Dict, List, Any, Optional, Union
 import numpy as np
 
-from syne_tune.search_space import Domain, is_log_space, FiniteRange, Categorical
+from syne_tune.config_space import Domain, is_log_space, FiniteRange, Categorical
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \
     import Hyperparameter, Configuration
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges \
@@ -199,7 +199,7 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
             self, name: str, lower_bound: float, upper_bound: float,
             size: int, scaling: Scaling, cast_int: bool = False):
         """
-        See :class:`FiniteRange` in `search_space`. Internally, we use an int
+        See :class:`FiniteRange` in `config_space`. Internally, we use an int
         with linear scaling.
         Note: Different to `HyperparameterRangeContinuous`, we require that
         `lower_bound < upper_bound` and `size >=2`.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/issm.py
@@ -41,10 +41,10 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_impl 
 
 def _prepare_data_internal(
         state: TuningJobState, data_lst: List[Tuple[Configuration, List, str]],
-        configspace_ext: ExtendedConfiguration, active_metric: str,
+        config_space_ext: ExtendedConfiguration, active_metric: str,
         do_fantasizing: bool, mean: float,
         std: float) -> (List[Configuration], List[np.ndarray], List[str]):
-    r_min, r_max = configspace_ext.resource_attr_range
+    r_min, r_max = config_space_ext.resource_attr_range
     configs = [x[0] for x in data_lst]
     trial_ids = [x[2] for x in data_lst]
     targets = []
@@ -130,7 +130,7 @@ def _create_tuple(
 
 
 def prepare_data(
-        state: TuningJobState, configspace_ext: ExtendedConfiguration,
+        state: TuningJobState, config_space_ext: ExtendedConfiguration,
         active_metric: str, normalize_targets: bool = False,
         do_fantasizing: bool = False) -> Dict:
     """
@@ -153,14 +153,14 @@ def prepare_data(
     normalized targets as well.
 
     :param state: `TuningJobState` with data
-    :param configspace_ext: Extended config space
+    :param config_space_ext: Extended config space
     :param active_metric:
     :param normalize_targets: See above
     :param do_fantasizing: See above
     :return: See above
     """
-    r_min, r_max = configspace_ext.resource_attr_range
-    hp_ranges = configspace_ext.hp_ranges
+    r_min, r_max = config_space_ext.resource_attr_range
+    hp_ranges = config_space_ext.hp_ranges
     data_lst = []
     targets = []
     for ev in state.trials_evaluations:
@@ -177,7 +177,7 @@ def prepare_data(
     configs, targets, trial_ids = _prepare_data_internal(
         state=state,
         data_lst=data_lst,
-        configspace_ext=configspace_ext,
+        config_space_ext=config_space_ext,
         active_metric=active_metric,
         do_fantasizing=do_fantasizing,
         mean=mean, std=std)
@@ -200,7 +200,7 @@ def prepare_data(
 
 
 def prepare_data_with_pending(
-        state: TuningJobState, configspace_ext: ExtendedConfiguration,
+        state: TuningJobState, config_space_ext: ExtendedConfiguration,
         active_metric: str, normalize_targets: bool = False) -> (Dict, Dict):
     """
     Similar to `prepare_data` with `do_fantasizing=False`, but two dicts are
@@ -213,14 +213,14 @@ def prepare_data_with_pending(
     evals are contiguous (when it comes to resource levels).
 
     :param state: See `prepare_data`
-    :param configspace_ext: See `prepare_data`
+    :param config_space_ext: See `prepare_data`
     :param active_metric: See `prepare_data`
     :param normalize_targets: See `prepare_data`
     :return: See above
 
     """
-    r_min, r_max = configspace_ext.resource_attr_range
-    hp_ranges = configspace_ext.hp_ranges
+    r_min, r_max = config_space_ext.resource_attr_range
+    hp_ranges = config_space_ext.hp_ranges
     data1_lst = []  # trials without pending evals
     data2_lst = []  # trials with pending evals
     num_pending = []
@@ -257,7 +257,7 @@ def prepare_data_with_pending(
         configs, targets, trial_ids = _prepare_data_internal(
             state=state,
             data_lst=data_lst,
-            configspace_ext=configspace_ext,
+            config_space_ext=config_space_ext,
             active_metric=active_metric,
             do_fantasizing=False,
             mean=mean, std=std)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/linear_cost_model.py
@@ -262,19 +262,19 @@ class FixedLayersMLPCostModel(MLPLinearCostModel):
 
     @staticmethod
     def get_expected_hidden_layer_width(
-            configspace: Dict, num_units_keys: List[str]):
+            config_space: Dict, num_units_keys: List[str]):
         """
         Constructs expected_hidden_layer_width function from the training
         evaluation function.
         Works because `impute_points_to_evaluate` imputes with the expected
         value under random sampling.
 
-        :param configspace: Configuration space
-        :param num_units_keys: Keys into `configspace` for number of
+        :param config_space: Configuration space
+        :param num_units_keys: Keys into `config_space` for number of
             units of different layers
         :return: expected_hidden_layer_width, exp_vals
         """
-        default_config = impute_points_to_evaluate(None, configspace)[0]
+        default_config = impute_points_to_evaluate(None, config_space)[0]
         exp_vals = [default_config[k] for k in num_units_keys]
 
         def expected_hidden_layer_width(x):

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
@@ -140,7 +140,6 @@ class NonLinearCostModel(CostModel):
         `state`, at the minimum resource level `res_min`.
 
         :param state: TuningJobState
-        :param configspace_ext:
         :return: dataset, num_data0, res_min, target_min
         """
         data_config = []

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
@@ -125,7 +125,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
             self, gpmodel: GaussianProcessLearningCurveModel,
             num_fantasy_samples: int,
             active_metric: str,
-            configspace_ext: ExtendedConfiguration,
+            config_space_ext: ExtendedConfiguration,
             normalize_targets: bool = False,
             profiler: Optional[SimpleProfiler] = None,
             debug_log: Optional[DebugLogPrinter] = None,
@@ -139,7 +139,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
         :param gpmodel: GaussianProcessLearningCurveModel
         :param num_fantasy_samples: See above
         :param active_metric: Name of the metric to optimize.
-        :param configspace_ext: ExtendedConfiguration
+        :param config_space_ext: ExtendedConfiguration
         :param normalize_targets: Normalize observed target values?
         :param debug_log: DebugLogPrinter (optional)
         :param filter_observed_data: Filter for observed data before
@@ -148,13 +148,13 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
         """
         self._gpmodel = gpmodel
         self.active_metric = active_metric
-        r_min, r_max = configspace_ext.resource_attr_range
+        r_min, r_max = config_space_ext.resource_attr_range
         assert 0 < r_min < r_max, \
             f"r_min = {r_min}, r_max = {r_max}: Need 0 < r_min < r_max"
         assert num_fantasy_samples >= 0, \
             f"num_fantasy_samples = {num_fantasy_samples}, must be non-negative int"
         self.num_fantasy_samples = num_fantasy_samples
-        self._configspace_ext = configspace_ext
+        self._config_space_ext = config_space_ext
         self._debug_log = debug_log
         self._profiler = profiler
         self._filter_observed_data = filter_observed_data
@@ -185,7 +185,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
 
         # [1] Fit model and compute posterior state, ignoring pending evals
         data = prepare_data(
-            state, self._configspace_ext, self.active_metric,
+            state, self._config_space_ext, self.active_metric,
             normalize_targets=self.normalize_targets,
             do_fantasizing=False)
         if fit_params:
@@ -214,7 +214,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
             logger.info("Recomputing posterior state with fantasy targets")
             data = prepare_data(
                 state=state_with_fantasies,
-                configspace_ext=self._configspace_ext,
+                config_space_ext=self._config_space_ext,
                 active_metric=self.active_metric,
                 normalize_targets=self.normalize_targets,
                 do_fantasizing=True)
@@ -256,7 +256,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
         # Recompute posterior state with fantasy samples
         data = prepare_data(
             state=state_with_fantasies,
-            configspace_ext=self._configspace_ext,
+            config_space_ext=self._config_space_ext,
             active_metric=self.active_metric,
             normalize_targets=self.normalize_targets,
             do_fantasizing=True)
@@ -292,7 +292,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
         # evaluations at a time.
         data_nopending, data_pending = prepare_data_with_pending(
             state=state,
-            configspace_ext=self._configspace_ext,
+            config_space_ext=self._config_space_ext,
             active_metric=self.active_metric,
             normalize_targets=self.normalize_targets)
         if not data_nopending['configs']:
@@ -340,7 +340,7 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
                 else:
                     all_fantasy_targets[pos].append(fantasies)
         # Convert into `FantasizedPendingEvaluation`
-        r_min = self._configspace_ext.resource_attr_range[0]
+        r_min = self._config_space_ext.resource_attr_range[0]
         pending_evaluations_with_fantasies = []
         for trial_id, targets, fantasies in zip(
                 data_pending['trial_ids'], data_pending['targets'],

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
@@ -22,7 +22,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges \
     import HyperparameterRanges
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state \
     import TuningJobState
-from syne_tune.search_space import search_space_size
+from syne_tune.config_space import config_space_size
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ class ExclusionList(object):
             self.hp_ranges = state['hp_ranges']
             self.excl_set = state['excl_set']
             self.keys = state['keys']
-        self.configspace_size = search_space_size(self.hp_ranges.config_space)
+        self.configspace_size = config_space_size(self.hp_ranges.config_space)
 
     def _to_matchstr(self, config) -> str:
         return self.hp_ranges.config_to_match_string(config, keys=self.keys)

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
@@ -15,7 +15,7 @@ import numpy as np
 import scipy.linalg as spl
 import copy
 
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \
     import TrialEvaluations, Configuration, dictionarize_objective, \
     INTERNAL_METRIC_NAME

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common \
     import Hyperparameter, Configuration, dictionarize_objective
-from syne_tune.search_space import Categorical, loguniform, randint, \
+from syne_tune.config_space import Categorical, loguniform, randint, \
     choice, uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges \
     import HyperparameterRanges

--- a/syne_tune/optimizer/schedulers/searchers/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/constrained_gp_fifo_searcher.py
@@ -37,11 +37,11 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
 
     """
 
-    def __init__(self, configspace, metric, **kwargs):
+    def __init__(self, config_space, metric, **kwargs):
         assert kwargs.get('constraint_attr') is not None, \
             "This searcher needs a constraint attribute. Please specify its " +\
             "name in search_options['constraint_attr']"
-        super().__init__(configspace, metric, **kwargs)
+        super().__init__(config_space, metric, **kwargs)
 
     def _create_kwargs_int(self, kwargs):
         _kwargs = check_and_merge_defaults(

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_fifo_searcher.py
@@ -70,11 +70,11 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
     surrogate model.
 
     """
-    def __init__(self, configspace, metric, **kwargs):
+    def __init__(self, config_space, metric, **kwargs):
         assert kwargs.get('cost_attr') is not None, \
             "This searcher needs a cost attribute. Please specify its " +\
             "name in search_options['cost_attr']"
-        super().__init__(configspace, metric, **kwargs)
+        super().__init__(config_space, metric, **kwargs)
 
     def _create_kwargs_int(self, kwargs):
         _kwargs = check_and_merge_defaults(

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware_gp_multifidelity_searcher.py
@@ -71,11 +71,11 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
     cost model being given by `kwargs['cost_model']`.
 
     """
-    def __init__(self, configspace, metric, **kwargs):
+    def __init__(self, config_space, metric, **kwargs):
         assert kwargs.get('cost_attr') is not None, \
             "This searcher needs a cost attribute. Please specify its " +\
             "name in search_options['cost_attr']"
-        super().__init__(configspace, metric, **kwargs)
+        super().__init__(config_space, metric, **kwargs)
 
     def _create_kwargs_int(self, kwargs):
         _kwargs = check_and_merge_defaults(
@@ -89,10 +89,10 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
         if self.resource_for_acquisition is not None:
             super()._fix_resource_attribute(**kwargs)
             fixed_resource = \
-                self.configspace_ext.hp_ranges_ext.value_for_last_pos
+                self.config_space_ext.hp_ranges_ext.value_for_last_pos
         else:
             # Cost at r_max
-            fixed_resource = self.configspace_ext.resource_attr_range[1]
+            fixed_resource = self.config_space_ext.resource_attr_range[1]
         cost_model_factory = self.state_transformer.model_factory[
             INTERNAL_COST_NAME]
         assert isinstance(cost_model_factory, CostSurrogateModelFactory)
@@ -109,7 +109,7 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
             output_model_factory=output_model_factory,
             init_state=init_state,
             output_skip_optimization=output_skip_optimization,
-            configspace_ext=self.configspace_ext,
+            config_space_ext=self.config_space_ext,
             resource_for_acquisition=self.resource_for_acquisition)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -425,7 +425,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
 
     Parameters
     ----------
-    configspace : Dict
+    config_space : Dict
         Configuration space. Constant parameters are filtered out
     metric : str
         Name of metric reported by evaluation function.
@@ -510,13 +510,13 @@ class GPFIFOSearcher(ModelBasedSearcher):
     transfer_learning_task_attr : str (optional)
         Used to support transfer HPO, where the state contains observed data
         from several tasks, one of which is the active one. To this end,
-        `configspace` must contain a categorical parameter of name
+        `config_space` must contain a categorical parameter of name
         `transfer_learning_task_attr`, whose range are all task IDs. Also,
         `transfer_learning_active_task` must denote the active task, and
         `transfer_learning_active_config_space` is used as
         `active_config_space` argument in :class:`HyperparameterRanges`. This
         allows us to use a narrower search space for the active task than for
-        the union of all tasks (`configspace` must be that), which is needed
+        the union of all tasks (`config_space` must be that), which is needed
         if some configurations of non-active tasks lie outside of the ranges
         in `active_config_space`.
         One of the implications is that `filter_observed_data` is selecting
@@ -525,7 +525,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
     transfer_learning_active_task : str (optional)
         See `transfer_learning_task_attr`.
     transfer_learning_active_config_space : Dict (optional)
-        See `transfer_learning_task_attr`. If not given, `configspace` is the
+        See `transfer_learning_task_attr`. If not given, `config_space` is the
         search space for the active task as well. This active config space need
         not contain the `transfer_learning_task_attr` parameter. In fact, this
         parameter is set to a categorical with `transfer_learning_active_task`
@@ -543,21 +543,21 @@ class GPFIFOSearcher(ModelBasedSearcher):
             that data from all tasks can be merged together
 
     """
-    def __init__(self, configspace, metric, clone_from_state=False, **kwargs):
+    def __init__(self, config_space, metric, clone_from_state=False, **kwargs):
         if not clone_from_state:
             super().__init__(
-                configspace,
+                config_space,
                 metric=metric,
                 points_to_evaluate=kwargs.get('points_to_evaluate'),
                 random_seed_generator=kwargs.get('random_seed_generator'),
                 random_seed=kwargs.get('random_seed'))
-            kwargs['configspace'] = configspace
+            kwargs['config_space'] = config_space
             kwargs_int = self._create_kwargs_int(kwargs)
         else:
             # Internal constructor, bypassing the factory
             # Note: Members which are part of the mutable state, will be
             # overwritten in `_restore_from_state`
-            super().__init__(configspace, metric=metric)
+            super().__init__(config_space, metric=metric)
             kwargs_int = kwargs.copy()
         self._call_create_internal(kwargs_int)
 
@@ -770,7 +770,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
         :return: kwargs for creating new searcher object in `clone_from_state`
         """
         return dict(
-            configspace=self.configspace,
+            config_space=self.config_space,
             metric=self._metric,
             clone_from_state=True,
             hp_ranges=self.hp_ranges,

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -65,7 +65,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
 
     Parameters
     ----------
-    configspace : Dict
+    config_space : Dict
         Configuration space. Constant parameters are filtered out
     metric : str
         Name of reward attribute reported by evaluation function
@@ -175,7 +175,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
             kwargs_int.pop(k)
             assert isinstance(self.resource_for_acquisition,
                               ResourceForAcquisitionMap)
-        self.configspace_ext = kwargs_int.pop('configspace_ext')
+        self.config_space_ext = kwargs_int.pop('config_space_ext')
         self._create_internal(**kwargs_int)
 
     def configure_scheduler(self, scheduler):
@@ -195,11 +195,11 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
                 "HyperbandScheduler"
 
     def _hp_ranges_in_state(self):
-        return self.configspace_ext.hp_ranges_ext
+        return self.config_space_ext.hp_ranges_ext
 
     def _config_ext_update(self, config, result):
         resource = int(result[self._resource_attr])
-        return self.configspace_ext.get(config, resource)
+        return self.config_space_ext.get(config, resource)
 
     def _metric_val_update(
             self, crit_val: float, result: Dict) -> MetricValues:
@@ -238,7 +238,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         Determines target resource level r at which the current call of
         `get_config` operates. This is done based on
         `resource_for_acquisition`. This resource level is then set in
-        `configspace_ext.hp_ranges_ext.value_for_last_pos`. This does the
+        `config_space_ext.hp_ranges_ext.value_for_last_pos`. This does the
         job for GP surrogate models. But if in subclasses, other surrogate
         models are involved, they need to get informed separately (see
         :class:`CostAwareGPMultiFidelitySearcher` for an example).
@@ -255,15 +255,15 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
                 target_resource = self.resource_for_acquisition(state, **kwargs)
             else:
                 # Any valid value works here:
-                target_resource = self.configspace_ext.resource_attr_range[0]
-            self.configspace_ext.hp_ranges_ext.value_for_last_pos = target_resource
+                target_resource = self.config_space_ext.resource_attr_range[0]
+            self.config_space_ext.hp_ranges_ext.value_for_last_pos = target_resource
             if self.debug_log is not None:
                 self.debug_log.append_extra(
                     f"Score values computed at target_resource = {target_resource}")
 
     def _postprocess_config(self, config: dict) -> dict:
         # If `config` is normal (not extended), nothing is removed
-        return self.configspace_ext.remove_resource(config)
+        return self.config_space_ext.remove_resource(config)
 
     def evaluation_failed(self, trial_id: str):
         # Remove all pending evaluations for trial
@@ -301,7 +301,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
             model_factory=model_factory,
             init_state=init_state,
             skip_optimization=skip_optimization,
-            configspace_ext=self.configspace_ext,
+            config_space_ext=self.config_space_ext,
             resource_for_acquisition=self.resource_for_acquisition)
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -161,7 +161,7 @@ def _create_gp_standard_model(
 
 def _create_gp_additive_model(
         model: str, hp_ranges: HyperparameterRanges,
-        active_metric: Optional[str], random_seed: int, configspace_ext,
+        active_metric: Optional[str], random_seed: int, config_space_ext,
         **kwargs):
     result = _create_gp_common(hp_ranges, **kwargs)
     if model == 'gp_issm':
@@ -188,7 +188,7 @@ def _create_gp_additive_model(
         gpmodel=gpmodel,
         num_fantasy_samples=num_fantasy_samples,
         active_metric=active_metric,
-        configspace_ext=configspace_ext,
+        config_space_ext=config_space_ext,
         profiler=result['profiler'],
         debug_log=result['debug_log'],
         filter_observed_data=filter_observed_data,
@@ -255,7 +255,7 @@ def _create_common_objects(model=None, **kwargs):
     }
     if is_hyperband:
         epoch_range = (1, kwargs['max_epochs'])
-        result['configspace_ext'] = ExtendedConfiguration(
+        result['config_space_ext'] = ExtendedConfiguration(
             hp_ranges,
             resource_attr_key=kwargs['resource_attr'],
             resource_attr_range=epoch_range)
@@ -274,7 +274,7 @@ def _create_common_objects(model=None, **kwargs):
             hp_ranges=hp_ranges,
             active_metric=INTERNAL_METRIC_NAME,
             random_seed=random_seed,
-            configspace_ext=result['configspace_ext'],
+            config_space_ext=result['config_space_ext'],
             **_kwargs))
     result['num_initial_candidates'] = kwargs['num_init_candidates']
     result['num_initial_random_choices'] = kwargs['num_init_random']
@@ -292,7 +292,7 @@ def gp_fifo_searcher_factory(**kwargs) -> Dict:
 
     Extensions of kwargs by the scheduler:
     - scheduler: Name of scheduler ('fifo', 'hyperband_*')
-    - configspace: Configuration space
+    - config_space: Configuration space
     Only Hyperband schedulers:
     - resource_attr: Name of resource (or time) attribute
     - max_epochs: Maximum resource value

--- a/syne_tune/optimizer/schedulers/searchers/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde_searcher.py
@@ -85,7 +85,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
 
     def __init__(
             self,
-            configspace: Dict,
+            config_space: Dict,
             metric: str,
             points_to_evaluate: Optional[List[Dict]] = None,
             mode: str = "min",
@@ -98,7 +98,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
             **kwargs
     ):
         super().__init__(
-            configspace=configspace, metric=metric,
+            config_space=config_space, metric=metric,
             points_to_evaluate=points_to_evaluate, **kwargs)
         self.mode = mode
         self.num_evaluations = 0
@@ -111,7 +111,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
         self.y = []
         self.categorical_maps = {
             k: {cat: i for i, cat in enumerate(v.categories)}
-            for k, v in configspace.items()
+            for k, v in config_space.items()
             if isinstance(v, sp.Categorical)
         }
         self.inv_categorical_maps = {
@@ -123,7 +123,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
 
         self.vartypes = []
 
-        for name, hp in self.configspace.items():
+        for name, hp in self.config_space.items():
             if isinstance(hp, sp.Categorical):
                 self.vartypes.append(('u', len(hp.categories)))
             if isinstance(hp, sp.Integer):
@@ -159,7 +159,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
 
         return np.hstack([
             numerize(value=config[k], domain=v, categorical_map=self.categorical_maps.get(k, {}))
-            for k, v in self.configspace.items()
+            for k, v in self.config_space.items()
             if isinstance(v, sp.Domain)
         ])
 
@@ -181,7 +181,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
 
         res = {}
         curr_pos = 0
-        for k, domain in self.configspace.items():
+        for k, domain in self.config_space.items():
             if isinstance(domain, sp.Domain):
                 res[k] = domain.cast(
                     inv_numerize(
@@ -229,7 +229,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
             if models is None or self.random_state.rand() < self.random_fraction:
                 # return random candidate because a) we don't have enough data points or
                 # b) we sample some fraction of all samples randomly
-                suggestion = {k: v.sample() if isinstance(v, sp.Domain) else v for k, v in self.configspace.items()}
+                suggestion = {k: v.sample() if isinstance(v, sp.Domain) else v for k, v in self.config_space.items()}
             else:
                 self.bad_kde = models[0]
                 self.good_kde = models[1]

--- a/syne_tune/optimizer/schedulers/searchers/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde_searcher.py
@@ -17,7 +17,7 @@ import statsmodels.api as sm
 import scipy.stats as sps
 
 from syne_tune.optimizer.schedulers.searchers import SearcherWithRandomSeed
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log \
     import DebugLogPrinter
 

--- a/syne_tune/optimizer/schedulers/searchers/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/multi_fidelity_kde_searcher.py
@@ -74,7 +74,7 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
 
     def __init__(
             self,
-            configspace: Dict,
+            config_space: Dict,
             metric: str,
             points_to_evaluate: Optional[List[Dict]] = None,
             mode: str = "min",
@@ -87,7 +87,7 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
             resource_attr: str = 'epoch',
             **kwargs):
         super().__init__(
-            configspace,
+            config_space,
             metric=metric,
             points_to_evaluate=points_to_evaluate,
             mode=mode,

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, List
 from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers import SearcherWithRandomSeed
-from syne_tune.search_space import Domain, Categorical
+from syne_tune.config_space import Domain, Categorical
 
 
 @dataclass

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -17,7 +17,7 @@ class PopulationElement:
 class RegularizedEvolution(SearcherWithRandomSeed):
     def __init__(
             self,
-            configspace,
+            config_space,
             metric: str,
             mode: str = 'min',
             population_size: int = 100,
@@ -40,7 +40,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
 
         Parameters
         ----------
-        configspace: dict
+        config_space: dict
             Configuration space for trial evaluation function
         metric : str
             Name of metric to optimize, key in result's obtained via
@@ -55,7 +55,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
             Seed for the random number generation. If set to None, use random seed.
         """
 
-        super(RegularizedEvolution, self).__init__(configspace, metric, points_to_evaluate=points_to_evaluate, **kwargs)
+        super(RegularizedEvolution, self).__init__(config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs)
         self.mode = mode
         self.population_size = population_size
         self.sample_size = sample_size
@@ -67,11 +67,11 @@ class RegularizedEvolution(SearcherWithRandomSeed):
 
         # pick random hyperparameter and mutate it
         hypers = []
-        for k, v in self.configspace.items():
+        for k, v in self.config_space.items():
             if isinstance(v, Domain):
                 hypers.append(k)
         name = self.random_state.choice(hypers)
-        hyperparameter = self.configspace[name]
+        hyperparameter = self.config_space[name]
 
         if isinstance(hyperparameter, Categorical):
             # drop current values from potential choices to not sample the same value again
@@ -87,7 +87,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
     def sample_random_config(self) -> Dict:
         return {
           k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
-          for k, v in self.configspace.items()
+          for k, v in self.config_space.items()
         }
 
     def get_config(self, **kwargs):

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -32,9 +32,9 @@ __all__ = ['BaseSearcher',
 logger = logging.getLogger(__name__)
 
 
-def _impute_default_config(default_config, configspace):
+def _impute_default_config(default_config, config_space):
     new_config = dict()
-    for name, hp_range in configspace.items():
+    for name, hp_range in config_space.items():
         if isinstance(hp_range, Domain):
             if name not in default_config:
                 if isinstance(hp_range, Categorical):
@@ -74,13 +74,13 @@ def _to_tuple(config: Dict, keys: List) -> Tuple:
     return tuple(config[k] for k in keys)
 
 
-def _sorted_keys(configspace: Dict) -> List[str]:
-    return sorted(k for k, v in configspace.items() if isinstance(v, Domain))
+def _sorted_keys(config_space: Dict) -> List[str]:
+    return sorted(k for k, v in config_space.items() if isinstance(v, Domain))
 
 
 def impute_points_to_evaluate(
         points_to_evaluate: Optional[List[Dict]],
-        configspace: Dict) -> List[Dict]:
+        config_space: Dict) -> List[Dict]:
     """
     Transforms `points_to_evaluate` argument to `BaseSearcher`. Each config in
     the list can be partially specified, or even be an empty dict. For each
@@ -91,7 +91,7 @@ def impute_points_to_evaluate(
     configurations are specified.
 
     :param points_to_evaluate:
-    :param configspace:
+    :param config_space:
     :return: List of fully specified initial configs
     """
     if points_to_evaluate is None:
@@ -99,9 +99,9 @@ def impute_points_to_evaluate(
     # Impute and filter out duplicates
     result = []
     excl_set = set()
-    keys = _sorted_keys(configspace)
+    keys = _sorted_keys(config_space)
     for point in points_to_evaluate:
-        config = _impute_default_config(point, configspace)
+        config = _impute_default_config(point, config_space)
         config_tpl = _to_tuple(config, keys)
         if config_tpl not in excl_set:
             result.append(config)
@@ -114,7 +114,7 @@ class BaseSearcher(ABC):
 
     Parameters
     ----------
-    configspace : Dict
+    config_space : Dict
         The configuration space to sample from. It contains the full
         specification of the Hyperparameters with their priors
     metric : str
@@ -129,12 +129,12 @@ class BaseSearcher(ABC):
         configurations are specified.
     """
     def __init__(
-            self, configspace, metric, points_to_evaluate=None):
-        self.configspace = configspace
+            self, config_space, metric, points_to_evaluate=None):
+        self.config_space = config_space
         assert metric is not None, "Argument 'metric' is required"
         self._metric = metric
         self._points_to_evaluate = impute_points_to_evaluate(
-            points_to_evaluate, configspace)
+            points_to_evaluate, config_space)
 
     def configure_scheduler(self, scheduler):
         """
@@ -342,9 +342,9 @@ class SearcherWithRandomSeed(BaseSearcher):
 
     """
     def __init__(
-            self, configspace, metric, points_to_evaluate=None, **kwargs):
+            self, config_space, metric, points_to_evaluate=None, **kwargs):
         super().__init__(
-            configspace, metric=metric, points_to_evaluate=points_to_evaluate)
+            config_space, metric=metric, points_to_evaluate=points_to_evaluate)
         random_seed, _ = extract_random_seed(kwargs)
         self.random_state = np.random.RandomState(random_seed)
 
@@ -371,10 +371,10 @@ class RandomSearcher(SearcherWithRandomSeed):
     """
     MAX_RETRIES = 100
 
-    def __init__(self, configspace, metric, points_to_evaluate=None, **kwargs):
+    def __init__(self, config_space, metric, points_to_evaluate=None, **kwargs):
         super().__init__(
-            configspace, metric, points_to_evaluate, **kwargs)
-        self._hp_ranges = make_hyperparameter_ranges(configspace)
+            config_space, metric, points_to_evaluate, **kwargs)
+        self._hp_ranges = make_hyperparameter_ranges(config_space)
         self._resource_attr = kwargs.get('resource_attr')
         self._excl_list = ExclusionList.empty_list(self._hp_ranges)
         # Debug log printing (switched on by default)
@@ -460,7 +460,7 @@ class RandomSearcher(SearcherWithRandomSeed):
 
     def clone_from_state(self, state: dict):
         new_searcher = RandomSearcher(
-            self.configspace, metric=self._metric, debug_log=self._debug_log)
+            self.config_space, metric=self._metric, debug_log=self._debug_log)
         new_searcher._resource_attr = self._resource_attr
         new_searcher._restore_from_state(state)
         return new_searcher

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -15,7 +15,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, List, Tuple
 
-from syne_tune.search_space import Domain, is_log_space, Categorical
+from syne_tune.config_space import Domain, is_log_space, Categorical
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log \
     import DebugLogPrinter
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -28,7 +28,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
     'transfer_learning_active_task', 'transfer_learning_active_config_space'
     as optional fields in `kwargs`. If given, they determine
     `active_config_space` and `prefix_keys` of `hp_ranges` created here,
-    and they also places constraints on 'configspace'.
+    and they also places constraints on 'config_space'.
 
     This function is not only called in `gp_searcher_factory` to create
     `hp_ranges` for a new :class:`GPFIFOSearcher` object. It is also needed to
@@ -36,7 +36,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
 
     """
     task_attr = kwargs.get('transfer_learning_task_attr')
-    config_space = kwargs['configspace']
+    config_space = kwargs['config_space']
     prefix_keys = None
     active_config_space = None
     if task_attr is not None:

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -40,7 +40,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
     prefix_keys = None
     active_config_space = None
     if task_attr is not None:
-        from syne_tune.search_space import Categorical
+        from syne_tune.config_space import Categorical
 
         active_task = kwargs.get('transfer_learning_active_task')
         assert active_task is not None, \

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -163,7 +163,7 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
         else:
             search_options = search_options.copy()
         search_options.update({
-            'configspace': self.config_space.copy(),
+            'config_space': self.config_space.copy(),
             'metric': self.metric,
             'points_to_evaluate': kwargs.get('points_to_evaluate'),
             'scheduler_mode': kwargs['mode'],

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -24,7 +24,7 @@ from syne_tune.optimizer.scheduler import TrialSuggestion, \
     SchedulerDecision
 from syne_tune.optimizer.schedulers.fifo import ResourceLevelsScheduler
 from syne_tune.backend.trial_status import Trial
-from syne_tune.search_space import cast_config_values
+from syne_tune.config_space import cast_config_values
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments \
     import check_and_merge_defaults, Categorical, String, \
     assert_no_invalid_options, Integer

--- a/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
@@ -3,10 +3,10 @@ from typing import Dict, Callable, Optional
 
 import pandas as pd
 
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 from syne_tune.optimizer.scheduler import TrialScheduler
 from syne_tune.optimizer.schedulers.transfer_learning import TransferLearningMixin, TransferLearningTaskEvaluations
-from syne_tune.search_space import Categorical
+from syne_tune.config_space import Categorical
 
 
 class BoundingBox(TransferLearningMixin, TrialScheduler):
@@ -54,7 +54,7 @@ class BoundingBox(TransferLearningMixin, TrialScheduler):
             metric=metric
         )
         print(f"hyperparameter ranges of best previous configurations {config_space}")
-        print(f"({sp.search_space_size(config_space)} options)")
+        print(f"({sp.config_space_size(config_space)} options)")
         self.scheduler = scheduler_fun(config_space, mode, metric)
 
     def compute_box(self,

--- a/syne_tune/search_space.py
+++ b/syne_tune/search_space.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This file has been taken from Ray. The reason for reusing the file is to be able to support the same API when
+# defining search space while avoiding to have Ray as a required dependency. We may want to add functionality in the
+# future.
+
+# ========================================================
+# DEPRECATED:
+# `search_space` is deprecated, use `config_space` instead
+# ========================================================
+
+import logging
+from typing import Dict, List
+import argparse
+
+from syne_tune.config_space import uniform as _uniform, \
+    loguniform as _loguniform, choice as _choice, \
+    randint as _randint, lograndint as _lograndint, \
+    finrange as _finrange, logfinrange as _logfinrange, \
+    add_to_argparse as _add_to_argparse
+
+logger = logging.getLogger(__name__)
+
+
+def _deprecated_warning(name: str):
+    logger.warning(
+        f"\n*****\n***** syne_tune.search_space.{name} is deprecated, use "
+        f"syne_tune.config_space.{name} instead!\n*****")
+
+
+def uniform(lower: float, upper: float):
+    _deprecated_warning('uniform')
+    return _uniform(lower, upper)
+
+
+def loguniform(lower: float, upper: float):
+    _deprecated_warning('loguniform')
+    return _loguniform(lower, upper)
+
+
+def choice(categories: List):
+    _deprecated_warning('choice')
+    return _choice(categories)
+
+
+def randint(lower: int, upper: int):
+    _deprecated_warning('randint')
+    return _randint(lower, upper)
+
+
+def lograndint(lower: int, upper: int):
+    _deprecated_warning('lograndint')
+    return _lograndint(lower, upper)
+
+
+def finrange(lower: float, upper: float, size: int, cast_int: bool = False):
+    _deprecated_warning('finrange')
+    return _finrange(lower, upper, size, cast_int=cast_int)
+
+
+def logfinrange(lower: float, upper: float, size: int, cast_int: bool = False):
+    _deprecated_warning('logfinrange')
+    return _logfinrange(lower, upper, size, cast_int=cast_int)
+
+
+def add_to_argparse(parser: argparse.ArgumentParser, config_space: Dict):
+    _deprecated_warning('add_to_argparse')
+    return _add_to_argparse(parser, config_space)

--- a/syne_tune/search_space.py
+++ b/syne_tune/search_space.py
@@ -36,7 +36,8 @@ logger = logging.getLogger(__name__)
 def _deprecated_warning(name: str):
     logger.warning(
         f"\n*****\n***** syne_tune.search_space.{name} is deprecated, use "
-        f"syne_tune.config_space.{name} instead!\n*****")
+        f"syne_tune.config_space.{name} instead!\n"
+        "***** syne_tune.search_space will be removed in the next release\n*****")
 
 
 def uniform(lower: float, upper: float):

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -142,7 +142,7 @@ class Tuner:
             # state
             running_trials_ids = set()
 
-            search_space_exhausted = False
+            config_space_exhausted = False
 
             while not self._stop_condition():
                 for callback in self.callbacks:
@@ -169,11 +169,11 @@ class Tuner:
                 done_trials_statuses.update(new_done_trial_statuses)
                 running_trials_ids.difference_update(new_done_trial_statuses.keys())
 
-                if search_space_exhausted:
+                if config_space_exhausted:
                     # if the search space is exhausted, we loop until the running trials are done or until the
                     # stop condition is reached
                     if len(running_trials_ids) > 0:
-                        logger.debug(f"Search space exhausted, waiting for completion of running trials "
+                        logger.debug(f"Configuration space exhausted, waiting for completion of running trials "
                                      f"{running_trials_ids}")
                         self._sleep()
                     else:
@@ -182,9 +182,9 @@ class Tuner:
                     try:
                         self._schedule_new_tasks(running_trials_ids=running_trials_ids)
                     except StopIteration:
-                        logger.info("Tuning is finishing as the whole search space got exhausted.")
-                        search_space_exhausted = True
-                        print("Tuning is finishing as the whole search space got exhausted.")
+                        logger.info("Tuning is finishing as the whole configuration space got exhausted.")
+                        config_space_exhausted = True
+                        print("Tuning is finishing as the whole configuration space got exhausted.")
 
                 self.status_printer(self.tuning_status)
 

--- a/tst/blackbox_repository/test_blackbox.py
+++ b/tst/blackbox_repository/test_blackbox.py
@@ -3,7 +3,7 @@ import tempfile
 import numpy as np
 import pandas as pd
 
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 from benchmarking.blackbox_repository import BlackboxOffline
 from benchmarking.blackbox_repository.blackbox import from_function

--- a/tst/blackbox_repository/test_surrogate.py
+++ b/tst/blackbox_repository/test_surrogate.py
@@ -9,7 +9,7 @@ from benchmarking.blackbox_repository import BlackboxOffline
 from benchmarking.blackbox_repository.blackbox_surrogate import add_surrogate
 from benchmarking.blackbox_repository.blackbox_tabular import BlackboxTabular
 
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 
 
 np.random.seed(0)

--- a/tst/schedulers/bayesopt/gpautograd/test_kernel.py
+++ b/tst/schedulers/bayesopt/gpautograd/test_kernel.py
@@ -25,7 +25,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants \
     import DATA_TYPE
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.gluon_blocks_helpers \
     import LogarithmScalarEncoding, PositiveScalarEncoding
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.config_ext \

--- a/tst/schedulers/bayesopt/test_bayesopt_cei.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_cei.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import \
     INTERNAL_METRIC_NAME, INTERNAL_CONSTRAINT_NAME
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import \
     DEFAULT_MCMC_CONFIG, DEFAULT_OPTIMIZATION_CONFIG
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl import \

--- a/tst/schedulers/bayesopt/test_bayesopt_ei.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_ei.py
@@ -17,7 +17,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import \
     dictionarize_objective, INTERNAL_METRIC_NAME
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import \
     DEFAULT_MCMC_CONFIG, DEFAULT_OPTIMIZATION_CONFIG
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl \

--- a/tst/schedulers/bayesopt/test_bayesopt_eipu.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_eipu.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import \
     dictionarize_objective, INTERNAL_METRIC_NAME
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import \
     DEFAULT_MCMC_CONFIG, DEFAULT_OPTIMIZATION_CONFIG
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl import \

--- a/tst/schedulers/bayesopt/test_bo_algorithm_components.py
+++ b/tst/schedulers/bayesopt/test_bo_algorithm_components.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import \
     dictionarize_objective
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import \
     TuningJobState
-from syne_tune.search_space import uniform, choice, randint
+from syne_tune.config_space import uniform, choice, randint
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import create_tuning_job_state
 

--- a/tst/schedulers/bayesopt/test_bo_algorithm_functions.py
+++ b/tst/schedulers/bayesopt/test_bo_algorithm_functions.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.duplicate_detector 
     import DuplicateDetectorIdentical
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import uniform, randint, choice
+from syne_tune.config_space import uniform, randint, choice
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import tuples_to_configs, create_exclusion_set
 

--- a/tst/schedulers/bayesopt/test_checkpointing.py
+++ b/tst/schedulers/bayesopt/test_checkpointing.py
@@ -36,7 +36,7 @@ def test_pickle_gp_fifo_searcher():
     num_pending = 2
     data = sample_data(Ackley, num_train=num_data + num_pending, num_grid=5)
     # Create searcher1 using default arguments
-    searcher_options['configspace'] = data['state'].hp_ranges.config_space
+    searcher_options['config_space'] = data['state'].hp_ranges.config_space
     searcher_options['scheduler'] = 'fifo'
     searcher_options['random_seed'] = random_seed
     reward_attr = 'accuracy'
@@ -98,7 +98,7 @@ def test_pickle_constrained_gp_fifo_searcher():
     num_pending = 2
     data = sample_data(Ackley, num_train=num_data + num_pending, num_grid=5)
     # Create searcher1 using default arguments
-    searcher_options['configspace'] = data['state'].hp_ranges.config_space
+    searcher_options['config_space'] = data['state'].hp_ranges.config_space
     searcher_options['scheduler'] = 'fifo'
     searcher_options['random_seed'] = random_seed
     reward_attr = 'accuracy'
@@ -165,7 +165,7 @@ def test_pickle_cost_aware_gp_fifo_searcher():
     num_pending = 2
     data = sample_data(Ackley, num_train=num_data + num_pending, num_grid=5)
     # Create searcher1 using default arguments
-    searcher_options['configspace'] = data['state'].hp_ranges.config_space
+    searcher_options['config_space'] = data['state'].hp_ranges.config_space
     searcher_options['scheduler'] = 'fifo'
     searcher_options['random_seed'] = random_seed
     reward_attr = 'accuracy'

--- a/tst/schedulers/bayesopt/test_common.py
+++ b/tst/schedulers/bayesopt/test_common.py
@@ -23,7 +23,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import RepeatedCandidateGenerator
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import randint, choice
+from syne_tune.config_space import randint, choice
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import create_tuning_job_state, create_exclusion_set
 

--- a/tst/schedulers/bayesopt/test_duplicate_detector.py
+++ b/tst/schedulers/bayesopt/test_duplicate_detector.py
@@ -16,7 +16,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.duplicate_detector 
     import DuplicateDetectorIdentical, DuplicateDetectorNoDetection
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
-from syne_tune.search_space import uniform, randint, choice
+from syne_tune.config_space import uniform, randint, choice
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import create_exclusion_set
 

--- a/tst/schedulers/bayesopt/test_expdecay_model.py
+++ b/tst/schedulers/bayesopt/test_expdecay_model.py
@@ -21,7 +21,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.default_arguments \
     import check_and_merge_defaults
 from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import \
     decode_state_from_old_encoding
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state \
     import TuningJobState
 

--- a/tst/schedulers/bayesopt/test_expdecay_model.py
+++ b/tst/schedulers/bayesopt/test_expdecay_model.py
@@ -26,10 +26,10 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
     import TuningJobState
 
 
-def _common_kwargs(configspace: Dict) -> Dict:
+def _common_kwargs(config_space: Dict) -> Dict:
     return {
-        'configspace': configspace,
-        'max_epochs': configspace['epochs'],
+        'config_space': config_space,
+        'max_epochs': config_space['epochs'],
         'metric': 'accuracy',
         'resource_attr': 'epoch',
         'scheduler': 'hyperband_stopping',
@@ -39,9 +39,9 @@ def _common_kwargs(configspace: Dict) -> Dict:
     }
 
 
-def build_gp_model_factory(configspace: Dict, model_params: Dict) -> Dict:
+def build_gp_model_factory(config_space: Dict, model_params: Dict) -> Dict:
     kwargs = dict(
-        _common_kwargs(configspace),
+        _common_kwargs(config_space),
         model='gp_multitask',
         gp_resource_kernel='freeze-thaw')
     _kwargs = check_and_merge_defaults(
@@ -76,9 +76,9 @@ def _convert_model_params(model_params: Dict) -> Dict:
 
 
 def build_gped_model_factory(
-        configspace: Dict, model_params: Dict, **kwargs):
+        config_space: Dict, model_params: Dict, **kwargs):
     kwargs = dict(
-        _common_kwargs(configspace),
+        _common_kwargs(config_space),
         model='gp_expdecay',
         expdecay_normalize_inputs=True,
         **kwargs)
@@ -176,13 +176,13 @@ def test_compare_gp_model_gped_model(_model_params, _state):
 
     model_params = json.loads(_model_params)
     gp_objs = build_gp_model_factory(config_space, model_params)
-    configspace_ext = gp_objs['configspace_ext']
+    config_space_ext = gp_objs['config_space_ext']
     gp_model_factory = gp_objs['model_factory']
     gped_model_factory = build_gped_model_factory(
         config_space, model_params)['model_factory']
 
     state = decode_state_from_old_encoding(
-        enc_state=json.loads(_state), hp_ranges=configspace_ext.hp_ranges_ext)
+        enc_state=json.loads(_state), hp_ranges=config_space_ext.hp_ranges_ext)
     if state.pending_evaluations:
         # Remove pending evaluations
         state = TuningJobState(
@@ -218,13 +218,13 @@ def test_compare_gped_likelihood_oldnew(_model_params, _state):
     kwargs = dict(no_fantasizing=True)
     gped_objs = build_gped_model_factory(
         config_space, model_params, **kwargs)
-    configspace_ext = gped_objs['configspace_ext']
+    config_space_ext = gped_objs['config_space_ext']
     gped_model_factory.append(gped_objs['model_factory'])
     gped_model_factory.append(build_gped_model_factory(
         config_space, model_params, use_new_code=False,
         **kwargs)['model_factory'])
     state = decode_state_from_old_encoding(
-        enc_state=json.loads(_state), hp_ranges=configspace_ext.hp_ranges_ext)
+        enc_state=json.loads(_state), hp_ranges=config_space_ext.hp_ranges_ext)
 
     # Compare likelihoods
     likelihood = [
@@ -259,13 +259,13 @@ def test_compare_gped_likelihood_fantasizing_oldnew(_model_params, _state):
         no_fantasizing=False)
     gped_objs = build_gped_model_factory(
         config_space, model_params, **kwargs)
-    configspace_ext = gped_objs['configspace_ext']
+    config_space_ext = gped_objs['config_space_ext']
     gped_model_factory.append(gped_objs['model_factory'])
     gped_model_factory.append(build_gped_model_factory(
         config_space, model_params, use_new_code=False,
         **kwargs)['model_factory'])
     state = decode_state_from_old_encoding(
-        enc_state=json.loads(_state), hp_ranges=configspace_ext.hp_ranges_ext)
+        enc_state=json.loads(_state), hp_ranges=config_space_ext.hp_ranges_ext)
 
     # Compare likelihoods
     # We need to force them to use the same fantasy samples

--- a/tst/schedulers/bayesopt/test_gaussproc.py
+++ b/tst/schedulers/bayesopt/test_gaussproc.py
@@ -30,7 +30,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_im
     import EIAcquisitionFunction
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import default_gpmodel, default_gpmodel_mcmc
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import create_tuning_job_state, tuples_to_configs
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \

--- a/tst/schedulers/bayesopt/test_get_set_params.py
+++ b/tst/schedulers/bayesopt/test_get_set_params.py
@@ -27,7 +27,7 @@ def test_params_gp_multifidelity():
     searcher_options['gp_resource_kernel'] = 'exp-decay-combined'
     # Note: We are lazy here, we just need the config_space
     data = sample_data(Ackley, num_train=5, num_grid=5)
-    searcher_options['configspace'] = data['state'].hp_ranges.config_space
+    searcher_options['config_space'] = data['state'].hp_ranges.config_space
     searcher_options['scheduler'] = 'hyperband_stopping'
     searcher_options['min_epochs'] = 1
     searcher_options['max_epochs'] = 27

--- a/tst/schedulers/bayesopt/test_gp_components.py
+++ b/tst/schedulers/bayesopt/test_gp_components.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import d
     INTERNAL_METRIC_NAME
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects \
     import dimensionality_and_warping_ranges, create_tuning_job_state
-from syne_tune.search_space import uniform, randint, choice, loguniform
+from syne_tune.config_space import uniform, randint, choice, loguniform
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges
 

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -202,10 +202,10 @@ def test_get_ndarray_bounds():
         '5': choice(['a', 'b', 'c'])}
     hp_ranges = make_hyperparameter_ranges(config_space)
     for epochs, val_last_pos in ((3, 1), (9, 3), (81, 81), (27, 1), (27, 9)):
-        configspace_ext = ExtendedConfiguration(
+        config_space_ext = ExtendedConfiguration(
             hp_ranges=hp_ranges, resource_attr_key='epoch',
             resource_attr_range=(1, epochs))
-        hp_ranges_ext = configspace_ext.hp_ranges_ext
+        hp_ranges_ext = config_space_ext.hp_ranges_ext
         hp_ranges_ext.value_for_last_pos = val_last_pos
         bounds = hp_ranges_ext.get_ndarray_bounds()
         val_enc = _int_encode(val_last_pos, lower=1, upper=epochs)

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -17,7 +17,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
 from pytest import approx
 
-from syne_tune.search_space import uniform, randint, choice, loguniform, \
+from syne_tune.config_space import uniform, randint, choice, loguniform, \
     lograndint, finrange, logfinrange
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory \
     import make_hyperparameter_ranges

--- a/tst/schedulers/bayesopt/test_iss_model.py
+++ b/tst/schedulers/bayesopt/test_iss_model.py
@@ -21,7 +21,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.default_arguments \
     import check_and_merge_defaults
 from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import \
     decode_state_from_old_encoding
-from syne_tune.search_space import randint, uniform, loguniform
+from syne_tune.config_space import randint, uniform, loguniform
 
 
 def _common_kwargs(config_space: Dict) -> Dict:

--- a/tst/schedulers/bayesopt/test_iss_model.py
+++ b/tst/schedulers/bayesopt/test_iss_model.py
@@ -24,10 +24,10 @@ from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import \
 from syne_tune.search_space import randint, uniform, loguniform
 
 
-def _common_kwargs(configspace: Dict) -> Dict:
+def _common_kwargs(config_space: Dict) -> Dict:
     return {
-        'configspace': configspace,
-        'max_epochs': configspace['epochs'],
+        'config_space': config_space,
+        'max_epochs': config_space['epochs'],
         'metric': 'accuracy',
         'resource_attr': 'epoch',
         'scheduler': 'hyperband_stopping',
@@ -38,9 +38,9 @@ def _common_kwargs(configspace: Dict) -> Dict:
 
 
 def build_gpiss_model_factory(
-        configspace: Dict, model_params: Dict, **kwargs):
+        config_space: Dict, model_params: Dict, **kwargs):
     kwargs = dict(
-        _common_kwargs(configspace),
+        _common_kwargs(config_space),
         model='gp_issm',
         issm_gamma_one=False,
         **kwargs)
@@ -141,13 +141,13 @@ def test_compare_gpiss_likelihood_oldnew(_model_params, _state):
     kwargs = dict(no_fantasizing=True)
     gpiss_objs = build_gpiss_model_factory(
         config_space, model_params, **kwargs)
-    configspace_ext = gpiss_objs['configspace_ext']
+    config_space_ext = gpiss_objs['config_space_ext']
     gpiss_model_factory.append(gpiss_objs['model_factory'])
     gpiss_model_factory.append(build_gpiss_model_factory(
         config_space, model_params, use_new_code=False,
         **kwargs)['model_factory'])
     state = decode_state_from_old_encoding(
-        enc_state=json.loads(_state), hp_ranges=configspace_ext.hp_ranges_ext)
+        enc_state=json.loads(_state), hp_ranges=config_space_ext.hp_ranges_ext)
 
     # Compare likelihoods
     likelihood = [
@@ -182,13 +182,13 @@ def test_compare_gpiss_likelihood_fantasizing_oldnew(_model_params, _state):
         no_fantasizing=False)
     gpiss_objs = build_gpiss_model_factory(
         config_space, model_params, **kwargs)
-    configspace_ext = gpiss_objs['configspace_ext']
+    config_space_ext = gpiss_objs['config_space_ext']
     gpiss_model_factory.append(gpiss_objs['model_factory'])
     gpiss_model_factory.append(build_gpiss_model_factory(
         config_space, model_params, use_new_code=False,
         **kwargs)['model_factory'])
     state = decode_state_from_old_encoding(
-        enc_state=json.loads(_state), hp_ranges=configspace_ext.hp_ranges_ext)
+        enc_state=json.loads(_state), hp_ranges=config_space_ext.hp_ranges_ext)
 
     # Compare likelihoods
     # We need to force them to use the same fantasy samples

--- a/tst/schedulers/bayesopt/test_transferlearning.py
+++ b/tst/schedulers/bayesopt/test_transferlearning.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 import numpy as np
 
-from syne_tune.search_space import uniform, randint, choice
+from syne_tune.config_space import uniform, randint, choice
 from syne_tune.optimizer.schedulers.searchers.gp_searcher_factory import \
     gp_fifo_searcher_defaults, gp_fifo_searcher_factory
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments \

--- a/tst/schedulers/bayesopt/test_transferlearning.py
+++ b/tst/schedulers/bayesopt/test_transferlearning.py
@@ -35,7 +35,7 @@ def test_create_transfer_learning():
     }
     search_options = {
         'scheduler': 'fifo',
-        'configspace': config_space,
+        'config_space': config_space,
         'transfer_learning_task_attr': 'task_id',
         'transfer_learning_active_task': '2',
         'transfer_learning_active_config_space': active_config_space,

--- a/tst/schedulers/test_hyperband.py
+++ b/tst/schedulers/test_hyperband.py
@@ -33,9 +33,9 @@ def _new_trial(trial_id: int, config: dict):
 
 
 class MyRandomSearcher(RandomSearcher):
-    def __init__(self, configspace, metric, points_to_evaluate=None, **kwargs):
+    def __init__(self, config_space, metric, points_to_evaluate=None, **kwargs):
         super().__init__(
-            configspace, metric, points_to_evaluate, **kwargs)
+            config_space, metric, points_to_evaluate, **kwargs)
         self._pending_records = []
 
     def register_pending(
@@ -79,7 +79,7 @@ def test_register_pending():
             searcher_data=searcher_data)
         old_searcher = scheduler.searcher
         new_searcher = MyRandomSearcher(
-            old_searcher.configspace,
+            old_searcher.config_space,
             metric=old_searcher._metric)
         new_searcher._resource_attr = scheduler._resource_attr
         scheduler.searcher = new_searcher
@@ -185,10 +185,10 @@ def test_hyperband_max_t_inference():
         (10, config_space7, 10),
     ]
 
-    for max_t, configspace, final_max_t in cases:
+    for max_t, config_space, final_max_t in cases:
         if final_max_t is not None:
             myscheduler = HyperbandScheduler(
-                configspace,
+                config_space,
                 searcher='random',
                 max_t=max_t,
                 resource_attr='epoch',
@@ -198,7 +198,7 @@ def test_hyperband_max_t_inference():
         else:
             with pytest.raises(AssertionError):
                 myscheduler = HyperbandScheduler(
-                    configspace,
+                    config_space,
                     searcher='random',
                     max_t=max_t,
                     resource_attr='epoch',

--- a/tst/schedulers/test_hyperband.py
+++ b/tst/schedulers/test_hyperband.py
@@ -15,7 +15,7 @@ from typing import Optional, Dict, Tuple
 import pytest
 
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-from syne_tune.search_space import randint, uniform
+from syne_tune.config_space import randint, uniform
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import SchedulerDecision
 from syne_tune.optimizer.schedulers.searchers.searcher import RandomSearcher
@@ -166,7 +166,7 @@ def test_hyperband_max_t_inference():
         'max_epochs': randint(13, 22),
         'blurb': randint(0, 20)
     }
-    # Fields: (max_t, search_space, final_max_t)
+    # Fields: (max_t, config_space, final_max_t)
     # If final_max_t is None, an assertion should be raised
     cases = [
         (None, config_space1, 15),

--- a/tst/schedulers/test_hyperband_cost_promotion.py
+++ b/tst/schedulers/test_hyperband_cost_promotion.py
@@ -13,7 +13,7 @@
 from datetime import datetime
 
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-from syne_tune.search_space import randint, uniform
+from syne_tune.config_space import randint, uniform
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import SchedulerDecision
 

--- a/tst/schedulers/test_random_searcher.py
+++ b/tst/schedulers/test_random_searcher.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 from syne_tune.optimizer.schedulers.searchers.searcher import \
     RandomSearcher
-from syne_tune.search_space import choice, randint
+from syne_tune.config_space import choice, randint
 
 
 def test_no_duplicates():

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -155,7 +155,7 @@ def test_async_schedulers_api(scheduler):
     for i in trial_ids:
         suggestion = scheduler.suggest(i)
         assert all(x in suggestion.config.keys() for x in config_space.keys()), \
-            "suggestion configuration should contain all keys of configspace."
+            "suggestion configuration should contain all keys of config_space."
         trials.append(Trial(trial_id=i, config=suggestion.config, creation_time=None))
 
     for trial in trials:

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -19,7 +19,7 @@ from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune.optimizer.schedulers.multiobjective.moasha import MOASHA
 from syne_tune.optimizer.schedulers.pbt import PopulationBasedTraining
 from syne_tune.optimizer.schedulers.ray_scheduler import RayTuneScheduler
-import syne_tune.search_space as sp
+import syne_tune.config_space as sp
 from syne_tune.optimizer.schedulers.transfer_learning import TransferLearningTaskEvaluations
 from syne_tune.optimizer.schedulers.transfer_learning.bounding_box import BoundingBox
 from syne_tune.optimizer.schedulers.transfer_learning.rush import RUSHScheduler

--- a/tst/schedulers/transfer_learning/test_rush.py
+++ b/tst/schedulers/transfer_learning/test_rush.py
@@ -18,7 +18,7 @@ from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.schedulers.hyperband_rush import RUSHStoppingRungSystem, RUSHDecider
 from syne_tune.optimizer.schedulers.transfer_learning import TransferLearningTaskEvaluations
 from syne_tune.optimizer.schedulers.transfer_learning.rush import RUSHScheduler
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 
 
 @pytest.fixture()

--- a/tst/test_benchmark.py
+++ b/tst/test_benchmark.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 import argparse
 
-from syne_tune.search_space import add_to_argparse, randint, uniform, \
+from syne_tune.config_space import add_to_argparse, randint, uniform, \
     loguniform
 
 

--- a/tst/test_bore.py
+++ b/tst/test_bore.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.schedulers.searchers.bore.bore import Bore
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 
 max_steps = 10
 

--- a/tst/test_config_space.py
+++ b/tst/test_config_space.py
@@ -13,8 +13,8 @@
 import pytest
 import numpy as np
 
-from syne_tune.search_space import randint, lograndint, uniform, \
-    loguniform, choice, search_space_size, randn, to_dict, from_dict, \
+from syne_tune.config_space import randint, lograndint, uniform, \
+    loguniform, choice, config_space_size, randn, to_dict, from_dict, \
     finrange, logfinrange
 
 
@@ -89,7 +89,7 @@ def test_serialization():
                 == {k: v for k, v in x2.__dict__.items() if k != "sampler"}
 
 
-def test_search_space_size():
+def test_config_space_size():
     upper_limit = 2 ** 20
     config_space = {
         'a': randint(1, 6),
@@ -109,9 +109,9 @@ def test_search_space_size():
         (dict(config_space, f=lograndint(1, upper_limit / 10)), None),
     ]
     for cs, size in cases:
-        _size = search_space_size(cs)
+        _size = config_space_size(cs)
         assert _size == size, \
-            f"search_space_size(cs) = {_size} != {size}\n{cs}"
+            f"config_space_size(cs) = {_size} != {size}\n{cs}"
 
 
 @pytest.mark.parametrize('domain,value_set', [

--- a/tst/test_constrained_bo.py
+++ b/tst/test_constrained_bo.py
@@ -16,7 +16,7 @@ import pytest
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune import StoppingCriterion
 
 

--- a/tst/test_cost_aware_bo.py
+++ b/tst/test_cost_aware_bo.py
@@ -16,7 +16,7 @@ import pytest
 from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner
-from syne_tune.search_space import uniform
+from syne_tune.config_space import uniform
 from syne_tune import StoppingCriterion
 
 

--- a/tst/test_moasha.py
+++ b/tst/test_moasha.py
@@ -21,7 +21,7 @@ from syne_tune.optimizer.scheduler import SchedulerDecision
 from syne_tune.optimizer.schedulers.multiobjective.moasha import MOASHA, _Bracket
 from syne_tune.optimizer.schedulers.multiobjective.multiobjective_priority import FixedObjectivePriority, \
     LinearScalarizationPriority, NonDominatedPriority
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 
 
 def test_bucket():

--- a/tst/test_pbt.py
+++ b/tst/test_pbt.py
@@ -13,7 +13,7 @@
 from datetime import datetime
 
 from syne_tune.backend.trial_status import Trial
-from syne_tune.search_space import loguniform
+from syne_tune.config_space import loguniform
 from syne_tune.optimizer.schedulers.pbt import PopulationBasedTraining
 
 max_steps = 10

--- a/tst/test_pointstoevaluate.py
+++ b/tst/test_pointstoevaluate.py
@@ -13,7 +13,7 @@
 from typing import Dict
 import numpy as np
 
-from syne_tune.search_space import randint, lograndint, uniform, \
+from syne_tune.config_space import randint, lograndint, uniform, \
     loguniform, choice, finrange, logfinrange
 from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune.optimizer.schedulers.searchers import RandomSearcher

--- a/tst/test_random_seed.py
+++ b/tst/test_random_seed.py
@@ -20,7 +20,7 @@ from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 from syne_tune import Tuner
 from syne_tune.tuner_callback import TunerCallback
 from syne_tune.backend.trial_status import Trial
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune.util import script_height_example_path
 from tst.util_test import temporary_local_backend
 

--- a/tst/test_schedulers.py
+++ b/tst/test_schedulers.py
@@ -19,7 +19,7 @@ from syne_tune.optimizer.schedulers.synchronous.hyperband_impl import \
     SynchronousGeometricHyperbandScheduler
 from syne_tune import Tuner
 from syne_tune import StoppingCriterion
-from syne_tune.search_space import randint
+from syne_tune.config_space import randint
 from syne_tune.util import script_checkpoint_example_path
 from tst.util_test import temporary_local_backend
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Maps 'configspace' to 'config_space', and 'search_space' to 'config_space'.
The latter is a breaking API change, so I kept search_space common functions in, which log warnings and call config_space functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
