### PR TITLE
Support no checkpointing in BlackboxRepositoryBackend

### DIFF
--- a/benchmarking/nursery/benchmark_automl/benchmark_main.py
+++ b/benchmarking/nursery/benchmark_automl/benchmark_main.py
@@ -106,7 +106,7 @@ def parse_args(methods: dict, benchmark_definitions: dict):
         help="number of seeds to run",
     )
     parser.add_argument(
-        "--run_all_seed",
+        "--run_all_seeds",
         type=int,
         default=1,
         help="if 1 run all the seeds [0, `num_seeds`-1], otherwise run seed `num_seeds` only",
@@ -138,9 +138,17 @@ def parse_args(methods: dict, benchmark_definitions: dict):
         default=0,
         help="first seed to run (if run_all_seed)",
     )
+    parser.add_argument(
+        "--support_checkpointing",
+        type=int,
+        default=1,
+        help="if 0, trials are started from scratch when resumed",
+    )
     args, _ = parser.parse_known_args()
     args.verbose = bool(args.verbose)
-    if args.run_all_seed == 1:
+    args.support_checkpointing = bool(args.support_checkpointing)
+    args.run_all_seeds = bool(args.run_all_seeds)
+    if args.run_all_seeds:
         seeds = list(range(args.start_seed, args.num_seeds))
     else:
         seeds = [args.num_seeds]
@@ -186,6 +194,7 @@ def main(methods: dict, benchmark_definitions: dict):
             dataset=benchmark.dataset_name,
             surrogate=benchmark.surrogate,
             surrogate_kwargs=benchmark.surrogate_kwargs,
+            support_checkpointing=args.support_checkpointing,
         )
 
         resource_attr = next(iter(backend.blackbox.fidelity_space.keys()))

--- a/benchmarking/nursery/benchmark_dehb/launch_remote.py
+++ b/benchmarking/nursery/benchmark_dehb/launch_remote.py
@@ -63,13 +63,13 @@ if __name__ == "__main__":
             "experiment_tag": experiment_tag,
             "num_seeds": args.num_seeds,
             "method": method,
+            "support_checkpointing": int(args.support_checkpointing),
+            "start_seed": args.start_seed,
         }
         if benchmark_name is not None:
             hyperparameters["benchmark"] = benchmark_name
         if args.num_brackets is not None:
             hyperparameters["num_brackets"] = args.num_brackets
-        if args.start_seed is not None:
-            hyperparameters["start_seed"] = args.start_seed
         print(
             f"{experiment_tag}-{method}\n"
             f"hyperparameters = {hyperparameters}\n"

--- a/syne_tune/blackbox_repository/conversion_scripts/recipes.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/recipes.py
@@ -24,10 +24,6 @@ from syne_tune.blackbox_repository.conversion_scripts.scripts.fcnet_import impor
     FCNETRecipe,
 )
 
-from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
-    YAHPORecipe,
-    yahpo_scenarios,
-)
 
 # add a blackbox recipe here to expose it in Syne Tune
 recipes = [
@@ -38,8 +34,19 @@ recipes = [
     LCBenchRecipe(),
 ]
 
-for scenario in yahpo_scenarios:
-    recipes.append(YAHPORecipe("yahpo-" + scenario))
+
+from syne_tune.try_import import try_import_yahpo_message
+
+try:
+    from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
+        YAHPORecipe,
+        yahpo_scenarios,
+    )
+
+    for scenario in yahpo_scenarios:
+        recipes.append(YAHPORecipe("yahpo-" + scenario))
+except ImportError:
+    print(try_import_yahpo_message())
 
 
 generate_blackbox_recipes = {recipe.name: recipe for recipe in recipes}

--- a/syne_tune/blackbox_repository/repository.py
+++ b/syne_tune/blackbox_repository/repository.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from typing import List, Union, Dict, Optional
 
-from syne_tune.try_import import try_import_aws_message
+from syne_tune.try_import import try_import_aws_message, try_import_yahpo_message
 
 try:
     import s3fs as s3fs
@@ -30,9 +30,12 @@ from syne_tune.blackbox_repository.blackbox_tabular import (
     deserialize as deserialize_tabular,
 )
 
-from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
-    instantiate_yahpo,
-)
+try:
+    from syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import import (
+        instantiate_yahpo,
+    )
+except ImportError:
+    print(try_import_yahpo_message())
 
 # where the blackbox repository is stored on s3
 from syne_tune.blackbox_repository.conversion_scripts.recipes import (

--- a/syne_tune/try_import.py
+++ b/syne_tune/try_import.py
@@ -49,6 +49,13 @@ def try_import_blackbox_repository_message() -> str:
     )
 
 
+def try_import_yahpo_message() -> str:
+    return _try_import_message(
+        "Dependencies of YAHPO are not imported",
+        tag="yahpo",
+    )
+
+
 def try_import_backend_message(backend_type: str) -> str:
     return (
         f"{backend_type} is not imported"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This allows to run simulation on blackboxes as if checkpoint was not supported.
Also, it allows to run blackbox repository without having Yahpo installed (a message is printed out).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
