### PR TITLE
Code for replaying events to create HyperbandScheduler state (needed …

### DIFF
--- a/examples/launch_nasbench201_simulated.py
+++ b/examples/launch_nasbench201_simulated.py
@@ -66,8 +66,6 @@ if __name__ == "__main__":
         metric=metric,
         random_seed=random_seed,
     )
-    # Make scheduler aware of time_keeper
-    scheduler.set_time_keeper(trial_backend.time_keeper)
 
     max_wallclock_time = 600
     stop_criterion = StoppingCriterion(max_wallclock_time=max_wallclock_time)

--- a/syne_tune/optimizer/schedulers/hb_replay/hyperband_wrapper.py
+++ b/syne_tune/optimizer/schedulers/hb_replay/hyperband_wrapper.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import Optional
+import logging
+
+from syne_tune.optimizer.schedulers import HyperbandScheduler
+from syne_tune.optimizer.scheduler import TrialSuggestion
+from syne_tune.backend.trial_status import Trial
+from syne_tune.optimizer.schedulers.hb_replay.replay_scheduler import (
+    SuggestEvent,
+    ResultEvent,
+    ErrorEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class HyperbandSchedulerWrapper(HyperbandScheduler):
+    r"""
+    Version of :class:`HyperbandScheduler` which records events relevant for
+    replaying. This is useful for testing the replaying code.
+    """
+
+    def __init__(self, config_space, **kwargs):
+        scheduler_type = kwargs.get("type", "stopping")
+        assert scheduler_type == "stopping", (
+            "Replaying only supported for stopping type"
+        )
+        super().__init__(config_space, **kwargs)
+        self.events_to_replay = []
+
+    def suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        suggestion = super().suggest(trial_id)
+        if suggestion is not None:
+            event = SuggestEvent(trial_id=trial_id, config=suggestion.config)
+            self.events_to_replay.append(event)
+            logger.debug(f"Recording {event}")
+        return suggestion
+
+    def on_trial_error(self, trial: Trial):
+        super().on_trial_error(trial)
+        event = ErrorEvent(trial_id=trial.trial_id)
+        self.events_to_replay.append(event)
+        logger.debug(f"Recording {event}")
+
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
+        trial_decision = super().on_trial_result(trial=trial, result=result)
+        event = ResultEvent(trial_id=trial.trial_id, result=result)
+        self.events_to_replay.append(event)
+        logger.debug(f"Recording {event}")
+        return trial_decision

--- a/syne_tune/optimizer/schedulers/hb_replay/replay_scheduler.py
+++ b/syne_tune/optimizer/schedulers/hb_replay/replay_scheduler.py
@@ -1,0 +1,140 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import List, Dict, Optional
+import logging
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.optimizer.scheduler import TrialScheduler, SchedulerDecision
+from syne_tune.optimizer.schedulers import HyperbandScheduler
+
+logger = logging.getLogger(__name__)
+
+
+class TrialEvent:
+    def __init__(self, trial_id: int):
+        self.trial_id = trial_id
+
+    def update_scheduler(
+            self, trial_scheduler: TrialScheduler, config: Optional[Dict] = None
+    ) -> Optional[str]:
+        return None
+
+
+class SuggestEvent(TrialEvent):
+    def __init__(self, trial_id: int, config: Dict):
+        super(SuggestEvent, self).__init__(trial_id=trial_id)
+        self.config = config
+
+    def update_scheduler(
+            self, trial_scheduler: TrialScheduler, config: Optional[Dict] = None
+    ) -> Optional[str]:
+        logger.debug(f"Replaying {self}")
+        # Note: Have to make sure (by using `points_to_evaluate`) that config returned here
+        # is equal to `self.config`.
+        suggestion = trial_scheduler.suggest(trial_id=self.trial_id)
+        assert suggestion.spawn_new_trial_id
+        assert suggestion.checkpoint_trial_id is None
+        trial = Trial(trial_id=self.trial_id, config=self.config, creation_time=None)
+        trial_scheduler.on_trial_add(trial=trial)
+        return None
+
+    def __repr__(self):
+        return f"Suggest(trial_id={self.trial_id}, config={self.config})"
+
+
+class ResultEvent(TrialEvent):
+    def __init__(self, trial_id: int, result: Dict):
+        super(ResultEvent, self).__init__(trial_id=trial_id)
+        self.result = result
+
+    def update_scheduler(
+            self, trial_scheduler: TrialScheduler, config: Optional[Dict] = None
+    ) -> Optional[str]:
+        logger.debug(f"Replaying {self}")
+        trial = Trial(trial_id=self.trial_id, config=config, creation_time=None)
+        trial_decision = trial_scheduler.on_trial_result(
+            trial=trial, result=self.result)
+        return trial_decision
+
+    def __repr__(self):
+        return (f"ResultEvent(trial_id={self.trial_id}, result={self.result})")
+
+
+class ErrorEvent(TrialEvent):
+    def __init__(self, trial_id: int):
+        super(ErrorEvent, self).__init__(trial_id=trial_id)
+
+    def update_scheduler(
+            self, trial_scheduler: TrialScheduler, config: Optional[Dict] = None
+    ) -> Optional[str]:
+        assert config is not None
+        logger.debug(f"Replaying {self}")
+        trial = Trial(trial_id=self.trial_id, config=config, creation_time=None)
+        trial_scheduler.on_trial_error(trial=trial)
+        return None
+
+    def __repr__(self):
+        return (
+            f"ErrorEvent(trial_id={self.trial_id})")
+
+
+def replay_scheduling_events(
+        events_to_replay: List[TrialEvent],
+        config_space: dict,
+        **scheduler_kwargs
+) -> dict:
+    """
+    Creates :class:`HyperbandScheduler` and replays events from
+    `events_to_replay`. We return the resulting scheduler as well as the
+    trial_ids corresponding to :class:`ResultEvent` events resulting in
+    STOP or PAUSE.
+
+    Replaying events is a simple and general way to implement a stateless
+    API.
+
+    :param events_to_replay:
+    :param config_space: Argument for `HyperbandScheduler`
+    :param scheduler_kwargs: Arguments for `HyperbandScheduler`
+    :return: `HyperbandScheduler` object after replaying
+    """
+    # Cannot rely on `suggest` to produce the same config's during replay, so
+    # we use `points_to_evaluate` to enforce the same sequence
+    points_to_evaluate = []
+    expected_trial_id = 0
+    for event in events_to_replay:
+        if isinstance(event, SuggestEvent):
+            assert event.trial_id == expected_trial_id
+            expected_trial_id += 1
+            points_to_evaluate.append(event.config)
+    scheduler_kwargs["points_to_evaluate"] = points_to_evaluate
+    trial_scheduler = HyperbandScheduler(config_space, **scheduler_kwargs)
+    results = []
+    for event in events_to_replay:
+        results.append(event.update_scheduler(
+            trial_scheduler=trial_scheduler,
+            config=points_to_evaluate[event.trial_id],
+        ))
+    # Determine which trial_id's are stopped / paused due to ResultEvent
+    # decisions
+    stopped_trial_ids = set()
+    paused_trial_ids = set()
+    for event, result in zip(events_to_replay, results):
+        if result == SchedulerDecision.STOP:
+            stopped_trial_ids.add(event.trial_id)
+        elif result == SchedulerDecision.PAUSE:
+            paused_trial_ids.add(event.trial_id)
+    return {
+        "trial_scheduler": trial_scheduler,
+        "stopped_trial_ids": list(stopped_trial_ids),
+        "paused_trial_ids": list(paused_trial_ids),
+    }

--- a/syne_tune/optimizer/schedulers/hb_replay/test_hyperband.py
+++ b/syne_tune/optimizer/schedulers/hb_replay/test_hyperband.py
@@ -1,0 +1,108 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import numbers
+from typing import Optional
+
+from syne_tune.optimizer.schedulers.hyperband import (
+    HyperbandScheduler,
+    HyperbandBracketManager,
+)
+from syne_tune.optimizer.schedulers.hyperband_stopping import (
+    RungSystem,
+    RungEntry,
+)
+from syne_tune.optimizer.schedulers.hyperband_promotion import PromotionRungSystem
+from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges import (
+    HyperparameterRanges
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.hp_ranges_factory import (
+    make_hyperparameter_ranges
+)
+
+
+def state_representation_hyperband(trial_scheduler: HyperbandScheduler):
+    """
+     Converts inner state of `HyperbandScheduler` into a representation which
+     can be compared for equality. The mapping is not invertible.
+     Useful for testing, in the context of `replay_scheduling_events`.
+
+     Note: Depends on internals of `HyperbandScheduler` and other classes used
+     there. Use for testing only.
+
+     Note: The representation does not contain information which is irrelevant
+     for comparisons, such as time stamps.
+
+     """
+    hp_ranges = make_hyperparameter_ranges(trial_scheduler.config_space)
+    return {
+        "active_trials": {
+            k: _convert_to_representation(
+                v, hp_ranges, parent_key="active_trials"
+            )
+            for k, v in trial_scheduler._active_trials.items()
+        },
+        "terminator": _convert_to_representation(
+            trial_scheduler.terminator, hp_ranges
+        ),
+        "cost_offset": _convert_to_representation(
+            trial_scheduler._cost_offset, hp_ranges
+        ),
+    }
+
+
+def _convert_to_representation(
+        x,
+        hp_ranges: HyperparameterRanges,
+        parent_key: Optional[str] = None):
+    """
+    :param x:
+    :param hp_ranges: Used to map config's to match strings
+    :param parent_key: Used to identify certain objects for special treatment
+    :return: Representation of x
+    """
+    convert_to_repr = lambda a: _convert_to_representation(a, hp_ranges)
+    if isinstance(x, dict):
+        is_active_trials = (parent_key == 'active_trials')
+        skip_keys = {"config", "time_stamp"} if is_active_trials else set()
+        result = {
+            str(k): convert_to_repr(v) for k, v in x.items()
+            if k not in skip_keys
+        }
+        if is_active_trials:
+            result["config"] = hp_ranges.config_to_match_string(x["config"])
+    elif isinstance(x, list) or isinstance(x, tuple):
+        result = [convert_to_repr(elem) for elem in x]
+    elif isinstance(x, HyperbandBracketManager):
+        supported_types = {"stopping", "promotion"}
+        if x._scheduler_type not in supported_types:
+            raise NotImplementedError(
+                f"Only implement for type in {supported_types}")
+        result = {
+            "task_info": convert_to_repr(x._task_info),
+            "rung_systems": convert_to_repr(x._rung_systems),
+        }
+    elif isinstance(x, RungSystem):
+        result = {"rungs": convert_to_repr(x._rungs)}
+        if isinstance(x, PromotionRungSystem):
+            result["running"] = convert_to_repr(x._running)
+    elif isinstance(x, RungEntry):
+        result = convert_to_repr(x.__dict__)
+    elif x is None:
+        result = "None"
+    elif isinstance(x, bool):
+        result = "True" if x else "False"
+    elif isinstance(x, numbers.Real):
+        result = f"{x:.3e}"
+    else:
+        result = x
+    return result

--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -10,7 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from abc import ABC
 from time import perf_counter
 from typing import Dict, List, Tuple
 import copy
@@ -23,7 +22,7 @@ from syne_tune.constants import ST_DECISION, ST_TRIAL_ID, ST_STATUS, ST_TUNER_TI
 from syne_tune.util import RegularCallback
 
 
-class TunerCallback(ABC):
+class TunerCallback(object):
     def on_tuning_start(self, tuner):
         pass
 

--- a/tst/schedulers/test_hyperband_replay_height.py
+++ b/tst/schedulers/test_hyperband_replay_height.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+
+from syne_tune.backend import LocalBackend
+from syne_tune.optimizer.schedulers.hb_replay.hyperband_wrapper import (
+    HyperbandSchedulerWrapper
+)
+from syne_tune.optimizer.schedulers.hb_replay.replay_scheduler import (
+    replay_scheduling_events
+)
+from syne_tune.optimizer.schedulers.hb_replay.test_hyperband import (
+    state_representation_hyperband
+)
+from syne_tune import Tuner, StoppingCriterion
+from syne_tune.config_space import randint
+from syne_tune.util import repository_root_path
+
+
+def test_hyperband_replay_height():
+    logging.getLogger().setLevel(logging.INFO)
+
+    random_seed = 31415927
+    max_steps = 100
+    n_workers = 4
+
+    config_space = {
+        "steps": max_steps,
+        "width": randint(0, 20),
+        "height": randint(-100, 100),
+        "sleep_time": 0.01,
+    }
+    entry_point = (
+        repository_root_path()
+        / "examples"
+        / "training_scripts"
+        / "height_example"
+        / "train_height.py"
+    )
+    mode = "min"
+    metric = "mean_loss"
+
+    # Run experiment to record events and build up scheduler state
+    print("\n*** Run experiment and record events ***\n")
+    trial_backend = LocalBackend(entry_point=str(entry_point))
+    stop_criterion = StoppingCriterion(max_wallclock_time=3)
+    scheduler_kwargs = dict(
+        metric= metric,
+        mode=mode,
+        searcher="random",
+        resource_attr="epoch",
+        max_t=max_steps,
+        search_options={"debug_log": False},
+    )
+    scheduler = HyperbandSchedulerWrapper(config_space, **scheduler_kwargs)
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        scheduler=scheduler,
+        stop_criterion=stop_criterion,
+        n_workers=n_workers,
+    )
+    tuner.run()
+
+    # Replay recorded events
+    print("\n*** Replay events ***\n")
+    original_state = state_representation_hyperband(scheduler)
+    replayed_scheduler = replay_scheduling_events(
+        events_to_replay=scheduler.events_to_replay,
+        config_space=config_space,
+        **scheduler_kwargs
+    )["trial_scheduler"]
+    replayed_state = state_representation_hyperband(replayed_scheduler)
+
+    print("\n*** Compare scheduler states ***\n")
+    assert original_state == replayed_state, (
+        "States are different! original_state:\n" + repr(original_state)
+        + "\nreplayed_state:\n" + repr(replayed_state)
+    )
+    print("OK, original and replayed state are the same")

--- a/tst/schedulers/test_hyperband_replay_nasbench201.py
+++ b/tst/schedulers/test_hyperband_replay_nasbench201.py
@@ -1,0 +1,157 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+import copy
+import pytest
+
+from benchmarking.definitions.definition_nasbench201 import (
+    nasbench201_default_params,
+    nasbench201_benchmark,
+)
+from syne_tune.blackbox_repository import BlackboxRepositoryBackend
+from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
+from syne_tune import Tuner, StoppingCriterion
+from syne_tune.optimizer.schedulers.hb_replay.hyperband_wrapper import (
+    HyperbandSchedulerWrapper
+)
+from syne_tune.optimizer.schedulers.hb_replay.replay_scheduler import (
+    replay_scheduling_events
+)
+from syne_tune.optimizer.schedulers.hb_replay.test_hyperband import (
+    state_representation_hyperband
+)
+
+
+class RecordedEventsSimulatorCallback(SimulatorCallback):
+    """
+    On top of :class:`SimulatorCallback`, this is also storing recorded
+    events and scheduler state several times during the course of the
+    experiment, which runs for `max_wallclock_time` seconds.
+    """
+
+    def __init__(
+            self,
+            max_wallclock_time: float,
+            num_writeout: int = 10
+    ):
+        super().__init__()
+        self._max_wallclock_time = max_wallclock_time
+        self._num_writeout = num_writeout
+        self._period_between_writeout = max_wallclock_time / num_writeout
+        self.events_and_states = []
+        self._next_threshold = self._period_between_writeout
+
+    def on_tuning_start(self, tuner: "Tuner"):
+        super().on_tuning_start(tuner=tuner)
+        assert isinstance(tuner.scheduler, HyperbandSchedulerWrapper)
+
+    def _writeout_event_and_state(self):
+        scheduler = self._tuner.scheduler
+        scheduler_state = state_representation_hyperband(scheduler)
+        self.events_and_states.append(
+            (copy.copy(scheduler.events_to_replay), scheduler_state)
+        )
+
+    def on_tuning_sleep(self, sleep_time: float):
+        super().on_tuning_sleep(sleep_time)
+        current_time = self._time_keeper.time()
+        if current_time >= self._next_threshold:
+            self._next_threshold += self._period_between_writeout
+            self._writeout_event_and_state()
+
+    def on_tuning_end(self):
+        if len(self.events_and_states) < self._num_writeout:
+            self._writeout_event_and_state()
+        # Resets `self._tuner`, so call here only
+        super().on_tuning_end()
+
+
+# This test runs very fast, but needs the nasbench201 files to be downloaded
+# for the blackbox repository, which can take a long time
+@pytest.mark.skip("Needs blackbox repository")
+def test_hyperband_replay_nasbench201():
+    logging.getLogger().setLevel(logging.INFO)
+
+    random_seed = 31415927
+    n_workers = 4
+    default_params = nasbench201_default_params({"backend": "simulated"})
+    benchmark = nasbench201_benchmark(default_params)
+    # Benchmark must be tabulated to support simulation:
+    assert benchmark.get("supports_simulated", False)
+    config_space = benchmark["config_space"]
+    mode = benchmark["mode"]
+    metric = benchmark["metric"]
+    blackbox_name = benchmark.get("blackbox_name")
+    # NASBench201 is a blackbox from the repository
+    assert blackbox_name is not None
+    dataset_name = "cifar100"
+
+    # Simulator back-end specialized to tabulated blackboxes
+    trial_backend = BlackboxRepositoryBackend(
+        blackbox_name=blackbox_name,
+        elapsed_time_attr=benchmark["elapsed_time_attr"],
+        time_this_resource_attr=benchmark.get("time_this_resource_attr"),
+        dataset=dataset_name,
+    )
+
+    # Run experiment to record events and build up scheduler state
+    print("\n*** Run experiment and record events ***\n")
+    scheduler_kwargs = dict(
+        searcher="random",
+        max_t=default_params["max_resource_level"],
+        grace_period=default_params["grace_period"],
+        reduction_factor=default_params["reduction_factor"],
+        resource_attr=benchmark["resource_attr"],
+        mode=mode,
+        metric=metric,
+        random_seed=random_seed,
+        search_options={"debug_log": False},
+    )
+    scheduler = HyperbandSchedulerWrapper(config_space, **scheduler_kwargs)
+    max_wallclock_time = 600
+    stop_criterion = StoppingCriterion(max_wallclock_time=max_wallclock_time)
+    print_update_interval = 700
+    results_update_interval = 300
+    # It is important to set `sleep_time` to 0 here (mandatory for simulator
+    # backend)
+    events_callback = RecordedEventsSimulatorCallback(
+        max_wallclock_time=max_wallclock_time
+    )
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        scheduler=scheduler,
+        stop_criterion=stop_criterion,
+        n_workers=n_workers,
+        sleep_time=0,
+        results_update_interval=results_update_interval,
+        print_update_interval=print_update_interval,
+        callbacks=[events_callback],
+    )
+    tuner.run()
+
+    # For each writeout: Replay events and compare states
+    for ind, (events_to_replay, scheduler_state) in enumerate(
+            events_callback.events_and_states):
+        print(f"\n*** Writeout {ind}: Replay events ***\n")
+        replayed_scheduler = replay_scheduling_events(
+            events_to_replay=events_to_replay,
+            config_space=config_space,
+            **scheduler_kwargs
+        )["trial_scheduler"]
+        replayed_state = state_representation_hyperband(replayed_scheduler)
+        print(f"\n*** Writeout {ind}: Compare scheduler states ***\n")
+        assert scheduler_state == replayed_state, (
+                "States are different! scheduler_state:\n" + repr(scheduler_state)
+                + "\nreplayed_state:\n" + repr(replayed_state)
+        )
+        print("OK, original and replayed state are the same")


### PR DESCRIPTION
…for a stateless API)

*Issue #, if available:*

*Description of changes:*
This code is used to allow for a stateless API for HyperbandScheduler, which is needed by our partners. I also include quite some code to test this, in particular you can compare the inner states between running an experiment normally and replaying it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
