### PR TITLE
Add strictly_non_binary_choice_hyperparameter_keys to enforce non-bin…

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges.py
@@ -32,7 +32,9 @@ class HyperparameterRanges(object):
             self, config_space: Dict, name_last_pos: Optional[str] = None,
             value_for_last_pos=None,
             active_config_space: Optional[Dict] = None,
-            prefix_keys: Optional[List[str]] = None):
+            prefix_keys: Optional[List[str]] = None,
+            strictly_non_binary_choice_hyperparameter_keys: Optional[List[str]] = None
+    ):
         """
         If name_last_pos is given, the hyperparameter of that name is assigned
         the final position in the vector returned by `to_ndarray`. This can be
@@ -65,12 +67,15 @@ class HyperparameterRanges(object):
         :param prefix_keys: If given, these keys into `config_space` come first
             in the internal ordering, which determines the internal
             encoding
+        :param strictly_non_binary_choice_hyperparameter_keys: If given, these keys are considered to be strictly
+            non-binary even if number of choices are 2.
         """
         self.config_space = _filter_constant_hyperparameters(config_space)
         self.name_last_pos = name_last_pos
         self.value_for_last_pos = value_for_last_pos
         self._set_internal_keys(prefix_keys)
         self._set_active_config_space(active_config_space)
+        self.strictly_non_binary_choice_hyperparameter_keys = strictly_non_binary_choice_hyperparameter_keys or []
 
     def _set_internal_keys(self, prefix_keys: Optional[List[str]]):
         keys = sorted(self.config_space.keys())

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_factory.py
@@ -26,11 +26,15 @@ def make_hyperparameter_ranges(
         name_last_pos: Optional[str] = None,
         value_for_last_pos=None,
         active_config_space: Optional[Dict] = None,
-        prefix_keys: Optional[List[str]] = None) -> HyperparameterRanges:
+        prefix_keys: Optional[List[str]] = None,
+        strictly_non_binary_choice_hyperparameter_keys: Optional[List[str]] = None,
+) -> HyperparameterRanges:
     hp_ranges = HyperparameterRangesImpl(
         config_space,
         name_last_pos=name_last_pos,
         value_for_last_pos=value_for_last_pos,
         active_config_space=active_config_space,
-        prefix_keys=prefix_keys)
+        prefix_keys=prefix_keys,
+        strictly_non_binary_choice_hyperparameter_keys=strictly_non_binary_choice_hyperparameter_keys
+    )
     return hp_ranges

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/datatypes/hp_ranges_impl.py
@@ -411,9 +411,10 @@ class HyperparameterRangesImpl(HyperparameterRanges):
     """
     def __init__(self, config_space: Dict, name_last_pos: str = None,
                  value_for_last_pos=None, active_config_space: Dict = None,
-                 prefix_keys: Optional[List[str]] = None):
+                 prefix_keys: Optional[List[str]] = None,
+                 strictly_non_binary_choice_hyperparameter_keys: Optional[List[str]] = None,):
         super().__init__(config_space, name_last_pos, value_for_last_pos,
-                         active_config_space, prefix_keys)
+                         active_config_space, prefix_keys, strictly_non_binary_choice_hyperparameter_keys)
         hp_ranges = []
         for name in self.internal_keys:
             hp_range = self.config_space[name]
@@ -425,7 +426,7 @@ class HyperparameterRangesImpl(HyperparameterRanges):
                         self.active_config_space[name].categories)
                 else:
                     active_choices = None
-                if len(hp_range.categories) == 2:
+                if len(hp_range.categories) == 2 and name not in self.strictly_non_binary_choice_hyperparameter_keys:
                     _cls = HyperparameterRangeCategoricalBinary
                 else:
                     _cls = HyperparameterRangeCategoricalNonBinary

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -39,6 +39,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
     config_space = kwargs['config_space']
     prefix_keys = None
     active_config_space = None
+    strictly_non_binary_choice_hyperparameter_keys = None
     if task_attr is not None:
         from syne_tune.config_space import Categorical
 
@@ -61,9 +62,11 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
         task_param = Categorical(categories=[active_task])
         active_config_space = dict(
             active_config_space, **{task_attr: task_param})
+        strictly_non_binary_choice_hyperparameter_keys = [task_attr]
     return make_hyperparameter_ranges(
         config_space, active_config_space=active_config_space,
-        prefix_keys=prefix_keys)
+        prefix_keys=prefix_keys,
+        strictly_non_binary_choice_hyperparameter_keys=strictly_non_binary_choice_hyperparameter_keys)
 
 
 def create_filter_observed_data_for_warmstarting(


### PR DESCRIPTION
…ary warm-starting task range parameter

*Issue #, if available:*

*Description of changes:* Introduces a new parameter `strictly_non_binary_choice_hyperparameter_keys` to make sure task attr parameter is non-binary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
