### PR TITLE
Bump GluonTS version in example

### DIFF
--- a/examples/training_scripts/gluonts/requirements.txt
+++ b/examples/training_scripts/gluonts/requirements.txt
@@ -1,1 +1,1 @@
-gluonts==0.8.1
+gluonts==0.9.5

--- a/examples/training_scripts/gluonts/train_gluonts.py
+++ b/examples/training_scripts/gluonts/train_gluonts.py
@@ -10,9 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-"""
-Train a Cartpole with PPO using Ray, the discount factor can be tuned.
-"""
+
 import logging
 
 from gluonts.evaluation import make_evaluation_predictions, Evaluator


### PR DESCRIPTION
*Description of changes:* Bumping the GluonTS version to the latest 0.9.5 release in the example's requirements. I tested this locally. The 0.9.x release branch of GluonTS does not have breaking changes that are relevant to this example, and the latest 0.9.5 brought back support for Python 3.6 (which some still use).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
