### PR TITLE
Avoid experiment abort due to throttling of SageMaker job launching

### DIFF
--- a/benchmarking/cli/estimator_factory.py
+++ b/benchmarking/cli/estimator_factory.py
@@ -16,7 +16,10 @@ from sagemaker.huggingface import HuggingFace
 from sagemaker.estimator import Framework
 
 from syne_tune.backend.sagemaker_backend.custom_framework import CustomFramework
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,7 @@ def sagemaker_estimator_factory(
         instance_type=instance_type,
         instance_count=instance_count,
         role=role,
+        sagemaker_session=default_sagemaker_session(),
     )
     if dependencies is not None:
         common_kwargs["dependencies"] = dependencies

--- a/benchmarking/nursery/remote_sm_backend/launch_experiment.py
+++ b/benchmarking/nursery/remote_sm_backend/launch_experiment.py
@@ -16,7 +16,10 @@ from argparse import ArgumentParser
 from sagemaker.pytorch import PyTorch
 
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import ASHA
 from syne_tune.stopping_criterion import StoppingCriterion
 from syne_tune.tuner import Tuner
@@ -80,6 +83,7 @@ if __name__ == "__main__":
             max_run=2 * args.max_wallclock_time,
             dependencies=[str(repository_root_path() / "benchmarking/")],
             disable_profiler=True,
+            sagemaker_session=default_sagemaker_session(),
         ),
         # names of metrics to track. Each metric will be detected by Sagemaker if it is written in the
         # following form: "[RMSE]: 1.2", see in train_main_example how metrics are logged for an example

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -268,7 +268,7 @@ If you run experiments with tabulated benchmarks using the `SimulatorBackend`, a
 
 ### <a name="remote-tuning"></a> I don’t want to wait, how can I launch the tuning on a remote machine?
 
-You can use the remote launcher to launch a tuning on a remote machine. The remote launcher supports both `LocalBackend` and `SagemakerBackend`. In the former case, multiple trials will be evaluated on the remote machine (one use-case being to use a beefy machine), in the latter case trials will be evaluated as separate SageMaker training jobs.
+You can use the remote launcher to launch a tuning on a remote machine. The remote launcher supports both `LocalBackend` and `SageMakerBackend`. In the former case, multiple trials will be evaluated on the remote machine (one use-case being to use a beefy machine), in the latter case trials will be evaluated as separate SageMaker training jobs.
 
 See for an example on how to run tuning with the remote launcher: [launch_height_sagemaker_remotely.py](https://github.com/awslabs/syne-tune/blob/main/examples/launch_height_sagemaker_remotely.py)
 

--- a/docs/tutorials/basics/scripts/launch_sagemaker_backend.py
+++ b/docs/tutorials/basics/scripts/launch_sagemaker_backend.py
@@ -28,7 +28,10 @@ from sagemaker.pytorch import PyTorch
 
 from syne_tune.config_space import randint, uniform, loguniform
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.schedulers import HyperbandScheduler
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.util import repository_root_path
@@ -91,6 +94,7 @@ if __name__ == "__main__":
             framework_version="1.7.1",
             py_version="py3",
             disable_profiler=True,
+            sagemaker_session=default_sagemaker_session(),
         ),
         metrics_names=[metric],
     )

--- a/examples/launch_height_sagemaker.py
+++ b/examples/launch_height_sagemaker.py
@@ -19,7 +19,10 @@ from pathlib import Path
 from sagemaker.pytorch import PyTorch
 
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.config_space import randint
@@ -61,6 +64,7 @@ if __name__ == "__main__":
             max_run=10 * 60,
             framework_version="1.7.1",
             py_version="py3",
+            sagemaker_session=default_sagemaker_session(),
         ),
         # names of metrics to track. Each metric will be detected by Sagemaker if it is written in the
         # following form: "[RMSE]: 1.2", see in train_main_example how metrics are logged for an example

--- a/examples/launch_height_sagemaker_custom_image.py
+++ b/examples/launch_height_sagemaker_custom_image.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 from syne_tune.backend.sagemaker_backend.custom_framework import CustomFramework
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.config_space import randint
@@ -62,6 +65,7 @@ if __name__ == "__main__":
             image_uri=image_uri,
             max_run=10 * 60,
             job_name_prefix="hpo-hyperband",
+            sagemaker_session=default_sagemaker_session(),
         ),
         # names of metrics to track. Each metric will be detected by Sagemaker if it is written in the
         # following form: "[RMSE]: 1.2", see in train_main_example how metrics are logged for an example

--- a/examples/launch_height_sagemaker_remotely.py
+++ b/examples/launch_height_sagemaker_remotely.py
@@ -20,7 +20,10 @@ from pathlib import Path
 from sagemaker.pytorch import PyTorch
 
 from syne_tune.backend import LocalBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune.remote.remote_launcher import RemoteLauncher
 from syne_tune.backend import SageMakerBackend
@@ -63,6 +66,7 @@ if __name__ == "__main__":
                 framework_version="1.6",
                 py_version="py3",
                 base_job_name="hpo-height",
+                sagemaker_session=default_sagemaker_session(),
             ),
         )
     else:

--- a/examples/launch_huggingface_classification.py
+++ b/examples/launch_huggingface_classification.py
@@ -20,7 +20,10 @@ from sagemaker.huggingface import HuggingFace
 
 import syne_tune
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner, StoppingCriterion
 
@@ -56,6 +59,7 @@ if __name__ == "__main__":
         py_version="py36",
         role=get_execution_role(),
         dependencies=[root / "benchmarking"],
+        sagemaker_session=default_sagemaker_session(),
     )
 
     # SageMaker backend

--- a/examples/launch_moasha_instance_tuning.py
+++ b/examples/launch_moasha_instance_tuning.py
@@ -20,7 +20,10 @@ from sagemaker.huggingface import HuggingFace
 
 from syne_tune.backend.sagemaker_backend.instance_info import select_instance_type
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.constants import ST_WORKER_TIME, ST_WORKER_COST
 from syne_tune.optimizer.schedulers.multiobjective import MOASHA
 from syne_tune.remote.remote_launcher import RemoteLauncher
@@ -79,6 +82,7 @@ if __name__ == "__main__":
             max_run=3600,
             role=get_execution_role(),
             dependencies=[str(Path(__file__).parent.parent / "benchmarking")],
+            sagemaker_session=default_sagemaker_session(),
         ),
     )
 

--- a/examples/launch_tuning_gluonts.py
+++ b/examples/launch_tuning_gluonts.py
@@ -22,7 +22,10 @@ import numpy as np
 from sagemaker.mxnet import MXNet
 
 from syne_tune.backend import LocalBackend, SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.baselines import ASHA
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.config_space import loguniform, lograndint
@@ -64,13 +67,14 @@ if __name__ == "__main__":
                 framework_version="1.7",
                 py_version="py3",
                 base_job_name="hpo-gluonts",
+                sagemaker_session=default_sagemaker_session(),
             ),
             # names of metrics to track. Each metric will be detected by Sagemaker if it is written in the
             # following form: "[RMSE]: 1.2", see in train_main_example how metrics are logged for an example
             metrics_names=[metric],
         )
     else:
-        # evaluate trials locally, replace with SagemakerBackend to evaluate trials on Sagemaker
+        # evaluate trials locally, replace with SageMakerBackend to evaluate trials on Sagemaker
         trial_backend = LocalBackend(entry_point=str(entry_point))
 
     # see examples to see other schedulers, mobster, Raytune, multiobjective, etc...

--- a/syne_tune/backend/sagemaker_backend/sagemaker_utils.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_utils.py
@@ -24,6 +24,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from sagemaker.estimator import Framework
+from sagemaker import Session
 
 import syne_tune
 from syne_tune.backend.trial_status import TrialResult
@@ -36,6 +37,11 @@ logger = logging.getLogger(__name__)
 def default_config() -> Config:
     # a default config that avoid throttling
     return Config(retries={"max_attempts": 10, "mode": "standard"})
+
+
+def default_sagemaker_session():
+    sagemaker_client = boto3.client(service_name="sagemaker", config=default_config())
+    return Session(sagemaker_client=sagemaker_client)
 
 
 def get_log(jobname: str, log_client=None) -> List[str]:

--- a/tst/remote_launcher/test_remote_launcher_path.py
+++ b/tst/remote_launcher/test_remote_launcher_path.py
@@ -16,7 +16,7 @@
 # import pytest
 # from sagemaker.pytorch import PyTorch
 #
-# from syne_tune.backend import SagemakerBackend
+# from syne_tune.backend import SageMakerBackend
 # from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
 # from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 # from syne_tune.remote.remote_launcher import RemoteLauncher
@@ -34,7 +34,7 @@
 #     role="dummy",
 # )
 #
-# backend = SagemakerBackend(sm_estimator=sm_estimator)
+# backend = SageMakerBackend(sm_estimator=sm_estimator)
 # remote_launcher = RemoteLauncher(
 #     tuner=Tuner(
 #         backend=backend,

--- a/tst/trial_backend/checkpoint_sagemaker/test_checkpoint_sagemaker.py
+++ b/tst/trial_backend/checkpoint_sagemaker/test_checkpoint_sagemaker.py
@@ -19,7 +19,10 @@ import pytest
 from sagemaker.pytorch import PyTorch
 
 from syne_tune.backend import SageMakerBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
 from syne_tune.optimizer.scheduler import TrialScheduler, TrialSuggestion, Trial
 from syne_tune.config_space import randint
 from syne_tune import StoppingCriterion, Tuner
@@ -76,6 +79,7 @@ def test_copy_checkpoint_sagemaker_backend():
             max_run=10 * 60,
             framework_version="1.7.1",
             py_version="py3",
+            sagemaker_session=default_sagemaker_session(),
         )
     )
 


### PR DESCRIPTION
*Issue #, if available:* 339

*Description of changes:*
Tested this by launching experiment with n_workers=32, nothing was throttled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
