### PR TITLE
Some small fixes

### DIFF
--- a/benchmarking/blackbox_repository/simulated_tabular_backend.py
+++ b/benchmarking/blackbox_repository/simulated_tabular_backend.py
@@ -323,6 +323,8 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             self._config_space_surrogate = {
                 k: from_dict(v)
                 for k, v in state['config_space_surrogate'].items()}
+        else:
+            self._config_space_surrogate = None
 
 
 class UserBlackboxBackend(_BlackboxSimulatorBackend):

--- a/benchmarking/definitions/definition_nashpobench.py
+++ b/benchmarking/definitions/definition_nashpobench.py
@@ -15,7 +15,7 @@ from benchmarking.blackbox_repository.conversion_scripts.scripts.fcnet_import \
     BLACKBOX_NAME, MAX_RESOURCE_LEVEL, CONFIGURATION_SPACE, NUM_UNITS_1, \
     NUM_UNITS_2
 
-from syne_tune.search_space import choice, uniform, loguniform, lograndint
+from syne_tune.config_space import choice, uniform, loguniform, lograndint
 
 
 DATASET_NAMES = [
@@ -58,7 +58,7 @@ def nashpobench_default_params(params=None):
         'framework': 'PyTorch',
         'framework_version': '1.6',
         'dataset_name': 'protein_structure',
-        'interpolate_blackbox': True,
+        'interpolate_blackbox': False,
     }
 
 

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -201,17 +201,19 @@ class Tuner:
                 mode=self.scheduler.metric_mode(),
             )
 
+            # Callbacks (typically includes writing final results)
+            for callback in self.callbacks:
+                callback.on_tuning_end()
+
+            # Serialize Tuner object
+            self.save()
+
             logger.info("Tuner finished, stopping trials that may still be running.")
             self.trial_backend.stop_all()
 
             # notify tuning status that jobs were stopped without having to query their status in the backend since
             # we know that all trials were stopped
             self.tuning_status.mark_running_job_as_stopped()
-
-            self.save()
-
-            for callback in self.callbacks:
-                callback.on_tuning_end()
 
             # in case too many errors were triggered, show log of last failed job and terminates with an error
             if self.tuning_status.num_trials_failed > self.max_failures:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
One small fix. Also, I am changing the order of things done at the end of tuning, so that the callbacks are called first (this is where final results are stored -- this is most important to have), then the tuner model is saved, and finally all remaining trials are stopped. If the last one fails, we still have all the results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
