### PR TITLE
Avoid Matplotlib Warning

### DIFF
--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -49,20 +49,20 @@ class ExperimentResult:
     def plot(self, **plt_kwargs):
         import matplotlib.pyplot as plt
 
-        metric = self.metric_names()[0]
         df = self.results
         if df is not None and len(df) > 0:
             df = df.sort_values(ST_TUNER_TIME)
             x = df.loc[:, ST_TUNER_TIME]
-            y = (
-                df.loc[:, metric].cummax()
-                if self.metric_mode() == "max"
-                else df.loc[:, metric].cummin()
-            )
-            plt.plot(x, y, **plt_kwargs)
-            plt.xlabel("wallclock time")
-            plt.ylabel(metric)
-            plt.title(f"Best result over time {self.name}")
+            for metric in self.metric_names():
+                y_metric = (
+                    df.loc[:, metric].cummax()
+                    if self.metric_mode() == "max"
+                    else df.loc[:, metric].cummin()
+                )
+                plt.plot(x, y_metric, label=metric, **plt_kwargs)
+            plt.xlabel("Wallclock time (s)")
+            plt.ylabel("Metric value")
+            plt.title(self.entrypoint_name() + " " + self.name)
             plt.legend()
             plt.show()
 

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -49,21 +49,20 @@ class ExperimentResult:
     def plot(self, **plt_kwargs):
         import matplotlib.pyplot as plt
 
+        metric = self.metric_names()[0]
         df = self.results
         if df is not None and len(df) > 0:
             df = df.sort_values(ST_TUNER_TIME)
             x = df.loc[:, ST_TUNER_TIME]
-            for metric in self.metric_names():
-                y_metric = (
-                    df.loc[:, metric].cummax()
-                    if self.metric_mode() == "max"
-                    else df.loc[:, metric].cummin()
-                )
-                plt.plot(x, y_metric, label=metric, **plt_kwargs)
-            plt.xlabel("Wallclock time (s)")
-            plt.ylabel("Metric value")
+            y = (
+                df.loc[:, metric].cummax()
+                if self.metric_mode() == "max"
+                else df.loc[:, metric].cummin()
+            )
+            plt.plot(x, y, **plt_kwargs)
+            plt.xlabel("wallclock time")
+            plt.ylabel(metric)
             plt.title(f"Best result over time {self.name}")
-            plt.legend()
             plt.show()
 
     def metric_mode(self) -> str:

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -62,7 +62,7 @@ class ExperimentResult:
                 plt.plot(x, y_metric, label=metric, **plt_kwargs)
             plt.xlabel("Wallclock time (s)")
             plt.ylabel("Metric value")
-            plt.title(self.entrypoint_name() + " " + self.name)
+            plt.title(f"Best result over time {self.name}")
             plt.legend()
             plt.show()
 


### PR DESCRIPTION
*Closes #251*

*Description of changes:*
The warning has been corrected because the metric label is explicitly indicated; Display all metrics in an experiment relative to time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
