### PR TITLE
New test for wait_trial_completion_when_stopping param of Tuner

### DIFF
--- a/tst/test_tuner.py
+++ b/tst/test_tuner.py
@@ -26,7 +26,7 @@ from tst.util_test import temporary_local_backend
 
 
 @pytest.fixture
-def tunertools(max_steps, sleep_time, max_wallclock_time, mode, metric):
+def tunertools():
     max_steps = 100
     sleep_time = 0.01
     max_wallclock_time = 0.5

--- a/tst/test_tuner.py
+++ b/tst/test_tuner.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from syne_tune import StoppingCriterion
+from syne_tune import Tuner
+from syne_tune.config_space import randint
+from syne_tune.optimizer.baselines import RandomSearch
+from syne_tune.util import script_height_example_path
+from tst.util_test import temporary_local_backend
+
+
+@pytest.fixture
+def tunertools():
+    max_steps = 100
+    sleep_time = 0.02
+    max_wallclock_time = 1
+    mode = "min"
+    metric = "mean_loss"
+
+    config_space = {
+        "steps": max_steps,
+        "sleep_time": sleep_time,
+        "width": randint(0, 20),
+        "height": randint(-100, 100),
+    }
+    entry_point = script_height_example_path()
+    scheduler = RandomSearch(config_space, metric=metric, mode=mode)
+    trial_backend = temporary_local_backend(entry_point=entry_point)
+    stop_criterion = StoppingCriterion(
+        max_wallclock_time=max_wallclock_time, min_metric_value={"mean_loss": -np.inf}
+    )
+    return scheduler, stop_criterion, trial_backend
+
+
+def test_tuner_not_wait_trial_completion_when_stopping(tunertools):
+    # Worker should be stopped after 1 second given the max_wallclock_time is 1s
+    scheduler, stop_criterion, trial_backend = tunertools
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        sleep_time=0.1,
+        scheduler=scheduler,
+        stop_criterion=stop_criterion,
+        n_workers=1,
+        wait_trial_completion_when_stopping=False
+    )
+    tuner.run()
+    for trial, status in tuner.tuning_status.last_trial_status_seen.items():
+        assert status == "Stopped"
+
+
+def test_tuner_wait_trial_completion_when_stopping(tunertools):
+    # Worker should NOT be stopped after 1 second given the run takes 2s and we wait untill its finished.
+    scheduler, stop_criterion, trial_backend = tunertools
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        sleep_time=1,
+        scheduler=scheduler,
+        stop_criterion=stop_criterion,
+        n_workers=1,
+        wait_trial_completion_when_stopping=True
+    )
+    tuner.run()
+    for trial, status in tuner.tuning_status.last_trial_status_seen.items():
+        assert status == "Completed"
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.DEBUG)
+    # Run the tests without capturing stdout if this file is executed
+    pytest.main(args=["-s", Path(__file__)])

--- a/tst/tuners/test_wait_trial_completion_when_stopping.py
+++ b/tst/tuners/test_wait_trial_completion_when_stopping.py
@@ -10,8 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-import logging
-from pathlib import Path
 
 import pytest
 

--- a/tst/tuners/test_wait_trial_completion_when_stopping.py
+++ b/tst/tuners/test_wait_trial_completion_when_stopping.py
@@ -23,14 +23,16 @@ from syne_tune.util import script_height_example_path
 from tst.util_test import temporary_local_backend
 
 _parameterizations = [
-    ("dummy", "dummy", False, Status.stopped),  # Worker should be stopped after 0.5 second
-    ("dummy", "dummy", True, Status.completed),  # Worker should complete (NOT be stopped) after 0.5 second
-    ("dummy", "dummy", True, Status.completed),  # Worker should complete (NOT be stopped) after 0.5 second
+    (False, Status.stopped),  # Worker should be stopped after 0.5 second
+    (
+        True,
+        Status.completed,
+    ),  # Worker should complete (NOT be stopped) after 0.5 second
 ]
 
 
-@pytest.mark.parametrize("dummy, dummy2, wait_for_completion, desired_status", _parameterizations)
-def test_tuner_wait_trial_completion_when_stopping(dummy, dummy2, wait_for_completion, desired_status):
+@pytest.mark.parametrize("wait_for_completion, desired_status", _parameterizations)
+def test_tuner_wait_trial_completion_when_stopping(wait_for_completion, desired_status):
     max_steps = 10
     sleep_time_bench = 0.2
     sleep_time_tuner = 0.1
@@ -55,14 +57,14 @@ def test_tuner_wait_trial_completion_when_stopping(dummy, dummy2, wait_for_compl
         scheduler=scheduler,
         stop_criterion=stop_criterion,
         n_workers=num_workers,
-        wait_trial_completion_when_stopping=wait_for_completion
+        wait_trial_completion_when_stopping=wait_for_completion,
     )
     tuner.run()
     for trial, status in tuner.tuning_status.last_trial_status_seen.items():
         assert status == desired_status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)
     # Run the tests without capturing stdout if this file is executed
     pytest.main(args=["-s", Path(__file__)])


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/syne-tune/issues/392

*Description of changes:* Added a new test for the tuner to check whether the workers continue runnig with the flag on and are stopped with the flag off. Closes #392 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
