### PR TITLE
Add suffix_tuner_name boolian to Tuner

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -77,7 +77,8 @@ class Tuner:
         :param metadata: dictionary of user-metadata that will be persistend in {tuner_path}/metadata.json, in addition
         to the metadata provided by the user, `SMT_TUNER_CREATION_TIMESTAMP` is always included which measures
         the time-stamp when the tuner started to run.
-        :param suffix_tuner_name: If True, a timestamp is appended to the provided `tuner_name` that ensures uniqueness.
+        :param suffix_tuner_name: If True, a timestamp is appended to the provided `tuner_name` that ensures uniqueness
+        otherwise the name is left unchanged and is expected to be unique.
         """
         self.trial_backend = trial_backend
         self.scheduler = scheduler
@@ -95,7 +96,7 @@ class Tuner:
             check_valid_sagemaker_name(tuner_name)
         else:
             tuner_name = Path(self.trial_backend.entrypoint_path()).stem.replace("_", "-")
-        if suffix_tuner_name:
+        if suffix_tuner_name or tuner_name is None:
             self.name = name_from_base(tuner_name, default="st-tuner")
         else:
             self.name = tuner_name


### PR DESCRIPTION
This change allows the user to set the tuner-name as he wants to (name is not altered by the suffix). Because the artifacts are saved in s3 using the tuner-name, this allows the user to have more control over the namings of the s3-paths, as well. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
