### PR TITLE
Control Decision for Running Trials When Stopping Criterion is Met

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -53,7 +53,7 @@ class Tuner:
         max_failures: int = 1,
         tuner_name: Optional[str] = None,
         asynchronous_scheduling: bool = True,
-        stop_immediately_when_stopping_criterion_met: bool = True,
+        wait_trial_completion_when_stopping: bool = True,
         callbacks: Optional[List[TunerCallback]] = None,
         metadata: Optional[Dict] = None,
         suffix_tuner_name: bool = True,
@@ -77,8 +77,8 @@ class Tuner:
         :param asynchronous_scheduling: whether to use asynchronous scheduling when scheduling new trials. If `True`,
         trials are scheduled as soon as a worker is available, if `False`, the tuner waits that all trials are finished
          before scheduling a new batch.
-        :param stop_immediately_when_stopping_criterion_met: how to deal with running trials when stopping criterion is
-        met. If `True`, all trials are terminated, if `False`, the tuner waits that all trials are finished.
+        :param wait_trial_completion_when_stopping: how to deal with running trials when stopping criterion is
+        met. If `True`, the tuner waits that all trials are finished, if `False`, all trials are terminated.
         :param callbacks: called when events happens in the tuning loop such as when a result is seen, by default
         a callback that stores results every `results_update_interval` is used.
         :param metadata: dictionary of user-metadata that will be persistend in {tuner_path}/metadata.json, in addition
@@ -94,9 +94,7 @@ class Tuner:
         self.results_update_interval = results_update_interval
         self.stop_criterion = stop_criterion
         self.asynchronous_scheduling = asynchronous_scheduling
-        self.stop_immediately_when_stopping_criterion_met = (
-            stop_immediately_when_stopping_criterion_met
-        )
+        self.wait_trial_completion_when_stopping = wait_trial_completion_when_stopping
         self.metadata = self._enrich_metadata(metadata)
 
         self.max_failures = max_failures
@@ -197,7 +195,7 @@ class Tuner:
 
                 if (
                     config_space_exhausted
-                    or self.stop_immediately_when_stopping_criterion_met
+                    or not self.wait_trial_completion_when_stopping
                     and stop_condition_reached
                 ):
                     # if the search space is exhausted, we loop until the running trials are done or until the

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -94,7 +94,9 @@ class Tuner:
         self.results_update_interval = results_update_interval
         self.stop_criterion = stop_criterion
         self.asynchronous_scheduling = asynchronous_scheduling
-        self.stop_immediately_when_stopping_criterion_met = stop_immediately_when_stopping_criterion_met
+        self.stop_immediately_when_stopping_criterion_met = (
+            stop_immediately_when_stopping_criterion_met
+        )
         self.metadata = self._enrich_metadata(metadata)
 
         self.max_failures = max_failures
@@ -193,8 +195,11 @@ class Tuner:
                 done_trials_statuses.update(new_done_trial_statuses)
                 running_trials_ids.difference_update(new_done_trial_statuses.keys())
 
-                if config_space_exhausted or \
-                        self.stop_immediately_when_stopping_criterion_met and stop_condition_reached:
+                if (
+                    config_space_exhausted
+                    or self.stop_immediately_when_stopping_criterion_met
+                    and stop_condition_reached
+                ):
                     # if the search space is exhausted, we loop until the running trials are done or until the
                     # stop condition is reached
                     if len(running_trials_ids) > 0:


### PR DESCRIPTION
*Description of changes:* An argument to the Tuner was added which allows to control how to deal with running trials when the stopping criterion is met.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
