### PR TITLE
Treat binary categorical as a special case (reduces encoding dimension)

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/test_objects.py
@@ -104,7 +104,11 @@ def dimensionality_and_warping_ranges(hp_ranges: HyperparameterRanges) -> \
                 assert _lower == _upper
             dims += 1
         else:
-            dims += len(hp_range.categories)
+            # For binary, we use a single dimension, not 2
+            sz = len(hp_range.categories)
+            if sz == 2:
+                sz = 1
+            dims += sz
     return dims, warping_ranges
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -96,7 +96,7 @@ class Bore(SearcherWithRandomSeed):
         elif self.classifier == 'gp':
             self.model = GPModel(**classifier_kwargs)
         elif self.classifier == 'mlp':
-            self.model = MLP(n_inputs=self._hp_ranges.ndarray_size(), **classifier_kwargs)
+            self.model = MLP(n_inputs=self._hp_ranges.ndarray_size, **classifier_kwargs)
 
         self.inputs = []
         self.targets = []

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -93,7 +93,7 @@ def _create_base_gp_kernel(
         # Transfer learning: Specific base kernel
         kernel = create_base_gp_kernel_for_warmstarting(hp_ranges, **kwargs)
     else:
-        kernel = Matern52(dimension=hp_ranges.ndarray_size(), ARD=True)
+        kernel = Matern52(dimension=hp_ranges.ndarray_size, ARD=True)
     return kernel
 
 

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_utils.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_utils.py
@@ -224,7 +224,7 @@ def resource_for_acquisition_factory(
         str(SUPPORTED_RESOURCE_FOR_ACQUISITION)
     if resource_acq == 'bohb':
         threshold = kwargs.get(
-            'resource_acq_bohb_threshold', hp_ranges.ndarray_size())
+            'resource_acq_bohb_threshold', hp_ranges.ndarray_size)
         resource_for_acquisition = ResourceForAcquisitionBOHB(
             threshold=threshold)
     elif resource_acq == 'first':

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -103,7 +103,7 @@ def create_base_gp_kernel_for_warmstarting(
     # `create_hp_ranges_for_warmstarting`
     assert hp_ranges.internal_keys[0] == task_attr  # Sanity check
     categ_dim = len(hp_range)
-    full_dim = hp_ranges.ndarray_size()
+    full_dim = hp_ranges.ndarray_size
     model = kwargs.get('transfer_learning_model', 'matern52_product')
     kernel2 = Matern52(full_dim - categ_dim, ARD=True)
     if model == 'matern52_product':

--- a/tst/schedulers/bayesopt/test_gaussproc.py
+++ b/tst/schedulers/bayesopt/test_gaussproc.py
@@ -194,7 +194,9 @@ def test_gp_fantasizing():
     # would be hard to compare below.
     pending_tuples = [tuple(np.random.rand(2,)) for _ in range(num_pending)]
     state = create_tuning_job_state(
-        hp_ranges=hp_ranges, cand_tuples=X, metrics=Y,
+        hp_ranges=hp_ranges,
+        cand_tuples=X,
+        metrics=Y,
         pending_tuples=pending_tuples)
     model, gpmodel = _make_model_gp_optimize(
         state, random_seed, num_fantasy_samples=num_fantasy_samples,
@@ -215,10 +217,13 @@ def test_gp_fantasizing():
         Y_full = Y + [dictionarize_objective(eval.fantasies[INTERNAL_METRIC_NAME][:, it])
                       for eval in fantasy_samples]
         state2 = create_tuning_job_state(
-            hp_ranges=hp_ranges, cand_tuples=X_full, metrics=Y_full)
+            hp_ranges=hp_ranges,
+            cand_tuples=X_full,
+            metrics=Y_full)
         # We have to skip parameter optimization here
         model_factory = GaussProcEmpiricalBayesModelFactory(
-            active_metric=INTERNAL_METRIC_NAME, gpmodel=gpmodel,
+            active_metric=INTERNAL_METRIC_NAME,
+            gpmodel=gpmodel,
             num_fantasy_samples=num_fantasy_samples,
             normalize_targets=False)
         model2 = model_factory.model(state2, fit_params=False)

--- a/tst/schedulers/bayesopt/test_gp_components.py
+++ b/tst/schedulers/bayesopt/test_gp_components.py
@@ -63,13 +63,14 @@ def test_get_internal_candidate_evaluations():
 
 
 def test_dimensionality_and_warping_ranges():
+    # Note: `choice` with binary value range is encoded as 1, not 2 dims
     hp_ranges = make_hyperparameter_ranges({
-        'a': choice(['X', 'Y']),
-        'b': loguniform(0.1, 10.0),
-        'c': choice(['a', 'b', 'c']),
-        'd': uniform(0.0, 10.0),
-        'e': choice(['X', 'Y'])})
+        'a': choice(['X', 'Y']),  # pos 0
+        'b': loguniform(0.1, 10.0),  # pos 1
+        'c': choice(['a', 'b', 'c']),  # pos 2
+        'd': uniform(0.0, 10.0),  # pos 5
+        'e': choice(['X', 'Y'])})  # pos 6
 
     dim, warping_ranges = dimensionality_and_warping_ranges(hp_ranges)
-    assert dim == 9
-    assert warping_ranges == {2: (0.0, 1.0), 6: (0.0, 1.0)}
+    assert dim == 7
+    assert warping_ranges == {1: (0.0, 1.0), 5: (0.0, 1.0)}

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -71,8 +71,9 @@ def test_continuous_to_and_from_ndarray(
 
 
 @pytest.mark.parametrize('choices,external_hp,internal_ndarray', [
-    (['a', 'b'], 'a', [1.0, 0.0]),
-    (['a', 'b'], 'b', [0.0, 1.0]),
+    (['a', 'b'], 'a', [0.25]),
+    (['a', 'b'], 'b', [0.75]),
+    (['a', 'b', 'c'], 'b', [0.0, 1.0, 0.0]),
     (['a', 'b', 'c', 'd'], 'c', [0.0, 0.0, 1.0, 0.0]),
 ])
 def test_categorical_to_and_from_ndarray(choices, external_hp, internal_ndarray):

--- a/tst/schedulers/bayesopt/test_transferlearning.py
+++ b/tst/schedulers/bayesopt/test_transferlearning.py
@@ -54,7 +54,7 @@ def test_create_transfer_learning():
 
     hp_ranges = kwargs_int['hp_ranges']
     assert hp_ranges.internal_keys == ['task_id', 'a', 'b', 'c']
-    assert hp_ranges.ndarray_size() == 9
+    assert hp_ranges.ndarray_size == 9
     expected_ndarray_bounds = [
         (0.0, 0.0), (0.0, 0.0), (1.0, 1.0), (0.0, 0.0),
         (0.1, 0.4),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Encodes binary categorical with a single int in {0, 1}, instead of one-hot, so the internal dimension is 1 instead of 2. Can make a difference of there are several binary choices, e.g. for FCNet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
