### PR TITLE
passing mode to searcher

### DIFF
--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -205,6 +205,7 @@ class FIFOScheduler(ResourceLevelsScheduler):
                 'metric': self.metric,
                 'points_to_evaluate': kwargs.get('points_to_evaluate'),
                 'scheduler_mode': kwargs['mode'],
+                'mode': kwargs['mode'],
                 'random_seed_generator': self.random_seed_generator})
             if self.max_t is not None:
                 search_options['max_epochs'] = self.max_t


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Some searchers such as TPE and BORE require the mode as input, but it's not passed in the FIFO searcher factory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
