### PR TITLE
Fix bug of debug_log on RandomSearcher

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -420,9 +420,6 @@ class RandomSearcher(SearcherWithRandomSeed):
         A new configuration that is valid, or None if no new config can be
         suggested.
         """
-        trial_id = kwargs.get("trial_id")
-        if self._debug_log is not None:
-            self._debug_log.start_get_config("random", trial_id=trial_id)
         new_config = self._next_initial_config()
         if new_config is None:
             if not self._excl_list.config_space_exhausted():
@@ -435,6 +432,8 @@ class RandomSearcher(SearcherWithRandomSeed):
         if new_config is not None:
             self._excl_list.add(new_config)  # Should not be suggested again
             if self._debug_log is not None:
+                trial_id = kwargs.get("trial_id")
+                self._debug_log.start_get_config("random", trial_id=trial_id)
                 self._debug_log.set_final_config(new_config)
                 # All get_config debug log info is only written here
                 self._debug_log.write_block()


### PR DESCRIPTION
* Prevent debug_log from opening a block and not closing it

Co-authored-by: Po-Wen(Jack) Chen <powenc@amazon.com>

*Issue #, if available:*

*Description of changes:*

In RandomSearcher's `get_config()`, the `_debug_log` will open a block with first `start_get_config("random", trial_id=trial_id)`
However, if the new_config is None, it will enter the else statement,
and the block will never have a chance to be written.
So I moved the `self._debug_log.start_get_config("random", trial_id=trial_id)` to make sure we could get a new_config and then open/write the block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
