### PR TITLE
Bugfix

### DIFF
--- a/benchmarking/cli/launch_hpo.py
+++ b/benchmarking/cli/launch_hpo.py
@@ -275,7 +275,7 @@ if __name__ == '__main__':
                 backend_kwargs['entry_point'] = benchmark['script']
                 trial_backend = SimulatorBackend(**backend_kwargs)
             else:
-                from benchmarking.blackbox_repository.tabulated_benchmark import BlackboxRepositoryBackend
+                from benchmarking.blackbox_repository.simulated_tabular_backend import BlackboxRepositoryBackend
 
                 # Tabulated benchmark from the blackbox repository (simulation
                 # runs faster)

--- a/benchmarking/definitions/definition_nashpobench.py
+++ b/benchmarking/definitions/definition_nashpobench.py
@@ -67,5 +67,4 @@ def nashpobench_benchmark(params):
         'cost_model': None,
         'supports_simulated': True,
         'blackbox_name': BLACKBOX_NAME,
-        'time_this_resource_attr': METRIC_ELAPSED_TIME,
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes a bad problem in benchmarking/definitions/definition_nashpobench.py, which will have (silently!) affect experiments run using these definitions.
Namely, nashpobench directly emits elapsed_time (cumulative time until epoch r). But in the definition, BOTH elapsed_time_attr and time_this_resource_attr were set to the same value. time_this_resource_attr MUST NOT be used when the benchmark directly emits elapsed_time.

What happened here:
- elapsed_time in the benchmark (cumulative) was taken as time_this_resource by the simulator backend
- this was cumulated again, so the elapsed_time being used are DOUBLY cumulated, and therefore much too large
- experiments stop after very few evaluations

The fix is just to remove time_this_resource_attr in the definition.

This is an nasty source of error, and David already suggested to remove it by requiring all tabulated benchmarks to emit elapsed_time. For nashpobench, this is already the case, but we'd have to change the importer for nasbench201.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
