### PR TITLE
Make saving Tuner object at end of tuning optional (default is to save)

### DIFF
--- a/benchmarking/commons/benchmark_main.py
+++ b/benchmarking/commons/benchmark_main.py
@@ -27,7 +27,7 @@ from syne_tune.blackbox_repository import load_blackbox
 from syne_tune.blackbox_repository.simulated_tabular_backend import (
     BlackboxRepositoryBackend,
 )
-from benchmarking.nursery.benchmark_automl.baselines import MethodArguments
+from benchmarking.commons.baselines import MethodArguments
 from syne_tune.backend.simulator_backend.simulator_callback import SimulatorCallback
 from syne_tune.optimizer.schedulers.transfer_learning import (
     TransferLearningTaskEvaluations,
@@ -147,6 +147,12 @@ def parse_args(
         default=1,
         help="if 0, trials are started from scratch when resumed",
     )
+    parser.add_argument(
+        "--save_tuner",
+        type=int,
+        default=1,
+        help="Serialize Tuner object at the end of tuning?",
+    )
     if extra_args is not None:
         for kwargs in extra_args:
             name = kwargs.pop("name")
@@ -154,6 +160,7 @@ def parse_args(
     args, _ = parser.parse_known_args()
     args.verbose = bool(args.verbose)
     args.support_checkpointing = bool(args.support_checkpointing)
+    args.save_tuner = bool(args.save_tuner)
     args.run_all_seeds = bool(args.run_all_seeds)
     if args.run_all_seeds:
         seeds = list(range(args.start_seed, args.num_seeds))
@@ -266,5 +273,6 @@ def main(
             print_update_interval=600,
             tuner_name=experiment_tag,
             metadata=metadata,
+            save_tuner=args.save_tuner,
         )
         tuner.run()

--- a/benchmarking/commons/launch_remote.py
+++ b/benchmarking/commons/launch_remote.py
@@ -81,6 +81,7 @@ def launch_remote(
             "experiment_tag": experiment_tag,
             "method": method,
             "support_checkpointing": int(args.support_checkpointing),
+            "save_tuner": int(args.save_tuner),
         }
         if extra_args is not None:
             assert map_extra_args is not None

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -126,6 +126,7 @@ class Tuner:
         )
 
         self.tuning_status = None
+        self.tuner_saver = None
 
     def run(self):
         """
@@ -147,10 +148,14 @@ class Tuner:
                 ),
             )
             # saves the tuner every results_update_interval seconds
-            self.tuner_saver = RegularCallback(
-                callback=lambda tuner: tuner.save(),
-                call_seconds_frequency=self.results_update_interval,
-            )
+            if self.save_tuner:
+                add_callback = self.tuner_saver is None
+                self.tuner_saver = RegularCallback(
+                    callback=lambda tuner: tuner.save(),
+                    call_seconds_frequency=self.results_update_interval,
+                )
+                if add_callback:
+                    self.callbacks.append(self.tuner_saver)
 
             self.metadata[ST_TUNER_START_TIMESTAMP] = time.time()
 

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -149,13 +149,10 @@ class Tuner:
             )
             # saves the tuner every results_update_interval seconds
             if self.save_tuner:
-                add_callback = self.tuner_saver is None
                 self.tuner_saver = RegularCallback(
                     callback=lambda tuner: tuner.save(),
                     call_seconds_frequency=self.results_update_interval,
                 )
-                if add_callback:
-                    self.callbacks.append(self.tuner_saver)
 
             self.metadata[ST_TUNER_START_TIMESTAMP] = time.time()
 
@@ -189,7 +186,7 @@ class Tuner:
                     running_trials_ids=running_trials_ids,
                 )
 
-                if new_results:
+                if new_results and self.save_tuner:
                     # Save tuner state only if there have been new results
                     self.tuner_saver(tuner=self)
 

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -54,6 +54,7 @@ class Tuner:
         callbacks: Optional[List[TunerCallback]] = None,
         metadata: Optional[dict] = None,
         suffix_tuner_name: bool = True,
+        save_tuner: bool = True,
     ):
         """
         Allows to run an tuning job, call `run` after initializing.
@@ -83,6 +84,9 @@ class Tuner:
         the time-stamp when the tuner started to run.
         :param suffix_tuner_name: If True, a timestamp is appended to the provided `tuner_name` that ensures uniqueness
         otherwise the name is left unchanged and is expected to be unique.
+        :param save_tuner: If True, the `Tuner` object is serialized at the end
+            of tuning, including its dependencies (e.g., scheduler). This allows
+            all details of the experiment to be recovered
         """
         self.trial_backend = trial_backend
         self.scheduler = scheduler
@@ -93,6 +97,7 @@ class Tuner:
         self.asynchronous_scheduling = asynchronous_scheduling
         self.wait_trial_completion_when_stopping = wait_trial_completion_when_stopping
         self.metadata = self._enrich_metadata(metadata)
+        self.save_tuner = save_tuner
 
         self.max_failures = max_failures
         self.print_update_interval = print_update_interval
@@ -256,7 +261,8 @@ class Tuner:
                 callback.on_tuning_end()
 
             # Serialize Tuner object
-            self.save()
+            if self.save_tuner:
+                self.save()
 
             logger.info("Stopping trials that may still be running.")
             self.trial_backend.stop_all()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Can save substantial amount of disk space for large experiments with many repetitions and cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
