### PR TITLE
Make BORE evaluate pre-selected configurations first 

### DIFF
--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -290,7 +290,7 @@ class BORE(FIFOScheduler):
         super(BORE, self).__init__(
             config_space=config_space,
             metric=metric,
-            searcher=Bore(config_space=config_space, metric=metric, mode=mode),
+            searcher=Bore(config_space=config_space, metric=metric, mode=mode, **kwargs),
             mode=mode,
             **kwargs,
         )

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -290,7 +290,9 @@ class BORE(FIFOScheduler):
         super(BORE, self).__init__(
             config_space=config_space,
             metric=metric,
-            searcher=Bore(config_space=config_space, metric=metric, mode=mode, **kwargs),
+            searcher=Bore(
+                config_space=config_space, metric=metric, mode=mode, **kwargs
+            ),
             mode=mode,
             **kwargs,
         )

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -155,6 +155,10 @@ class Bore(SearcherWithRandomSeed):
 
         start_time = time.time()
 
+        config = self._next_initial_config()
+        if config is not None:
+            return config
+
         if len(self.inputs) < self.init_random or np.random.rand() < self.random_prob:
             config = self._hp_ranges.random_config(self.random_state)
 


### PR DESCRIPTION
*Description of changes:*

Small fix such that BORE actually evaluate all configs in `points_to_evaluate` before starting the search.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
