### PR TITLE
fix mismatch between trials in sagemaker backend.

### DIFF
--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -152,7 +152,9 @@ def load_experiment(
         logging.info(
             f"experiment {tuner_name} not found locally, trying to get it from s3."
         )
-        download_single_experiment(tuner_name=tuner_name, experiment_name=experiment_name)
+        download_single_experiment(
+            tuner_name=tuner_name, experiment_name=experiment_name
+        )
     try:
         with open(metadata_path, "r") as f:
             metadata = json.load(f)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/syne-tune/issues/214

*Description of changes:* should fix the issue #214, as Matthias guessed some mismatch was occurring with prefixes when searching for trial information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
