### PR TITLE
Blackbox surrogate dictionary, small fixes

### DIFF
--- a/benchmarking/benchmark_loop/plot_results.py
+++ b/benchmarking/benchmark_loop/plot_results.py
@@ -27,8 +27,8 @@ import matplotlib.pyplot as plt
 def show_results(df_task, title: str, colors: Dict, show_seeds: bool = False):
 
     if len(df_task) > 0:
-        metric = df_task.loc[:, 'metric'].values[0]
-        mode = df_task.loc[:, 'mode'].values[0]
+        metric = df_task.loc[:, 'metric_names'].values[0]
+        mode = df_task.loc[:, 'metric_mode'].values[0]
 
         fig, ax = plt.subplots()
 

--- a/benchmarking/blackbox_repository/blackbox_surrogate.py
+++ b/benchmarking/blackbox_repository/blackbox_surrogate.py
@@ -30,7 +30,7 @@ class BlackboxSurrogate(Blackbox):
             configuration_space: Dict,
             fidelity_space: Optional[Dict] = None,
             fidelity_values: Optional[np.array] = None,
-            surrogate=KNeighborsRegressor(n_neighbors=1),
+            surrogate=None,
             max_fit_samples: Optional[int] = None,
             name: Optional[str] = None,
     ):
@@ -43,11 +43,14 @@ class BlackboxSurrogate(Blackbox):
         :param y: dataframe containing objectives values
         :param configuration_space:
         :param fidelity_space:
-        :param surrogate: the model that is fitted to predict objectives given any configuration.
+        :param surrogate: the model that is fitted to predict objectives given any configuration, default to
+        KNeighborsRegressor(n_neighbors=1).
         Possible examples: KNeighborsRegressor(n_neighbors=1), MLPRegressor() or any estimator obeying Scikit-learn API.
         The model is fit on top of pipeline that applies basic feature-processing to convert rows in X to vectors.
         We use the configuration_space hyperparameters types to deduce the types of columns in X (for instance
         CategoricalHyperparameter are one-hot encoded).
+        :param max_fit_samples: maximum number of samples to be fed to the surrogate estimator, if the more data points
+        than this number are passed, then they are subsampled without replacement.
         :param name:
         """
         super(BlackboxSurrogate, self).__init__(
@@ -57,7 +60,7 @@ class BlackboxSurrogate(Blackbox):
         )
         assert len(X) == len(y)
         # todo other types of assert with configuration_space, objective_names, ...
-        self.surrogate = surrogate
+        self.surrogate = surrogate if surrogate is not None else KNeighborsRegressor(n_neighbors=1)
         self.max_fit_samples = max_fit_samples
         self.fit_surrogate(X=X, y=y, surrogate=surrogate, max_samples=self.max_fit_samples)
         self.name = name
@@ -101,14 +104,14 @@ class BlackboxSurrogate(Blackbox):
             ('model', model)
         ])
 
-    def fit_surrogate(self, X, y, surrogate=KNeighborsRegressor(n_neighbors=1), max_samples: Optional[int] = None) -> Blackbox:
+    def fit_surrogate(self, X, y, surrogate=None, max_samples: Optional[int] = None) -> Blackbox:
         """
         Fits a surrogate model to a blackbox.
         :param surrogate: fits the model and apply the model transformation when evaluating a
         blackbox configuration. Possible example: KNeighborsRegressor(n_neighbors=1), MLPRegressor() or any estimator
         obeying Scikit-learn API.
         """
-        self.surrogate = surrogate
+        self.surrogate = surrogate if surrogate is not None else KNeighborsRegressor(n_neighbors=1)
 
         self.surrogate_pipeline = self.make_model_pipeline(
             configuration_space=self.configuration_space,

--- a/benchmarking/blackbox_repository/blackbox_surrogate.py
+++ b/benchmarking/blackbox_repository/blackbox_surrogate.py
@@ -31,6 +31,7 @@ class BlackboxSurrogate(Blackbox):
             fidelity_space: Optional[Dict] = None,
             fidelity_values: Optional[np.array] = None,
             surrogate=KNeighborsRegressor(n_neighbors=1),
+            max_fit_samples: Optional[int] = None,
             name: Optional[str] = None,
     ):
         """
@@ -56,10 +57,9 @@ class BlackboxSurrogate(Blackbox):
         )
         assert len(X) == len(y)
         # todo other types of assert with configuration_space, objective_names, ...
-        self.X = X
-        self.y = y
         self.surrogate = surrogate
-        self.fit_surrogate(surrogate)
+        self.max_fit_samples = max_fit_samples
+        self.fit_surrogate(X=X, y=y, surrogate=surrogate, max_samples=self.max_fit_samples)
         self.name = name
         self._fidelity_values = fidelity_values
 
@@ -67,35 +67,24 @@ class BlackboxSurrogate(Blackbox):
     def fidelity_values(self) -> np.array:
         return self._fidelity_values
 
-    def fit_surrogate(self, surrogate=KNeighborsRegressor(n_neighbors=1)) -> Blackbox:
-        """
-        Fits a surrogate model to a blackbox.
-        :param surrogate: fits the model and apply the model transformation when evaluating a
-        blackbox configuration. Possible example: KNeighborsRegressor(n_neighbors=1), MLPRegressor() or any estimator
-        obeying Scikit-learn API.
-        """
-        self.surrogate = surrogate
-
+    @staticmethod
+    def make_model_pipeline(configuration_space, fidelity_space, model):
         # gets hyperparameters types, categorical for CategoricalHyperparameter, numeric for everything else
         numeric = []
         categorical = []
 
-        if self.fidelity_space is not None:
+        if fidelity_space is not None:
             surrogate_hps = dict()
-            surrogate_hps.update(self.configuration_space)
-            surrogate_hps.update(self.fidelity_space)
+            surrogate_hps.update(configuration_space)
+            surrogate_hps.update(fidelity_space)
         else:
-            surrogate_hps = self.configuration_space
+            surrogate_hps = configuration_space
 
         for hp_name, hp in surrogate_hps.items():
             if isinstance(hp, sp.Categorical):
                 categorical.append(hp_name)
             else:
                 numeric.append(hp_name)
-
-        # apply transformation to columns according its type
-        print(f"fitting surrogate predicting {self.y.columns} given numerical cols {numeric} and "
-              f"categorical cols {categorical}")
 
         # builds a pipeline that standardize numeric features and one-hot categorical ones before applying
         # the surrogate model
@@ -106,15 +95,38 @@ class BlackboxSurrogate(Blackbox):
         if len(numeric) > 0:
             features_union.append(('numeric', make_pipeline(Columns(names=numeric), StandardScaler())))
 
-        self.surrogate_pipeline = Pipeline([
+        return Pipeline([
             ("features", FeatureUnion(features_union)),
-            ('model', surrogate)
+            ('standard scaler', StandardScaler(with_mean=False)),
+            ('model', model)
         ])
 
-        self.surrogate_pipeline.fit(
-            X=self.X,
-            y=self.y
+    def fit_surrogate(self, X, y, surrogate=KNeighborsRegressor(n_neighbors=1), max_samples: Optional[int] = None) -> Blackbox:
+        """
+        Fits a surrogate model to a blackbox.
+        :param surrogate: fits the model and apply the model transformation when evaluating a
+        blackbox configuration. Possible example: KNeighborsRegressor(n_neighbors=1), MLPRegressor() or any estimator
+        obeying Scikit-learn API.
+        """
+        self.surrogate = surrogate
+
+        self.surrogate_pipeline = self.make_model_pipeline(
+            configuration_space=self.configuration_space,
+            fidelity_space=self.fidelity_space,
+            model=surrogate
         )
+        # todo would be nicer to have this in the feature pipeline
+        if max_samples is not None and max_samples < len(X):
+            random_indices = np.random.permutation(len(X))[:max_samples]
+            self.surrogate_pipeline.fit(
+                X=X.loc[random_indices],
+                y=y.loc[random_indices]
+            )
+        else:
+            self.surrogate_pipeline.fit(
+                X=X,
+                y=y
+            )
         return self
 
     def _objective_function(

--- a/syne_tune/backend/simulator_backend/simulator_callback.py
+++ b/syne_tune/backend/simulator_backend/simulator_callback.py
@@ -80,7 +80,9 @@ class SimulatorCallback(StoreResultsCallback):
                 max_num_trials_completed=stop_criterion.max_num_trials_completed,
                 max_cost=stop_criterion.max_cost,
                 max_num_trials_finished=stop_criterion.max_num_trials_finished,
-                max_metric_value={ST_TUNER_TIME: max_wallclock_time})
+                max_metric_value={ST_TUNER_TIME: max_wallclock_time},
+                max_num_evaluations=stop_criterion.max_num_evaluations,
+            )
             tuner.stop_criterion = new_stop_criterion
 
     def on_tuning_start(self, tuner: "Tuner"):

--- a/syne_tune/stopping_criterion.py
+++ b/syne_tune/stopping_criterion.py
@@ -29,6 +29,7 @@ class StoppingCriterion:
     Using this class is needed when using the remote launcher to ensure serialization works correctly.
     """
     max_wallclock_time: float = None
+    max_num_evaluations: int = None
     max_num_trials_started: int = None
     max_num_trials_completed: int = None
     max_cost: float = None
@@ -56,7 +57,9 @@ class StoppingCriterion:
         if self.max_cost is not None and status.cost > self.max_cost:
             logger.info(f"reaching max cost ({self.max_cost}), stopping there.")
             return True
-
+        if self.max_num_evaluations is not None and status.overall_metric_statistics.count > self.max_num_evaluations:
+            logger.info(f"reaching {status.overall_metric_statistics.count} evaluations, stopping there. ")
+            return True
         if self.max_metric_value is not None and status.overall_metric_statistics.count > 0:
             max_metrics_observed = status.overall_metric_statistics.max_metrics
             for metric, max_metric_accepted in self.max_metric_value.items():
@@ -71,6 +74,5 @@ class StoppingCriterion:
                 if metric in min_metrics_observed and min_metrics_observed[metric] < min_metric_accepted:
                     logger.info(f"found {metric} with value ({min_metrics_observed[metric]}), "
                                 f"bellow the provided threshold {min_metric_accepted} stopping there.")
-
                     return True
         return False


### PR DESCRIPTION
*Description of changes:* backport changes on blackboxes from kdd branch (I will open separate PR for CTS and additional tooling for experiment).
* add option to fit surrogate on subset
* standardize output before fitting surrogates
* make sure cumulative time is increasing in simulations
* change BlackboxRepositoryBackend surrogate parameters to string/dictionary and only fit estimator in a lazy fashion (as proposed in Matthias PR)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
