### PR TITLE
swap lines

### DIFF
--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -194,8 +194,8 @@ class TensorboardCallback(TunerCallback):
             result[ST_TUNER_TIME] = perf_counter() - self.start_time_stamp
 
     def on_trial_result(self, trial: Trial, status: str, result: dict, decision: str):
-        walltime = result[ST_TUNER_TIME]
         self._set_time_fields(result)
+        walltime = result[ST_TUNER_TIME]
 
         if self.target_metric is not None:
 


### PR DESCRIPTION
#410 #411 

*Description of changes:*

Makes sure that `st_tuner_time` is in results dict, before reading it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
