### PR TITLE
Revert wait_trial_completion_when_stopping to False

### DIFF
--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -54,7 +54,7 @@ class Tuner:
         max_failures: int = 1,
         tuner_name: Optional[str] = None,
         asynchronous_scheduling: bool = True,
-        wait_trial_completion_when_stopping: bool = True,
+        wait_trial_completion_when_stopping: bool = False,
         callbacks: Optional[List[TunerCallback]] = None,
         metadata: Optional[Dict] = None,
         suffix_tuner_name: bool = True,


### PR DESCRIPTION
*Description of changes:* this change revert to not wait trial completion when stopping condition is met as it is the standard behavior in other packages and may surprise users who gives a maximum budget in the stopping condition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
