### PR TITLE
Supporting deleting checkpoints once not needed anymore

### DIFF
--- a/benchmarking/nursery/lstm_wikitext2/definition_lstm_wikitext2.py
+++ b/benchmarking/nursery/lstm_wikitext2/definition_lstm_wikitext2.py
@@ -13,6 +13,8 @@
 """
 Example that reproduces the LSTM on WikiText2 benchmark from AutoGluonExperiments repo
 """
+from pathlib import Path
+
 from benchmarking.utils import get_cost_model_for_batch_size
 from benchmarking.nursery.lstm_wikitext2.lstm_wikitext2 import \
     BATCH_SIZE_LOWER, BATCH_SIZE_UPPER, BATCH_SIZE_KEY, _config_space, \
@@ -49,7 +51,7 @@ def lstm_wikitext2_benchmark(params):
         epochs=params['max_resource_level'],
         report_current_best=params['report_current_best'])
     return {
-        'script': "lstm_wikitext2.py",
+        'script': Path(__file__).parent / "lstm_wikitext2.py",
         'metric': METRIC_NAME,
         'mode': 'max',
         'resource_attr': RESOURCE_ATTR,

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -205,14 +205,8 @@ class LocalBackend(TrialBackend):
             # (which allows to write a time-stamp when the process finishes) but it is probably OK if all_results
             # is called every few seconds.
             if os.path.exists(trial_path / "end"):
-                try:
-                    training_end_time = self._read_time_stamp(
-                        trial_id=trial_id, name="end")
-                except ValueError as exc:
-                    # File is present, but empty
-                    training_end_time = datetime.now()
-                    logger.warning(
-                        f"Timestamp file {str(trial_path / 'end')} exists, but is empty:\n{exc}")
+                training_end_time = self._read_time_stamp(
+                    trial_id=trial_id, name="end")
             else:
                 training_end_time = datetime.now()
 

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -260,12 +260,8 @@ class LocalBackend(TrialBackend):
 
     def _write_time_stamp(self, trial_id: int, name: str):
         time_stamp_path = self._file_path(trial_id=trial_id, filename=name)
-        try:
-            with open(time_stamp_path, 'w') as f:
-                f.write(str(datetime.now().timestamp()))
-        except OSError as exc:
-            logger.warning(
-                f"Failed to write timestamp file {str(time_stamp_path)}:\n{exc}")
+        with open(time_stamp_path, 'w') as f:
+            f.write(str(datetime.now().timestamp()))
 
     def _read_time_stamp(self, trial_id: int, name: str):
         time_stamp_path = self._file_path(trial_id=trial_id, filename=name)

--- a/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
@@ -40,6 +40,7 @@ class SageMakerBackend(TrialBackend):
             sm_estimator: Framework,
             metrics_names: Optional[List[str]] = None,
             s3_path: Optional[str] = None,
+            delete_checkpoints: bool = False,
             *args,
             **sagemaker_fit_kwargs):
         """
@@ -52,6 +53,8 @@ class SageMakerBackend(TrialBackend):
         :param sagemaker_fit_kwargs: extra arguments that are passed to sagemaker.estimator.Framework when fitting the
         job, for instance `{'train': 's3://my-data-bucket/path/to/my/training/data'}`
         """
+        assert not delete_checkpoints, \
+            "delete_checkpoints=True not yet supported for SageMaker backend"
         super(SageMakerBackend, self).__init__()
         self.sm_estimator = sm_estimator
 
@@ -253,9 +256,13 @@ class SageMakerBackend(TrialBackend):
     def copy_checkpoint(self, src_trial_id: int, tgt_trial_id: int):
         # todo sync checkpoint path with s3 sync
         logger.warning(
-            "Starting trials with a previous checkpoint is not supported yet in Sagemaker. "
+            "Starting trials with a previous checkpoint is not supported yet in SageMaker. "
             "The trial will run from scratch."
         )
+
+    def delete_checkpoint(self, trial_id: int):
+        # TODO
+        logger.warning("Deleting checkpoints not yet supported for SageMaker backend")
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         # we use the tuner-name to set the checkpoint directory

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -21,7 +21,17 @@ from syne_tune.constants import ST_WORKER_TIMESTAMP
 
 
 class TrialBackend:
-    def __init__(self, ):
+    def __init__(self, delete_checkpoints: bool = False):
+        """
+        If `delete_checkpoints` is True, the checkpoints written by a trial are
+        deleted once the trial is stopped or is registered as completed. Also,
+        as part of `stop_all` called at the end of the tuning loop, all remaining
+        checkpoints are deleted.
+
+        :param delete_checkpoints: See above
+
+        """
+        self.delete_checkpoints = delete_checkpoints
         self.trial_ids = []
         self._trial_dict = {}
 
@@ -56,6 +66,16 @@ class TrialBackend:
         Copy the checkpoint folder from one trial to the other.
         :param src_trial_id:
         :param tgt_trial_id:
+        :return:
+        """
+        raise NotImplementedError()
+
+    def delete_checkpoint(self, trial_id: int):
+        """
+        Removes checkpoint folder for a trial, if it exists. Otherwise, nothing
+        is done.
+
+        :param trial_id:
         :return:
         """
         raise NotImplementedError()
@@ -114,6 +134,8 @@ class TrialBackend:
         # todo assert trial_id is valid
         # todo assert trial_id has not been stopped or paused before
         self._stop_trial(trial_id=trial_id)
+        if self.delete_checkpoints:
+            self.delete_checkpoint(trial_id=trial_id)  # checkpoint not needed anymore
 
     def _stop_trial(self, trial_id: int):
         """
@@ -157,6 +179,8 @@ class TrialBackend:
                     position_last_seen = self._last_metric_seen_index[trial_result.trial_id]
                     new_metrics = trial_result.metrics[position_last_seen:]
                     self._last_metric_seen_index[trial_result.trial_id] += len(new_metrics)
+                    if self.delete_checkpoints and trial_result.status == Status.completed:
+                        self.delete_checkpoint(trial_id=trial_result.trial_id)
                 for new_metric in new_metrics:
                     results.append((trial_result.trial_id, new_metric))
 
@@ -193,6 +217,10 @@ class TrialBackend:
         for trial in trial_results:
             if trial.status == Status.in_progress:
                 self.stop_trial(trial_id=trial.trial_id)
+        if self.delete_checkpoints:
+            # Delete all remaining checkpoints (e.g., of paused trials)
+            for trial_id in self.trial_ids:
+                self.delete_checkpoint(trial_id=trial_id)
 
     def set_path(self, results_root: Optional[str] = None, tuner_name: Optional[str] = None):
         """

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -15,9 +15,12 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
+import logging
 
 from syne_tune.backend.trial_status import TrialResult, Trial, Status
 from syne_tune.constants import ST_WORKER_TIMESTAMP
+
+logger = logging.getLogger(__name__)
 
 
 class TrialBackend:
@@ -135,6 +138,7 @@ class TrialBackend:
         # todo assert trial_id has not been stopped or paused before
         self._stop_trial(trial_id=trial_id)
         if self.delete_checkpoints:
+            logger.info(f"Removing checkpoints for trial_id = {trial_id}")
             self.delete_checkpoint(trial_id=trial_id)  # checkpoint not needed anymore
 
     def _stop_trial(self, trial_id: int):
@@ -180,6 +184,7 @@ class TrialBackend:
                     new_metrics = trial_result.metrics[position_last_seen:]
                     self._last_metric_seen_index[trial_result.trial_id] += len(new_metrics)
                     if self.delete_checkpoints and trial_result.status == Status.completed:
+                        logger.info(f"Removing checkpoints for trial_id = {trial_result.trial_id}")
                         self.delete_checkpoint(trial_id=trial_result.trial_id)
                 for new_metric in new_metrics:
                     results.append((trial_result.trial_id, new_metric))
@@ -219,6 +224,7 @@ class TrialBackend:
                 self.stop_trial(trial_id=trial.trial_id)
         if self.delete_checkpoints:
             # Delete all remaining checkpoints (e.g., of paused trials)
+            logger.info("Removing all remaining checkpoints of trials")
             for trial_id in self.trial_ids:
                 self.delete_checkpoint(trial_id=trial_id)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This unblocks tuning of HuggingFace models without syncing checkpoints to S3. If checkpoints are written locally to ~/, the local disk fills up quickly.

Supporting this for SageMaker backend will be a forthcoming PR. Already implemented it, but a test is missing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
