### PR TITLE
Fix a typo in product kernel implementation, add / update kernel unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 *__pycache__
 *.egg-info
 .idea
-
+.vscode

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/kernel/product_kernel.py
@@ -47,7 +47,7 @@ class ProductKernelFunction(KernelFunction):
         X1_1 = X1[:, :d1]
         X1_2 = X1[:, d1:]
         X2_1 = X2[:, :d1]
-        X2_2 = X1[:, d1:]
+        X2_2 = X2[:, d1:]
         kmat1 = self.kernel1(X1_1, X2_1)
         kmat2 = self.kernel2(X1_2, X2_2)
         return kmat1 * kmat2


### PR DESCRIPTION
*Description of changes:*

There is a typo in implementation of product kernel. This breaks warmstart functionality in some cases. 

This PR fixes typo and adds unit tests to check for correct functioning of the kernel.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
