### PR TITLE
Integrate Yahpo to blackbox repository, add example to show how to ru…

### DIFF
--- a/examples/launch_asha_yahpo.py
+++ b/examples/launch_asha_yahpo.py
@@ -1,0 +1,137 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""
+Example for running ASHA with 4 workers with the simulator back-end based on three Yahpo surrogate benchmarks.
+"""
+import logging
+from dataclasses import dataclass
+
+import matplotlib.pyplot as plt
+
+from syne_tune.blackbox_repository import BlackboxRepositoryBackend
+from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
+from syne_tune.experiments import load_experiment
+from syne_tune.optimizer.baselines import ASHA
+from syne_tune import Tuner, StoppingCriterion
+
+
+def plot_yahpo_learning_curves(
+    trial_backend, benchmark: str, time_col: str, metric_col: str
+):
+    bb = trial_backend.blackbox
+    plt.figure()
+    plt.title(
+        f"Learning curves from Yahpo {benchmark} for 10 different hyperparameters."
+    )
+    for i in range(10):
+        config = {k: v.sample() for k, v in bb.configuration_space.items()}
+        evals = bb(config)
+        time_index = next(
+            i for i, name in enumerate(bb.objectives_names) if name == time_col
+        )
+        accuracy_index = next(
+            i for i, name in enumerate(bb.objectives_names) if name == metric_col
+        )
+        import numpy as np
+
+        if np.diff(evals[:, time_index]).min() < 0:
+            print("negative time between two different steps...")
+        plt.plot(evals[:, time_index], evals[:, accuracy_index])
+    plt.xlabel(time_col)
+    plt.ylabel(metric_col)
+    plt.show()
+
+
+@dataclass
+class BenchmarkInfo:
+    blackbox_name: str
+    elapsed_time_attr: str
+    metric: str
+    dataset: str
+    mode: str
+    max_t: int
+    resource_attr: str
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+
+    benchmark_infos = {
+        "nb301": BenchmarkInfo(
+            elapsed_time_attr="runtime",
+            metric="val_accuracy",
+            blackbox_name="yahpo-nb301",
+            dataset="CIFAR10",
+            mode="max",
+            max_t=97,
+            resource_attr="epoch",
+        ),
+        "lcbench": BenchmarkInfo(
+            elapsed_time_attr="time",
+            metric="val_accuracy",
+            blackbox_name="yahpo-lcbench",
+            dataset="3945",
+            mode="max",
+            max_t=51,
+            resource_attr="epoch",
+        ),
+        "fcnet": BenchmarkInfo(
+            elapsed_time_attr="runtime",
+            metric="valid_mse",
+            blackbox_name="yahpo-fcnet",
+            dataset="fcnet_naval_propulsion",
+            mode="min",
+            max_t=99,
+            resource_attr="epoch",
+        ),
+    }
+    for benchmark in ["nb301", "lcbench", "fcnet"]:
+        benchmark_info = benchmark_infos[benchmark]
+
+        trial_backend = BlackboxRepositoryBackend(
+            blackbox_name=benchmark_info.blackbox_name,
+            elapsed_time_attr=benchmark_info.elapsed_time_attr,
+            dataset=benchmark_info.dataset,
+        )
+
+        plot_yahpo_learning_curves(
+            trial_backend,
+            benchmark=benchmark,
+            time_col=benchmark_info.elapsed_time_attr,
+            metric_col=benchmark_info.metric,
+        )
+
+        scheduler = ASHA(
+            config_space=trial_backend.blackbox.configuration_space,
+            max_t=benchmark_info.max_t,
+            resource_attr=benchmark_info.resource_attr,
+            mode=benchmark_info.mode,
+            metric=benchmark_info.metric,
+        )
+
+        stop_criterion = StoppingCriterion(max_num_trials_started=200)
+
+        tuner = Tuner(
+            trial_backend=trial_backend,
+            scheduler=scheduler,
+            stop_criterion=stop_criterion,
+            n_workers=4,
+            sleep_time=0,
+            print_update_interval=10,
+            callbacks=[SimulatorCallback()],
+            tuner_name=f"ASHA-Yahpo-{benchmark}",
+        )
+        tuner.run()
+
+        tuning_experiment = load_experiment(tuner.name)
+        tuning_experiment.plot()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ required_kde = load_requirements("requirements-kde.txt")
 required_blackbox_repository = load_requirements(
     "syne_tune/blackbox_repository/requirements.txt"
 )
+required_yahpo = load_requirements(
+    "syne_tune/blackbox_repository/conversion_scripts/scripts/requirements-yahpo.txt"
+)
 required_benchmarks = load_benchmark_requirements()
 required_dev = load_requirements("requirements-dev.txt")
 required_aws = load_requirements("requirements-aws.txt")
@@ -45,6 +48,7 @@ required_extra = (
     + required_botorch
     + required_dev
     + required_aws
+    + required_yahpo
 )
 setup(
     name="syne_tune",
@@ -67,6 +71,7 @@ setup(
         "benchmarks": required_benchmarks,
         "blackbox-repository": required_blackbox_repository,
         "aws": required_aws,
+        "yahpo": required_yahpo,
         "extra": required_extra,
     },
     install_requires=required_core,

--- a/syne_tune/blackbox_repository/conversion_scripts/recipes.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/recipes.py
@@ -24,6 +24,11 @@ from syne_tune.blackbox_repository.conversion_scripts.scripts.fcnet_import impor
     FCNETRecipe,
 )
 
+from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
+    YAHPORecipe,
+    yahpo_scenarios,
+)
+
 # add a blackbox recipe here to expose it in Syne Tune
 recipes = [
     DeepARRecipe(),
@@ -32,5 +37,9 @@ recipes = [
     FCNETRecipe(),
     LCBenchRecipe(),
 ]
+
+for scenario in yahpo_scenarios:
+    recipes.append(YAHPORecipe("yahpo-" + scenario))
+
 
 generate_blackbox_recipes = {recipe.name: recipe for recipe in recipes}

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/requirements-yahpo.txt
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/requirements-yahpo.txt
@@ -1,0 +1,5 @@
+onnxruntime>=1.10.0
+pyyaml
+configspace
+pandas
+yahpo-gym

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -1,0 +1,271 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Wrap Surrogates from 
+YAHPO Gym - An Efficient Multi-Objective Multi-Fidelity Benchmark for Hyperparameter Optimization
+Florian Pfisterer, Lennart Schneider, Julia Moosbauer, Martin Binder, Bernd Bischl
+"""
+import logging
+import shutil
+
+from yahpo_gym import benchmark_set
+import numpy as np
+import zipfile
+from pathlib import Path
+
+from syne_tune.blackbox_repository.conversion_scripts.blackbox_recipe import (
+    BlackboxRecipe,
+)
+from syne_tune.blackbox_repository.conversion_scripts.scripts import (
+    default_metric,
+    metric_elapsed_time,
+    resource_attr,
+)
+from syne_tune.blackbox_repository.conversion_scripts.utils import repository_path
+from syne_tune.blackbox_repository.serialize import (
+    serialize_metadata,
+)
+import syne_tune.config_space as cs
+from syne_tune.blackbox_repository.blackbox import Blackbox
+from typing import Dict, Optional
+
+
+import ConfigSpace
+from yahpo_gym.benchmark_set import BenchmarkSet
+from yahpo_gym.configuration import list_scenarios
+from yahpo_gym import local_config
+
+from syne_tune.constants import ST_WORKER_ITER
+
+
+def download(target_path: Path, version: str):
+    import urllib
+
+    root = "https://github.com/slds-lmu/yahpo_data/archive/refs/tags/"
+
+    target_file = target_path / f"yahpo_data-{version}"
+    if not target_file.exists():
+        logging.info(f"File {target_file} not found redownloading it.")
+        urllib.request.urlretrieve(root + f"v{version}.zip", str(target_path) + ".zip")
+        with zipfile.ZipFile(str(target_path) + ".zip", "r") as zip_ref:
+            zip_ref.extractall(target_path)
+    else:
+        logging.info(f"File {target_file} found, skipping download.")
+
+
+class BlackBoxYAHPO(Blackbox):
+    """
+    A wrapper that allows putting a 'YAHPO' BenchmarkInstance into a Blackbox.
+    """
+
+    def __init__(self, benchmark):
+        self.benchmark = benchmark
+        super(BlackBoxYAHPO, self).__init__(
+            configuration_space=cs_to_synetune(
+                self.benchmark.get_opt_space(drop_fidelity_params=True)
+            ),
+            fidelity_space=cs_to_synetune(self.benchmark.get_fidelity_space()),
+            objectives_names=self.benchmark.config.y_names,
+        )
+
+    def _objective_function(
+        self,
+        configuration: Dict,
+        fidelity: Optional[Dict] = None,
+        seed: Optional[int] = None,
+    ) -> Dict:
+        if fidelity is not None:
+            configuration.update(fidelity)
+            return self.benchmark.objective_function(configuration, seed)[0]
+        else:
+            """
+            copying the parent comment of the parent class:
+            "not passing a fidelity is possible if either the blackbox does not have a fidelity space
+            or if it has a single fidelity in its fidelity space. In the latter case, all fidelities are returned in form
+            of a tensor with shape (num_fidelities, num_objectives)."
+            This is used for efficiency (it is much faster to retrieve a full row in an array in term of read time).
+            """
+            # returns a tensor of shape (num_fidelities, num_objectives)
+            num_fidelities = len(self.fidelity_values)
+            num_objectives = len(self.objectives_names)
+            result = np.empty((num_fidelities, num_objectives))
+            fidelity_name = next(iter(self.fidelity_space.keys()))
+            configs = []
+            for fidelity in self.fidelity_values:
+                config_with_fidelity = configuration.copy()
+                config_with_fidelity[fidelity_name] = fidelity
+                configs.append(config_with_fidelity)
+            result_dicts = self.benchmark.objective_function(configs, seed=seed)
+
+            for i, fidelity in enumerate(self.fidelity_values):
+                result[i] = [
+                    result_dicts[i][objective] for objective in self.objectives_names
+                ]
+
+            return result
+
+    def set_instance(self, instance):
+        """
+        Set an instance for the underlying YAHPO Benchmark.
+        """
+        # Set the instance in the benchmark
+        self.benchmark.set_instance(instance)
+        # Update the configspace with the fixed instance
+        if self.benchmark.config.instance_names:
+            instance_names = self.benchmark.config.instance_names
+        else:
+            instance_names = "instance-names"
+        self.configuration_space[instance_names] = cs.choice([instance])
+        return self
+
+    @property
+    def instances(self) -> np.array:
+        return self.benchmark.instances
+
+    @property
+    def fidelity_values(self) -> np.array:
+        fids = next(iter(self.fidelity_space.values()))
+        return np.arange(fids.lower, fids.upper)
+
+    @property
+    def time_attribute(self) -> str:
+        """Name of the time column"""
+        return self.benchmark.config.runtime_name
+
+
+def cs_to_synetune(config_space):
+    """
+    Convert ConfigSpace.ConfigSpace to a synetune configspace.
+
+    This should probably either be improved or we could also dump the 'synetune-configspaces' in 'yahpo_data'
+    like we did for R (paradox) configspaces.
+    Currently this does not cover all possible hyperparameters I think.
+    """
+    hps = config_space.get_hyperparameters()
+
+    keys = []
+    vals = []
+    for a in hps:
+        keys += [a.name]
+        if isinstance(a, ConfigSpace.hyperparameters.CategoricalHyperparameter):
+            vals += [cs.choice(a.choices)]
+        if isinstance(a, ConfigSpace.hyperparameters.Constant):
+            vals += [cs.choice([a.value])]
+        if isinstance(a, ConfigSpace.hyperparameters.UniformIntegerHyperparameter):
+            if a.log:
+                vals += [cs.lograndint(a.lower, a.upper)]
+            else:
+                vals += [cs.randint(a.lower, a.upper)]
+        if isinstance(a, ConfigSpace.hyperparameters.UniformFloatHyperparameter):
+            if a.log:
+                vals += [cs.loguniform(a.lower, a.upper)]
+            else:
+                vals += [cs.uniform(a.lower, a.upper)]
+
+    # FIXME: This should also handle dependencies between hyperparameters.
+    return dict(zip(keys, vals))
+
+
+def instantiate_yahpo(scenario: str):
+    assert scenario.startswith("yahpo")
+    scenario = scenario[6:]
+
+    local_config.init_config()
+    local_config.set_data_path(str(repository_path / "yahpo"))
+
+    # Select a Benchmark, active_session False because the ONNX session can not be serialized.
+    bench = benchmark_set.BenchmarkSet(scenario, active_session=False)
+
+    # FIXME: I can now create one scenario per instance but this is probably
+    #        overkill since its just a copy of the same thing with a different constant set?
+    return {
+        instance: BlackBoxYAHPO(
+            BenchmarkSet(scenario, active_session=False, check=False)
+        ).set_instance(instance)
+        for instance in bench.instances
+    }
+
+
+def serialize_yahpo(scenario: str, version: str = "1.0"):
+    """
+    Serialize YAHPO (Metadata only for now)
+    """
+    assert scenario.startswith("yahpo-")
+    scenario = scenario[6:]
+
+    # download yahpo metadata and surrogate
+    download(version=version, target_path=repository_path)
+
+    target_path = repository_path / f"yahpo" / scenario
+
+    # copy files to yahpo-scenario
+    if target_path.exists():
+        shutil.rmtree(target_path)
+    shutil.copytree(
+        str(repository_path / f"yahpo_data-{version}" / scenario), str(target_path)
+    )
+
+    # For now we only serialize metadata because everything else can be obtained from YAHPO.
+    serialize_metadata(
+        path=target_path,
+        metadata={
+            metric_elapsed_time: "time",
+            default_metric: "val_accuracy",
+            resource_attr: ST_WORKER_ITER,  # TODO, ressource not present, we can use ST_WORKER_ITER
+        },
+    )
+
+
+class YAHPORecipe(BlackboxRecipe):
+    def __init__(self, name: str):
+        self.scenario = name
+        super(YAHPORecipe, self).__init__(
+            name=name,
+            cite_reference="YAHPO Gym - An Efficient Multi-Objective Multi-Fidelity Benchmark for Hyperparameter Optimization. "
+            "Pfisterer F., Schneider S., Moosbauer J., Binder M., Bischl B., 2022",
+        )
+
+    def _generate_on_disk(self):
+        serialize_yahpo(self.scenario)
+
+
+yahpo_scenarios = list_scenarios()
+
+
+if __name__ == "__main__":
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    scenario = "lcbench"
+
+    YAHPORecipe(f"yahpo-{scenario}").generate()
+
+    # plot one learning-curve for sanity-check
+    from syne_tune.blackbox_repository import load_blackbox
+
+    bb_dict = load_blackbox(f"yahpo-{scenario}", skip_if_present=False)
+    first_task = next(iter(bb_dict.keys()))
+    b = bb_dict[first_task]
+    configuration = {k: v.sample() for k, v in b.configuration_space.items()}
+    errors = []
+    runtime = []
+
+    import matplotlib.pyplot as plt
+
+    for i in range(1, 52):
+        res = b.objective_function(configuration=configuration, fidelity={"epoch": i})
+        errors.append(res["val_accuracy"])
+        runtime.append(res["time"])
+
+    plt.plot(np.cumsum(runtime), errors)
+    plt.show()

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -30,6 +30,10 @@ from syne_tune.blackbox_repository.blackbox_tabular import (
     deserialize as deserialize_tabular,
 )
 
+from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
+    instantiate_yahpo,
+)
+
 # where the blackbox repository is stored on s3
 from syne_tune.blackbox_repository.conversion_scripts.recipes import (
     generate_blackbox_recipes,
@@ -113,6 +117,8 @@ def load_blackbox(
             )
             generate_blackbox_recipes[name].generate(s3_root=s3_root)
 
+    if name.startswith("yahpo"):
+        return instantiate_yahpo(name)
     if (tgt_folder / "hyperparameters.parquet").exists():
         return deserialize_tabular(tgt_folder)
     else:

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -62,7 +62,7 @@ class ExperimentResult:
             plt.plot(x, y, **plt_kwargs)
             plt.xlabel("wallclock time")
             plt.ylabel(metric)
-            plt.title(self.entrypoint_name() + " " + self.name)
+            plt.title(f"Best result over time {self.name}")
             plt.legend()
             plt.show()
 


### PR DESCRIPTION
…n ASHA on three epoch-based benchmarks

*Issue #, if available:* https://github.com/awslabs/syne-tune/issues/326

*Description of changes:* 
* Make Yahpo benchmarks available in syne-tune and integrate them in blackbox-repository for easy access. 
* One example showing how to run ASHA on lcbench, fcnet and Nas301 benchmarks

This work is partly based on https://github.com/awslabs/syne-tune/pull/301, I opened a new PR for simplicity given a few merge conflicts.

@pfistl: I cannot add you as a reviewer because you are not in the project, could you still review the PR?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
