### PR TITLE
Support different kinds of ordinal type

### DIFF
--- a/benchmarking/commons/benchmark_main.py
+++ b/benchmarking/commons/benchmark_main.py
@@ -167,6 +167,13 @@ def parse_args(
         default=0,
         help="Serialize Tuner object at the end of tuning?",
     )
+    parser.add_argument(
+        "--fcnet_ordinal",
+        type=str,
+        choices=("none", "equal", "nn", "nn-log"),
+        default="none",
+        help="Ordinal encoding for fcnet categorical HPs",
+    )
     # Internal parameter, to support nested dict for `benchmark_definitions`
     nested_dict = is_dict_of_dict(benchmark_definitions)
     if nested_dict:
@@ -288,6 +295,12 @@ def main(
                 random_seed=seed,
                 resource_attr=resource_attr,
                 verbose=args.verbose,
+                fcnet_ordinal=args.fcnet_ordinal,
+                transfer_learning_evaluations=get_transfer_learning_evaluations(
+                    blackbox_name=benchmark.blackbox_name,
+                    test_task=benchmark.dataset_name,
+                    datasets=benchmark.datasets,
+                ),
                 use_surrogates="lcbench" in benchmark_name,
                 **method_kwargs,
             )
@@ -302,6 +315,7 @@ def main(
             "algorithm": method,
             "tag": experiment_tag,
             "benchmark": benchmark_name,
+            "fcnet_ordinal": args.fcnet_ordinal,
         }
         if extra_args is not None:
             metadata.update(extra_args)

--- a/benchmarking/commons/launch_remote.py
+++ b/benchmarking/commons/launch_remote.py
@@ -82,6 +82,8 @@ def launch_remote(
         checkpoint_s3_uri = s3_experiment_path(
             tuner_name=tuner_name, experiment_name=experiment_tag
         )
+        if checkpoint_s3_uri[-1] != "/":
+            checkpoint_s3_uri += "/"
         sm_args = dict(
             entry_point=entry_point.name,
             source_dir=str(entry_point.parent),
@@ -103,6 +105,7 @@ def launch_remote(
             "support_checkpointing": int(args.support_checkpointing),
             "save_tuner": int(args.save_tuner),
             "verbose": int(args.verbose),
+            "fcnet_ordinal": args.fcnet_ordinal,
         }
         if extra_args is not None:
             assert map_extra_args is not None

--- a/benchmarking/nursery/benchmark_dehb/baselines.py
+++ b/benchmarking/nursery/benchmark_dehb/baselines.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 from benchmarking.commons.baselines import (
     convert_categorical_to_ordinal,
+    convert_categorical_to_ordinal_numeric,
     MethodArguments,
     search_options,
 )
@@ -38,9 +39,23 @@ class Methods:
     SYNCMOBSTER = "SYNCMOBSTER"
 
 
+def conv_numeric_only(margs) -> dict:
+    return convert_categorical_to_ordinal_numeric(
+        margs.config_space, kind=margs.fcnet_ordinal
+    )
+
+
+def conv_numeric_then_rest(margs) -> dict:
+    return convert_categorical_to_ordinal(
+        convert_categorical_to_ordinal_numeric(
+            margs.config_space, kind=margs.fcnet_ordinal
+        )
+    )
+
+
 methods = {
     Methods.ASHA: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         type="promotion",
         search_options=search_options(method_arguments),
@@ -52,7 +67,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.SYNCHB: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -63,7 +78,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.DEHB: lambda method_arguments: GeometricDifferentialEvolutionHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random_encoded",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -74,7 +89,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.BOHB: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="kde",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -85,7 +100,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.ASHA_ORD: lambda method_arguments: HyperbandScheduler(
-        config_space=convert_categorical_to_ordinal(method_arguments),
+        config_space=conv_numeric_then_rest(method_arguments),
         searcher="random",
         type="promotion",
         search_options=search_options(method_arguments),
@@ -96,7 +111,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.SYNCHB_ORD: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=convert_categorical_to_ordinal(method_arguments),
+        config_space=conv_numeric_then_rest(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -107,7 +122,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.DEHB_ORD: lambda method_arguments: GeometricDifferentialEvolutionHyperbandScheduler(
-        config_space=convert_categorical_to_ordinal(method_arguments),
+        config_space=conv_numeric_then_rest(method_arguments),
         searcher="random_encoded",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -118,7 +133,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.BOHB_ORD: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=convert_categorical_to_ordinal(method_arguments),
+        config_space=conv_numeric_then_rest(method_arguments),
         searcher="kde",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -129,7 +144,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.ASHA_STOP: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         type="stopping",
         search_options=search_options(method_arguments),
@@ -141,7 +156,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.SYNCMOBSTER: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="bayesopt",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,

--- a/benchmarking/nursery/benchmark_hypertune/baselines.py
+++ b/benchmarking/nursery/benchmark_hypertune/baselines.py
@@ -10,7 +10,10 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from benchmarking.commons.baselines import search_options
+from benchmarking.commons.baselines import (
+    search_options,
+    convert_categorical_to_ordinal_numeric,
+)
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune.optimizer.schedulers.synchronous import (
     SynchronousGeometricHyperbandScheduler,
@@ -27,9 +30,15 @@ class Methods:
     BOHB = "BOHB"
 
 
+def conv_numeric_only(margs) -> dict:
+    return convert_categorical_to_ordinal_numeric(
+        margs.config_space, kind=margs.fcnet_ordinal
+    )
+
+
 methods = {
     Methods.ASHA: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         type="promotion",
         search_options=search_options(method_arguments),
@@ -41,7 +50,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.MOBSTER_JOINT: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="bayesopt",
         type="promotion",
         search_options=search_options(method_arguments),
@@ -53,7 +62,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.MOBSTER_INDEP: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="bayesopt",
         type="promotion",
         search_options=dict(
@@ -68,7 +77,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.HYPERTUNE_INDEP: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="hypertune",
         type="promotion",
         search_options=dict(
@@ -84,7 +93,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.HYPERTUNE_JOINT: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="hypertune",
         type="promotion",
         search_options=dict(
@@ -100,7 +109,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.SYNCHB: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -111,7 +120,7 @@ methods = {
         brackets=method_arguments.num_brackets,
     ),
     Methods.BOHB: lambda method_arguments: SynchronousGeometricHyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="kde",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,

--- a/benchmarking/nursery/benchmark_neuralband/baselines.py
+++ b/benchmarking/nursery/benchmark_neuralband/baselines.py
@@ -10,7 +10,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from benchmarking.commons.baselines import MethodArguments, search_options
+from benchmarking.commons.baselines import (
+    MethodArguments,
+    search_options,
+    convert_categorical_to_ordinal_numeric,
+)
 from syne_tune.blackbox_repository.simulated_tabular_backend import (
     BlackboxRepositoryBackend,
 )
@@ -39,9 +43,15 @@ class Methods:
     NeuralBandEpsilon = "NeuralBandEpsilon"
 
 
+def conv_numeric_only(margs) -> dict:
+    return convert_categorical_to_ordinal_numeric(
+        margs.config_space, kind=margs.fcnet_ordinal
+    )
+
+
 methods = {
     Methods.RS: lambda method_arguments: FIFOScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         metric=method_arguments.metric,
@@ -49,7 +59,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.ASHA: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -59,7 +69,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.HP: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="random",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -70,7 +80,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.BOHB: lambda method_arguments: HyperbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="kde",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -81,7 +91,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.TPE: lambda method_arguments: FIFOScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="kde",
         search_options=search_options(method_arguments),
         metric=method_arguments.metric,
@@ -89,7 +99,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.GP: lambda method_arguments: FIFOScheduler(
-        method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="bayesopt",
         search_options=search_options(method_arguments),
         metric=method_arguments.metric,
@@ -97,7 +107,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.MOBSTER: lambda method_arguments: HyperbandScheduler(
-        method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         searcher="bayesopt",
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,
@@ -108,7 +118,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.NeuralBandSH: lambda method_arguments: NeuralbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         gamma=0.05,
         nu=0.02,
         max_while_loop=50,
@@ -123,7 +133,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.NeuralBandHB: lambda method_arguments: NeuralbandScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         gamma=0.04,
         nu=0.02,
         max_while_loop=50,
@@ -138,7 +148,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.NeuralBand_UCB: lambda method_arguments: NeuralbandUCBScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         lamdba=0.1,
         nu=0.001,
         max_while_loop=50,
@@ -153,7 +163,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.NeuralBand_TS: lambda method_arguments: NeuralbandTSScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         lamdba=0.1,
         nu=0.001,
         max_while_loop=50,
@@ -168,7 +178,7 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.NeuralBandEpsilon: lambda method_arguments: NeuralbandEGreedyScheduler(
-        config_space=method_arguments.config_space,
+        config_space=conv_numeric_only(method_arguments),
         epsilon=0.1,
         max_while_loop=1000,
         step_size=5,

--- a/docs/search_space.md
+++ b/docs/search_space.md
@@ -54,10 +54,19 @@ means, a basic component of many HPO algorithms. The following domains are curre
 * `choice(categories)`: Uniform from the finite list `categories` of values.
   Entries in `categories` should ideally be of type `str`, but types `int` and
   `float` are also allowed (the latter can lead to errors due to round-off).
-* `ordinal(categories)`: Variant of `choice` for which the order of entries in
-  `categories` matters. Essentially, we use `randint(0, len(categories) - 1)`
-  internally on the positions in `categories`. For methods like Bayesian
-  optimization, nearby elements in the list have closer encodings.
+* `ordinal(categories, kind)`: Variant of `choice` for which the order of
+  entries in `categories` matters. For methods like Bayesian optimization,
+  nearby elements in the list have closer encodings. Compared to `choice`, the
+  encoding consists of a single number here. Different variants are implemented.
+  If `kind="equal"` (general default), we use `randint(0, len(categories) - 1)`
+  internally on the positions in `categories`, so that each category is chosen
+  with the same probability. If `kind="nn"` (default if `categories` strictly
+  increasing and of type `int` or `float`), `categories` must contain strictly
+  increasing `int` or `float` values. Internally, we use `uniform` for an
+  interval containing all values, a real value is mapped to a category by
+  nearest neighbor. If `kind="nn-log"`, this is done in the log space. The
+  latter two kinds are finite set versions of `uniform`, `loguniform`, the
+  different categories are (in general) not chosen with equal probabilities.
 * `finrange(lower, upper, size)`: Can be used as finite analogue of `uniform`.
   Uniform from the finite range `lower, ..., upper` of size `size`, where
   entries are equally spaced. For example, `finrange(0.5, 1.5, 3)` means
@@ -108,10 +117,14 @@ provide some recommendations.
 * **For finite numerical domains, use `finrange` or `logfinrange`.** If you
   insist on a finite range (in some cases, this may be the better choice) for
   a numerical parameter, make use of `finrange` or `logfinrange` instead of
-  `choice`, as alternatives to `uniform` and `loguniform` respectively.
+  `choice`, as alternatives to `uniform` and `loguniform` respectively. If
+  your value spacing is not regular, you can use `ordinal` with `kind="nn"`
+  or `kind="nn-log"`. For example,
+  `choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1])` can be replaced by
+  `ordinal([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1], kind="nn-log")`.
 * **Explore `ordinal` as alternative to `choice`.** Ordinal parameters are
-  encoded by a single int value, which is more economical in Bayesian
+  encoded by a single int value (if `kind="equal"`) or a single float value
+  (if `kind in {"nn", "nn-log"}`), which is more economical in Bayesian
   optimization.
 * **Use a log transform** for parameters which may vary over several orders of
   magnitude. Examples are learning rates or regularization constants.
-

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_bracket.py
@@ -15,6 +15,8 @@ from operator import itemgetter
 import numpy as np
 from dataclasses import dataclass
 
+from syne_tune.util import is_increasing, is_positive_integer
+
 
 @dataclass
 class SlotInRung:
@@ -53,27 +55,17 @@ class SynchronousBracket:
         self.current_rung = 0
 
     @staticmethod
-    def _is_increasing(lst: List[int]) -> bool:
-        return all(x < y for x, y in zip(lst, lst[1:]))
-
-    @staticmethod
-    def _is_positive_integer(lst: List[int]) -> bool:
-        return all(x == int(x) and x >= 1 for x in lst)
-
-    @staticmethod
     def assert_check_rungs(rungs: List[Tuple[int, int]]):
         assert len(rungs) > 0, "There must be at least one rung"
         sizes, levels = zip(*rungs)
-        assert SynchronousHyperbandBracket._is_positive_integer(
+        assert is_positive_integer(
             levels
         ), f"Rung levels {levels} are not positive integers"
-        assert SynchronousHyperbandBracket._is_increasing(
-            levels
-        ), f"Rung levels {levels} are not increasing"
-        assert SynchronousHyperbandBracket._is_positive_integer(
+        assert is_increasing(levels), f"Rung levels {levels} are not increasing"
+        assert is_positive_integer(
             sizes
         ), f"Rung sizes {sizes} are not positive integers"
-        assert SynchronousHyperbandBracket._is_increasing(
+        assert is_increasing(
             [-x for x in sizes]
         ), f"Rung sizes {sizes} are not decreasing"
 

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -17,7 +17,7 @@ import random
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Union
 from time import perf_counter
 from contextlib import contextmanager
 
@@ -195,3 +195,11 @@ def catchtime(name: str) -> float:
         yield lambda: perf_counter() - start
     finally:
         print(f"Time for {name}: {perf_counter() - start:.4f} secs")
+
+
+def is_increasing(lst: List[Union[float, int]]) -> bool:
+    return all(x < y for x, y in zip(lst, lst[1:]))
+
+
+def is_positive_integer(lst: List[int]) -> bool:
+    return all(x == int(x) and x >= 1 for x in lst)

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -111,17 +111,23 @@ def test_categorical_to_and_from_ndarray(choices, external_hp, internal_ndarray)
 
 
 @pytest.mark.parametrize(
-    "choices,external_hp,internal_ndarray",
+    "choices,external_hp,internal_ndarray,kind",
     [
-        (["a", "b"], "a", [0.25]),
-        (["a", "b"], "b", [0.75]),
-        (["a", "b", "c"], "b", [0.5]),
-        (["a", "b", "c"], "c", [2.5 / 3]),
-        (["a", "b", "c", "d"], "c", [2.5 / 4]),
+        (["a", "b"], "a", [0.25], "equal"),
+        (["a", "b"], "b", [0.75], "equal"),
+        (["a", "b", "c"], "b", [0.5], "equal"),
+        (["a", "b", "c"], "c", [2.5 / 3], "equal"),
+        (["a", "b", "c", "d"], "c", [2.5 / 4], "equal"),
+        ([1, 2, 4, 7], 2, [2 / 8], "nn"),
+        ([1, 2, 4, 7], 7, [7 / 8], "nn"),
+        ([0.01, 0.05, 0.1, 0.5], 0.05, [0.43355607], "nn-log"),
+        ([0.01, 0.05, 0.1, 0.5], 0.1, [0.56644393], "nn-log"),
+        ([0.01, 0.05, 0.1, 0.5], 0.01, [0.125], "nn-log"),
+        ([0.01, 0.05, 0.1, 0.5], 0.5, [0.875], "nn-log"),
     ],
 )
-def test_ordinal_to_and_from_ndarray(choices, external_hp, internal_ndarray):
-    hp_ranges = make_hyperparameter_ranges({"a": ordinal(choices)})
+def test_ordinal_to_and_from_ndarray(choices, external_hp, internal_ndarray, kind):
+    hp_ranges = make_hyperparameter_ranges({"a": ordinal(choices, kind=kind)})
     config = hp_ranges.tuple_to_config((external_hp,))
     config_enc = np.array(internal_ndarray)
     assert_allclose(hp_ranges.to_ndarray(config), config_enc)
@@ -437,6 +443,8 @@ def test_encoded_ranges():
         "4": choice([3, 2, 1]),
         "5": choice([0.01, 0.001, 0.0001, 0.00001]),
         "6": choice(["a", "b"]),
+        "7": ordinal([0.05, 0.25, 0.5, 0.8], kind="equal"),
+        "8": ordinal([0.05, 0.25, 0.5, 0.8], kind="nn"),
     }
     hp_ranges = make_hyperparameter_ranges(config_space)
     encoded_ranges = hp_ranges.encoded_ranges
@@ -447,3 +455,5 @@ def test_encoded_ranges():
     assert encoded_ranges["4"] == (6, 9)
     assert encoded_ranges["5"] == (9, 13)
     assert encoded_ranges["6"] == (13, 14)
+    assert encoded_ranges["7"] == (14, 15)
+    assert encoded_ranges["8"] == (15, 16)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New encoding for ordinal, which does not weight the values equally. Change datatype of fcnet HP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
