### PR TITLE
Fix upper bound of benchmark

### DIFF
--- a/benchmarking/blackbox_repository/conversion_scripts/scripts/lcbench/lcbench.py
+++ b/benchmarking/blackbox_repository/conversion_scripts/scripts/lcbench/lcbench.py
@@ -24,7 +24,7 @@ def convert_task(bench, dataset_name):
 
     configuration_space = {
         "num_layers": sp.randint(1, 5),
-        "max_units": sp.lograndint(64, 512),
+        "max_units": sp.lograndint(64, 1024),
         "batch_size": sp.lograndint(16, 512),
         "learning_rate": sp.loguniform(1e-4, 1e-1),
         "weight_decay": sp.uniform(1e-5, 1e-1),


### PR DESCRIPTION
Upper bound of max units is 1024 (see: https://github.com/automl/LCBench)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
