### PR TITLE
Write checkpoint before reporting metrics in training loop

### DIFF
--- a/benchmarking/training_scripts/lstm_wikitext2/lstm_wikitext2.py
+++ b/benchmarking/training_scripts/lstm_wikitext2/lstm_wikitext2.py
@@ -305,6 +305,9 @@ def objective(config):
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
             mutable_state["lr"] /= lr_factor
 
+        # Write checkpoint (optional)
+        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
+
         # Feed the score back back to Tune.
         _loss = best_val_loss if report_current_best else val_loss
         objective = -math.exp(_loss)
@@ -314,9 +317,6 @@ def objective(config):
             ELAPSED_TIME_ATTR: elapsed_time,
         }
         report(**report_kwargs)
-
-        # Write checkpoint (optional)
-        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
 
         if debug_log:
             print(

--- a/benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
+++ b/benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
@@ -174,6 +174,8 @@ def objective(config):
         elapsed_time = time.time() - ts_start
         if current_best is None or accuracy > current_best:
             current_best = accuracy
+        # Write checkpoint (optional)
+        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
         # Feed the score back to Tune.
         objective = current_best if report_current_best else accuracy
         report(
@@ -183,8 +185,6 @@ def objective(config):
                 ELAPSED_TIME_ATTR: elapsed_time,
             }
         )
-        # Write checkpoint (optional)
-        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
 
 
 if __name__ == "__main__":

--- a/benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
+++ b/benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
@@ -208,13 +208,13 @@ def objective(config):
         scheduler.step()
         elapsed_time = time.time() - ts_start
 
-        # Feed the score back back to Tune.
+        # Write checkpoint (optional)
+        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
+
+        # Feed the score back to Tune.
         report(
             **{RESOURCE_ATTR: epoch, METRIC_NAME: y, ELAPSED_TIME_ATTR: elapsed_time}
         )
-
-        # Write checkpoint (optional)
-        checkpoint_model_at_rung_level(config, save_model_fn, epoch)
 
         if debug_log:
             print(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Martin observed that if checkpoints are written after metrics are reported, the training job may get killed while writing the checkpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
