### PR TITLE
Fix s3-path

### DIFF
--- a/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
@@ -132,11 +132,10 @@ class SageMakerBackend(TrialBackend):
         return json.loads(json.dumps(dict, default=np_encoder))
 
     def _checkpoint_s3_uri_for_trial(self, trial_id: int) -> str:
-        res_path = Path(self.s3_path)
+        res_path = self.s3_path
         if self.tuner_name is not None:
-            res_path = res_path / self.tuner_name
-        res_path = res_path / str(trial_id) / 'checkpoints'
-        return str(res_path) + '/'
+            res_path = f"{res_path}/{self.tuner_name}"
+        return f"{res_path}/{str(trial_id)}/checkpoints/"
 
     def _schedule(self, trial_id: int, config: Dict):
         config[ST_CHECKPOINT_DIR] = "/opt/ml/checkpoints"


### PR DESCRIPTION
There is bug in the s3-key convertion in sagemaker backend. S3-key contains a double slash. The conversion to python `Path` removes one of them. Consequently, the returned string is not a proper key anymore.
We should keep the s3 key as string and not convert it to `Path`. This pr fixes the issue.

```python
>>> from pathlib import Path
>>> str(Path("s3://xxx"))
's3:/xxx'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.