### PR TITLE
Fixing issue with checkpoint_s3_uri usage (must end on "/")

### DIFF
--- a/benchmarking/commons/launch_remote.py
+++ b/benchmarking/commons/launch_remote.py
@@ -29,6 +29,16 @@ def _filter_none(a: dict) -> dict:
     return {k: v for k, v in a.items() if v is not None}
 
 
+def message_sync_from_s3(experiment_tag: str) -> str:
+    return (
+        "Launched all requested experiments. Once everything is done, use this "
+        "command to sync result files from S3:\n"
+        f"$ aws s3 sync {s3_experiment_path(experiment_name=experiment_tag)} "
+        f'~/syne-tune/{experiment_tag}/ --exclude "*" '
+        '--include "*metadata.json" --include "*results.csv.zip"'
+    )
+
+
 def launch_remote(
     entry_point: Path,
     methods: dict,
@@ -102,10 +112,4 @@ def launch_remote(
         est = PyTorch(**sm_args)
         est.fit(job_name=f"{experiment_tag}-{tuner_name}-{suffix}", wait=False)
 
-    print(
-        "\nLaunched all requested experiments. Once everything is done, use this "
-        "command to sync result files from S3:\n"
-        f"$ aws s3 sync {s3_experiment_path(experiment_name=experiment_tag)}/ "
-        f'~/syne-tune/{experiment_tag}/ --exclude "*" '
-        '--include "*metadata.json" --include "*results.csv.zip"'
-    )
+    print("\n" + message_sync_from_s3(experiment_tag))

--- a/benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
+++ b/benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
@@ -21,6 +21,7 @@ from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
     get_execution_role,
 )
 from syne_tune.util import s3_experiment_path, random_string
+from benchmarking.commons.launch_remote import message_sync_from_s3
 
 
 if __name__ == "__main__":
@@ -108,10 +109,4 @@ if __name__ == "__main__":
         print(f"Launching {job_name}")
         est.fit(wait=False, job_name=job_name)
 
-    print(
-        "\nLaunched all requested experiments. Once everything is done, use this "
-        "command to sync result files from S3:\n"
-        f"$ aws s3 sync {s3_experiment_path(experiment_name=experiment_name)}/ "
-        f'~/syne-tune/{experiment_name}/ --exclude "*" '
-        '--include "*metadata.json" --include "*results.csv.zip"'
-    )
+    print("\n" + message_sync_from_s3(experiment_tag))

--- a/benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
+++ b/benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
@@ -109,4 +109,4 @@ if __name__ == "__main__":
         print(f"Launching {job_name}")
         est.fit(wait=False, job_name=job_name)
 
-    print("\n" + message_sync_from_s3(experiment_tag))
+    print("\n" + message_sync_from_s3(experiment_name))

--- a/benchmarking/nursery/remote_sm_backend/launch_remote.py
+++ b/benchmarking/nursery/remote_sm_backend/launch_remote.py
@@ -24,6 +24,7 @@ from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
 import syne_tune
 import benchmarking
 from syne_tune.util import s3_experiment_path, random_string
+from benchmarking.commons.launch_remote import message_sync_from_s3
 
 
 if __name__ == "__main__":
@@ -106,10 +107,4 @@ if __name__ == "__main__":
         est = PyTorch(**sm_args)
         est.fit(job_name=f"{experiment_tag}-{seed}-{suffix}", wait=False)
 
-    print(
-        "\nLaunched all requested experiments. Once everything is done, use this "
-        "command to sync result files from S3:\n"
-        f"$ aws s3 sync {s3_experiment_path(experiment_name=experiment_tag)}/ "
-        f'~/syne-tune/{experiment_tag}/ --exclude "*" '
-        '--include "*metadata.json" --include "*results.csv.zip"'
-    )
+    print("\n" + message_sync_from_s3(experiment_tag))

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -116,7 +116,7 @@ def download_single_experiment(
     """
     s3_path = s3_experiment_path(
         s3_bucket=s3_bucket, tuner_name=tuner_name, experiment_name=experiment_name
-    )
+    ).rstrip("/")
     tgt_dir = experiment_path(tuner_name=tuner_name)
     tgt_dir.mkdir(exist_ok=True, parents=True)
     s3 = boto3.client("s3")

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -88,7 +88,7 @@ class RemoteLauncher:
         self.log_level = log_level
         if s3_path is None:
             s3_path = s3_experiment_path()
-        self.s3_path = s3_path
+        self.s3_path = s3_path.rstrip("/")
         assert isinstance(no_tuner_logging, bool)
         self.no_tuner_logging = no_tuner_logging
 

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -89,8 +89,9 @@ def s3_experiment_path(
 ) -> str:
     """
     Returns S3 path for storing results and checkpoints.
+    Note: The path ends on "/".
 
-    :param s3_bucket: If not given,, the default bucket for the SageMaker
+    :param s3_bucket: If not given, the default bucket for the SageMaker
         session is used
     :param experiment_name: If given, this is used as first directory
     :param tuner_name: If given, this is used as second directory
@@ -98,10 +99,10 @@ def s3_experiment_path(
     """
     if s3_bucket is None:
         s3_bucket = sagemaker.Session().default_bucket()
-    s3_path = f"s3://{s3_bucket}/{SYNE_TUNE_DEFAULT_FOLDER}"
+    s3_path = f"s3://{s3_bucket}/{SYNE_TUNE_DEFAULT_FOLDER}/"
     for part in (experiment_name, tuner_name):
         if part is not None:
-            s3_path += "/" + part
+            s3_path += part + "/"
     return s3_path
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is fixing an annoying issue. When setting checkpoint_s3_uri = s3_experiment_path(...), if this does not end on "/", the SM training job will sync back anything from S3 with that prefix (without the "/").

For example, if checkpoint_s3_uri = ".../ASHA-1", it will sync back anything in ".../ASHA-1*", which includes ASHA-10, ASHA-11, ASHA-12, ... This is what happened to me just now.

Having checkpoint_s3_uri end on "/" fixes this. Note we also set the local directory to "/opt/ml/checkpoints/", so trailing "/".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
