### PR TITLE
Fix to domain for bounding-box (support having only a single element …

### DIFF
--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -619,6 +619,10 @@ class FiniteRange(Domain):
             self._step_internal = (upper_internal - self._lower_internal) / (size - 1) if size > 1 else 0
         self._values = [self._map_from_int(x) for x in range(self.size)]
 
+    @property
+    def values(self):
+        return self._values
+
     def _map_from_int(self, x: int) -> Union[float, int]:
         y = x * self._step_internal + self._lower_internal
         if self.log_scale:
@@ -991,7 +995,7 @@ def restrict_domain(numerical_domain: Domain, lower: float, upper: float) -> Dom
         new_domain_dict['domain_kwargs']['upper'] = upper
         return from_dict(new_domain_dict)
     else:
-        values = numerical_domain._values
+        values = numerical_domain.values
         assert lower < max(numerical_domain._values)
         assert upper > min(numerical_domain._values)
         i = 0

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -600,8 +600,8 @@ class FiniteRange(Domain):
     """
     def __init__(self, lower: float, upper: float, size: int,
                  log_scale: bool = False, cast_int: bool = False):
-        assert lower < upper
-        assert size >= 2
+        assert lower <= upper
+        assert size >= 1
         if log_scale:
             assert lower > 0.0
         self._uniform_int = randint(0, size - 1)
@@ -612,38 +612,44 @@ class FiniteRange(Domain):
         self.size = size
         if not log_scale:
             self._lower_internal = lower
-            self._step_internal = (upper - lower) / (size - 1)
+            self._step_internal = (upper - lower) / (size - 1) if size > 1 else 0
         else:
             self._lower_internal = np.log(lower)
             upper_internal = np.log(upper)
-            self._step_internal = \
-                (upper_internal - self._lower_internal) / (size - 1)
+            self._step_internal = (upper_internal - self._lower_internal) / (size - 1) if size > 1 else 0
+        self._values = [self._map_from_int(x) for x in range(self.size)]
 
     def _map_from_int(self, x: int) -> Union[float, int]:
         y = x * self._step_internal + self._lower_internal
         if self.log_scale:
             y = np.exp(y)
-        y = np.clip(y, self.lower, self.upper)
-        if not self.cast_int:
-            return float(y)
-        else:
-            return int(np.round(y))
+        res = float(np.clip(y, self.lower, self.upper))
+        if self.cast_int:
+            res = int(np.rint(res))
+        return res
+
+    def __repr__(self):
+        values_str = ",".join([str(x) for x in self._values])
+        return f"finite-range([{values_str}])"
 
     @property
     def value_type(self):
         return float if not self.cast_int else int
 
     def _map_to_int(self, value) -> int:
-        int_value = np.clip(value, self.lower, self.upper)
-        if self.log_scale:
-            int_value = np.log(int_value)
-        sz = len(self._uniform_int)
-        return int(np.clip(round(
-            (int_value - self._lower_internal) / self._step_internal),
-            0, sz - 1))
+        if self._step_internal == 0:
+            return 0
+        else:
+            int_value = np.clip(value, self.lower, self.upper)
+            if self.log_scale:
+                int_value = np.log(int_value)
+            sz = len(self._uniform_int)
+            return int(np.clip(round(
+                (int_value - self._lower_internal) / self._step_internal),
+                0, sz - 1))
 
     def cast(self, value):
-        return self._map_from_int(self._map_to_int(value))
+        return self._values[self._map_to_int(value)]
 
     def set_sampler(self, sampler, allow_override=False):
         raise NotImplementedError()
@@ -654,9 +660,9 @@ class FiniteRange(Domain):
     def sample(self, spec=None, size=1, random_state=None):
         int_sample = self._uniform_int.sample(spec, size, random_state)
         if size > 1:
-            return [self._map_from_int(x) for x in int_sample]
+            return [self._values[x] for x in int_sample]
         else:
-            return self._map_from_int(int_sample)
+            return self._values[int_sample]
 
     @property
     def domain_str(self):
@@ -967,3 +973,38 @@ def from_dict(d: Dict) -> Domain:
         sampler = sampler_cls(**sampler_kwargs)
         domain.set_sampler(sampler)
     return domain
+
+
+def restrict_domain(numerical_domain: Domain, lower: float, upper: float) -> Domain:
+    """
+    Restricts a numerical domain to be in the range [lower, upper]
+    :return:
+    """
+    assert hasattr(numerical_domain, "lower") and hasattr(numerical_domain, "upper")
+    assert lower <= upper
+    if not isinstance(numerical_domain, FiniteRange):
+        # domain is numerical, set new lower and upper ranges with bounding-box values
+        new_domain_dict = to_dict(numerical_domain)
+        new_domain_dict['domain_kwargs']['lower'] = lower
+        new_domain_dict['domain_kwargs']['upper'] = upper
+        return from_dict(new_domain_dict)
+    else:
+        values = numerical_domain._values
+        assert lower < max(numerical_domain._values)
+        assert upper > min(numerical_domain._values)
+        i = 0
+        while values[i] < lower and i < len(values) - 1:
+            i += 1
+        new_lower = values[i]
+
+        j = len(values) - 1
+        while upper < values[j] and i < j:
+            j -= 1
+        new_upper = values[j]
+        return FiniteRange(
+            lower=new_lower,
+            upper=new_upper,
+            size=len(values) - i - (len(values) - j - 1),
+            cast_int=numerical_domain.cast_int,
+            log_scale=numerical_domain.log_scale
+        )

--- a/syne_tune/config_space.py
+++ b/syne_tune/config_space.py
@@ -981,6 +981,8 @@ def restrict_domain(numerical_domain: Domain, lower: float, upper: float) -> Dom
     :return:
     """
     assert hasattr(numerical_domain, "lower") and hasattr(numerical_domain, "upper")
+    lower = numerical_domain.cast(lower)
+    upper = numerical_domain.cast(upper)
     assert lower <= upper
     if not isinstance(numerical_domain, FiniteRange):
         # domain is numerical, set new lower and upper ranges with bounding-box values
@@ -1004,7 +1006,7 @@ def restrict_domain(numerical_domain: Domain, lower: float, upper: float) -> Dom
         return FiniteRange(
             lower=new_lower,
             upper=new_upper,
-            size=len(values) - i - (len(values) - j - 1),
+            size=j-i+1,
             cast_int=numerical_domain.cast_int,
             log_scale=numerical_domain.log_scale
         )

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -14,7 +14,6 @@ import json
 import logging
 from datetime import datetime
 from json.decoder import JSONDecodeError
-from pathlib import Path
 from typing import List, Dict, Callable, Optional
 
 import boto3

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -13,6 +13,8 @@
 import json
 import logging
 from datetime import datetime
+from json.decoder import JSONDecodeError
+from pathlib import Path
 from typing import List, Dict, Callable, Optional
 
 import boto3
@@ -119,7 +121,8 @@ def download_single_experiment(
 
 def load_experiment(
         tuner_name: str,
-        download_if_not_found: bool = True
+        download_if_not_found: bool = True,
+        load_tuner: bool = False,
 ) -> ExperimentResult:
     """
     :param tuner_name: name of a tuning experiment previously run
@@ -144,13 +147,15 @@ def load_experiment(
             results = pd.read_csv(path / "results.csv")
     except Exception:
         results = None
-    try:
-        tuner = Tuner.load(path)
-    except FileNotFoundError:
+    if load_tuner:
+        try:
+            tuner = Tuner.load(path)
+        except FileNotFoundError:
+            tuner = None
+        except Exception:
+            tuner = None
+    else:
         tuner = None
-    except Exception:
-        tuner = None
-
     return ExperimentResult(
         name=tuner.name if tuner is not None else path.stem,
         results=results,
@@ -159,16 +164,39 @@ def load_experiment(
     )
 
 
+def get_metadata(name_filter: Callable[[str], bool] = None) -> Dict[str, Dict]:
+    """
+    :param name_filter: if passed then only experiments whose path matching the filter are kept. This allows
+    rapid filtering in the presence of many experiments.
+    :return: dictionary from tuner name to metadata dict
+    """
+    res = {}
+    for path in experiment_path().rglob("*/metadata.json"):
+        if name_filter is None or name_filter(str(path)):
+            try:
+                tuner_name = path.parent.name
+                path = experiment_path(tuner_name)
+                metadata_path = path / "metadata.json"
+                with open(metadata_path, "r") as f:
+                    metadata = json.load(f)
+                res[tuner_name] = metadata
+            except JSONDecodeError as e:
+                print(f"could not read {path}")
+                pass
+    return res
+
+
 def list_experiments(
         name_filter: Callable[[str], bool] = None,
-        experiment_filter: Callable[[ExperimentResult], bool] = None
+        experiment_filter: Callable[[ExperimentResult], bool] = None,
+        load_tuner: bool = False,
 ) -> List[ExperimentResult]:
     res = []
     for path in experiment_path().rglob("*/results.csv*"):
         if name_filter is None or name_filter(str(path)):
-            exp = load_experiment(path.parent.name)
+            exp = load_experiment(path.parent.name, load_tuner)
             if experiment_filter is None or experiment_filter(exp):
-                if exp.results is not None and exp.tuner is not None and exp.metadata is not None:
+                if exp.results is not None and exp.metadata is not None:
                     res.append(exp)
     return sorted(res, key=lambda exp: exp.metadata.get(ST_TUNER_CREATION_TIMESTAMP, 0), reverse=True)
 
@@ -196,7 +224,8 @@ def scheduler_name(scheduler):
 
 def load_experiments_df(
         name_filter: Callable[[str], bool] = None,
-        experiment_filter: Callable[[ExperimentResult], bool] = None
+        experiment_filter: Callable[[ExperimentResult], bool] = None,
+        load_tuner: bool = False,
 ) -> pd.DataFrame:
     """
     :param: name_filter: if specified, only experiment whose name matches the filter will be kept.
@@ -213,15 +242,14 @@ def load_experiments_df(
      `entry_point_name`/`entry_point_path` name and path of the entry point that was tuned
     """
     dfs = []
-    for experiment in list_experiments(name_filter=name_filter, experiment_filter=experiment_filter):
-        assert experiment.tuner is not None
+    for experiment in list_experiments(
+            name_filter=name_filter, experiment_filter=experiment_filter, load_tuner=load_tuner
+    ):
         assert experiment.results is not None
         assert experiment.metadata is not None
 
         df = experiment.results
         df["tuner_name"] = experiment.name
-        df["scheduler"] = scheduler_name(experiment.tuner.scheduler)
-        df["backend"] = experiment.tuner.trial_backend.__class__.__name__
         for k, v in experiment.metadata.items():
             if isinstance(v, List):
                 if len(v) > 1:
@@ -231,18 +259,6 @@ def load_experiments_df(
                     df[k] = v[0]
             else:
                 df[k] = v
-        metrics = experiment.tuner.scheduler.metric_names()
-        if len(metrics) == 1:
-            df["metric"] = experiment.tuner.scheduler.metric_names()[0]
-        else:
-            # assume error is always the first
-            df["metric"] = experiment.tuner.scheduler.metric_names()[0]
-
-        scheduler_mode = experiment.tuner.scheduler.metric_mode()
-        if isinstance(scheduler_mode, str):
-            df["mode"] = scheduler_mode
-        else:
-            df["mode"] = scheduler_mode[0]
         dfs.append(df)
     return pd.concat(dfs, ignore_index=True)
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
@@ -206,16 +206,15 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
 
         """
         super().__init__(name)
-        assert lower_bound < upper_bound
-        assert size >= 2
+        assert lower_bound <= upper_bound
+        assert size >= 1
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
         self.cast_int = cast_int
         self._scaling = scaling
         self._lower_internal = scaling.to_internal(lower_bound)
         self._upper_internal = scaling.to_internal(upper_bound)
-        self._step_internal = \
-            (self._upper_internal - self._lower_internal) / (size - 1)
+        self._step_internal = (self._upper_internal - self._lower_internal) / (size - 1) if size > 1 else 0
         self._range_int = HyperparameterRangeInteger(
             name=name + '_INTERNAL', lower_bound=0, upper_bound=size - 1,
             scaling=LinearScaling())
@@ -234,9 +233,12 @@ class HyperparameterRangeFiniteRange(HyperparameterRange):
             return int(np.round(y))
 
     def _map_to_int(self, y: Union[float, int]) -> int:
-        y_int = np.clip(self._scaling.to_internal(y), self._lower_internal,
-                        self._upper_internal)
-        return int(round((y_int - self._lower_internal) / self._step_internal))
+        if self._step_internal == 0:
+            return 0
+        else:
+            y_int = np.clip(self._scaling.to_internal(y), self._lower_internal,
+                            self._upper_internal)
+            return int(round((y_int - self._lower_internal) / self._step_internal))
 
     def to_ndarray(self, hp: Hyperparameter) -> np.ndarray:
         return self._range_int.to_ndarray(self._map_to_int(hp))

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -49,6 +49,7 @@ def _assert_allclose_config(c1, c2, hp_ranges):
     (0.1, 100, 1.0, 1.0/3, loguniform, None),
     (1, 10001, 5001, 0.5, randint, None),
     (-10, 10, 0, 0.5, randint, None),
+    (0.1, 1.0, 0.1, 0.5, finrange, 1),
     (0.1, 1.0, 0.1, 0.5/10, finrange, 10),
     (0.1, 1.0, 1.0, 9.5/10, finrange, 10),
     (0.1, 1.0, 0.5, 4.5/10, finrange, 10),

--- a/tst/test_config_space.py
+++ b/tst/test_config_space.py
@@ -127,6 +127,9 @@ def test_config_space_size():
      np.array([0, 2, 4, 6, 8])),
     (logfinrange(8, 512, 7, cast_int=True),
      np.array([8, 16, 32, 64, 128, 256, 512])),
+    (finrange(0.1, 1.0, 1),
+     np.array([0.1])),
+
 ])
 def test_finrange_domain(domain, value_set):
     seed = 31415927


### PR DESCRIPTION
…and provide support for restricting finite search spaces).

*Issue #, if available:*

*Description of changes:* pull changes from automl experiment branch that affects common components (this is the last one the other PR will be just new schedulers and experiment scripts)

* support finite range with only single elements
* support restricting finite range to smaller intervals
* support not loading tuner when accessing results (much faster)
* use metadata instead of inspecting the tuner for mode and metrics
* allow to load metadata only of experiments and filter by name (much faster than loading all experiments results)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
