### PR TITLE
Improve doc strings of all user-facing code, in order to allow for sp…

### DIFF
--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -24,7 +24,20 @@ except ImportError:
     print("coolname is not installed, will not be used")
 
 
-def parse_args(methods: dict, extra_args: Optional[List[dict]] = None):
+def parse_args(
+    methods: Dict[str, Any], extra_args: Optional[List[dict]] = None
+) -> (Any, List[str], List[int]):
+    """Default implementation for parsing command line arguments.
+
+    :param methods: If `--method` is not given, then `method_names` are the
+        keys of this dictionary
+    :param extra_args: List of dictionaries, containing additional arguments
+        to be passed. Must contain `name` for argument name (without leading
+        `"--"`), and other kwargs to `parser.add_argument`. Optional
+    :return: `(args, method_names, seeds)`, where `args` is result of
+        `parser.parse_known_args()`, `method_names` see `methods`, and
+        `seeds` are list of seeds specified by `--num_seeds` and `--start_seed`
+    """
     try:
         default_experiment_tag = generate_slug(2)
     except Exception:
@@ -95,6 +108,17 @@ def get_metadata(
     benchmark: Optional[BenchmarkDefinition] = None,
     extra_args: Optional[dict] = None,
 ) -> Dict[str, Any]:
+    """Returns default value for `metadata` passed to `Tuner`.
+
+    :param seed: Seed of repetition
+    :param method: Name of method
+    :param experiment_tag: Tag of experiment
+    :param benchmark_name: Name of benchmark
+    :param benchmark: Optional. Take `n_workers`, `max_wallclock_time`
+        from there
+    :param extra_args: `metadata` updated by these at the end. Optional
+    :return: Default `metadata` dictionary
+    """
     metadata = {
         "seed": seed,
         "algorithm": method,

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -10,12 +10,12 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Optional, List, Union, Dict
+from typing import Optional, List, Union, Dict, Any
 import numpy as np
 import itertools
 from tqdm import tqdm
 
-from benchmarking.commons.baselines import MethodArguments
+from benchmarking.commons.baselines import MethodArguments, MethodDefinitions
 from benchmarking.commons.benchmark_definitions.common import (
     SurrogateBenchmarkDefinition,
 )
@@ -108,10 +108,26 @@ def get_transfer_learning_evaluations(
 
 
 def parse_args(
-    methods: dict,
+    methods: Dict[str, Any],
     benchmark_definitions: SurrogateBenchmarkDefinitions,
     extra_args: Optional[List[dict]] = None,
-):
+) -> (Any, List[str], List[str], List[int]):
+    """Parse command line arguments for simulator back-end experiments.
+
+    :param methods: If `--method` is not given, then `method_names` are the
+        keys of this dictionary
+    :param benchmark_definitions: Dictionary with tabulated or surrogate
+        benchmarks. If `--benchmark` is not given, then `benchmark_names` are
+        keys of this dictionary.
+        Can be nested (only for internal use).
+    :param extra_args: List of dictionaries, containing additional arguments
+        to be passed. Must contain `name` for argument name (without leading
+        `"--"`), and other kwargs to `parser.add_argument`. Optional
+    :return: `(args, method_names, benchmark_names, seeds)`, where `args` is
+        result of `parser.parse_known_args()`, `method_names` see `methods`,
+        'benchmark_names` see `benchmark_definitions`, and `seeds` are list of
+        seeds specified by `--num_seeds` and `--start_seed`
+    """
     if extra_args is None:
         extra_args = []
     else:
@@ -177,12 +193,26 @@ def parse_args(
 
 
 def main(
-    methods: dict,
+    methods: MethodDefinitions,
     benchmark_definitions: SurrogateBenchmarkDefinitions,
     extra_args: Optional[List[dict]] = None,
     map_extra_args: Optional[callable] = None,
     use_transfer_learning: bool = False,
 ):
+    """
+    Runs sequence of experiments with simulator back-end sequentially. The loop
+    runs over methods selected from `methods`, repetitions and benchmarks
+    selected from `benchmark_definitions`, with the range being controlled by
+    command line arguments.
+
+    :param methods: Dictionary with method constructors
+    :param benchmark_definitions: Definitions of benchmarks
+    :param extra_args: Extra arguments for command line parser. Optional
+    :param map_extra_args: Maps `args` returned by `parse_args` to dictionary
+        for extra argument values. Needed if `extra_args` given
+    :param use_transfer_learning: If True, we use transfer tuning. Defaults to
+        False
+    """
     args, method_names, benchmark_names, seeds = parse_args(
         methods, benchmark_definitions, extra_args
     )

--- a/benchmarking/commons/launch_remote_common.py
+++ b/benchmarking/commons/launch_remote_common.py
@@ -29,6 +29,21 @@ def sagemaker_estimator_args(
     benchmark: Optional[BenchmarkDefinition] = None,
     sagemaker_backend: bool = False,
 ) -> Dict[str, Any]:
+    """
+    Returns SageMaker estimator keyword arguments for remote tuning job.
+
+    Note: We switch off SageMaker profiler and debugger, as both are not needed
+    and consume extra resources and may introduce instabilities.
+
+    :param entry_point: Script for running HPO experiment, used for `entry_point`
+        and `source_dir` arguments
+    :param experiment_tag: Tag of experiment, used to create `checkpoint_s3_uri`
+    :param tuner_name: Name of tuner, used to create `checkpoint_s3_uri`
+    :param benchmark: Benchmark definition, optional
+    :param sagemaker_backend: Is remote tuning job running the SageMaker back-end?
+        If not, it either runs local or simulator back-end. Defaults to False
+    :return: Keyword arguments for SageMaker estimator
+    """
     checkpoint_s3_uri = s3_experiment_path(
         tuner_name=tuner_name, experiment_name=experiment_tag
     )

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -35,16 +35,31 @@ from benchmarking.commons.utils import (
 )
 from benchmarking.commons.launch_remote_common import sagemaker_estimator_args
 from benchmarking.commons.launch_remote_local import get_hyperparameters
+from benchmarking.commons.baselines import MethodDefinitions
 from syne_tune.util import random_string
 
 
 def launch_remote(
     entry_point: Path,
-    methods: dict,
+    methods: MethodDefinitions,
     benchmark_definitions: RealBenchmarkDefinitions,
     extra_args: Optional[List[dict]] = None,
     map_extra_args: Optional[callable] = None,
 ):
+    """
+    Launches sequence of SageMaker training jobs, each running an experiment
+    with the SageMaker back-end. The loop runs over methods selected from
+    `methods` and repetitions, both controlled by command line arguments.
+
+    :param entry_point: Script for running the experiment
+    :param methods: Dictionary with method constructors; one is selected from
+        command line arguments
+    :param benchmark_definitions: Definitions of benchmarks; one is selected from
+        command line arguments
+    :param extra_args: Extra arguments for command line parser, optional
+    :param map_extra_args: Maps `args` returned by `parse_args` to dictionary
+        for extra argument values. Needed only if `extra_args` given
+    """
     args, method_names, seeds = parse_args(methods, extra_args)
     experiment_tag = args.experiment_tag
     suffix = random_string(4)

--- a/benchmarking/commons/utils.py
+++ b/benchmarking/commons/utils.py
@@ -38,6 +38,13 @@ sagemaker_estimator = {
 # Used for simulator back-end experiments and for remote launching of
 # SageMaker back-end experiments
 def basic_cpu_instance_sagemaker_estimator(**kwargs):
+    """
+    Returns SageMaker estimator to be used for simulator back-end experiments
+    and for remote launching of SageMaker back-end experiments.
+
+    :param kwargs: Extra arguments to SageMaker estimator
+    :return: SageMaker estimator
+    """
     return SKLearn(
         instance_type="ml.c5.4xlarge",
         instance_count=1,

--- a/benchmarking/utils/checkpoint.py
+++ b/benchmarking/utils/checkpoint.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Dict, Callable, Any, Optional
+from typing import Callable, Any, Optional
 import argparse
 import os
 
@@ -23,13 +23,13 @@ def add_checkpointing_to_argparse(parser: argparse.ArgumentParser):
     Arguments added here are optional. If checkpointing is not supported,
     they are simply not parsed.
 
-    :param parser:
+    :param parser: Parser to add extra arguments to
     """
     parser.add_argument(f"--{ST_CHECKPOINT_DIR}", type=str)
 
 
 def resume_from_checkpointed_model(
-    config: Dict, load_model_fn: Callable[[str], int]
+    config: dict, load_model_fn: Callable[[str], int]
 ) -> int:
     """
     Checks whether there is a checkpoint to be resumed from. If so, the
@@ -42,9 +42,10 @@ def resume_from_checkpointed_model(
     If checkpointing is not supported in `config`, or no checkpoint is
     found, resume_from = 0 is returned.
 
-    :param config:
-    :param load_model_fn:
-    :return: resume_from (0 if no checkpoint has been loaded)
+    :param config: Configuration the training script is called with
+    :param load_model_fn: See above, must return `resume_from`. See
+        `pytorch_load_save_functions` for an example
+    :return: `resume_from` (0 if no checkpoint has been loaded)
     """
     resume_from = 0
     local_path = config.get(ST_CHECKPOINT_DIR)
@@ -60,7 +61,7 @@ def resume_from_checkpointed_model(
 
 
 def checkpoint_model_at_rung_level(
-    config: Dict, save_model_fn: Callable[[str, int], Any], resource: int
+    config: dict, save_model_fn: Callable[[str, int], Any], resource: int
 ):
     """
     If checkpointing is supported, checks whether a checkpoint is to be
@@ -73,9 +74,10 @@ def checkpoint_model_at_rung_level(
     writing the checkpoint is expensive compared to the time needed to
     run one resource unit.
 
-    :param config:
-    :param save_model_fn:
-    :param resource:
+    :param config: Configuration the training script is called with
+    :param save_model_fn: See above. See `pytorch_load_save_functions` for an
+        example
+    :param resource: Current resource level (e.g., number of epochs done)
     """
     local_path = config.get(ST_CHECKPOINT_DIR)
     if local_path is not None:
@@ -110,7 +112,7 @@ def pytorch_load_save_functions(
     :param mutable_state: Optional. Additional dict with elementary value
         types
     :param fname: Name of local file (path is taken from config)
-    :return: load_model_fn, save_model_fn
+    :return: `load_model_fn, save_model_fn`
     """
     import torch
 

--- a/examples/launch_height_python_backend.py
+++ b/examples/launch_height_python_backend.py
@@ -15,7 +15,7 @@ An example showing to launch a tuning of a python function `train_height`.
 """
 
 from syne_tune import Tuner, StoppingCriterion
-from syne_tune.backend.python_backend import PythonBackend
+from syne_tune.backend import PythonBackend
 from syne_tune.config_space import randint
 from syne_tune.optimizer.baselines import ASHA
 

--- a/examples/launch_tensorboard_example.py
+++ b/examples/launch_tensorboard_example.py
@@ -29,7 +29,7 @@ from syne_tune.backend import LocalBackend
 from syne_tune.optimizer.baselines import RandomSearch
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.config_space import randint
-from syne_tune.tuner_callback import TensorboardCallback
+from syne_tune.callbacks.tensorboard_callback import TensorboardCallback
 
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)

--- a/syne_tune/backend/python_backend/__init__.py
+++ b/syne_tune/backend/python_backend/__init__.py
@@ -10,6 +10,3 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-__all__ = ["PythonBackend"]
-
-from syne_tune.backend.python_backend.python_backend import PythonBackend

--- a/syne_tune/backend/simulator_backend/simulator_backend.py
+++ b/syne_tune/backend/simulator_backend/simulator_backend.py
@@ -50,20 +50,18 @@ class SimulatorConfig:
     """
     Configures the simulator:
 
-    delay_on_trial_result:
-        Time from `report` called on worker to result registered at back-end
-    delay_complete_after_final_report:
-        Time from final `report` called on worker to job completion being
-        registered at back-end
-    delay_complete_after_stop:
-        Time from stop signal received at worker to job completion being
-        registered at back-end
-    delay_start:
-        Time from start command being sent at back-end and job starting on
-        the worker (which is free)
-    delay_stop:
-        Time from stop signal being sent at back-end to signal received at
-        worker (which is running)
+    :param delay_on_trial_result: Time from `report` called on worker to result
+        registered at back-end, defaults to `DEFAULT_DELAY`
+    :param delay_complete_after_final_report: Time from final `report` called
+        on worker to job completion being registered at back-end. Defaults to
+        `DEFAULT_DELAY`
+    :param delay_complete_after_stop: Time from stop signal received at worker
+        to job completion being registered at back-end. Defaults to
+        `DEFAULT_DELAY`
+    :param delay_start: Time from start command being sent at back-end and job
+        starting on the worker (which is free). Defaults to `DEFAULT_DELAY`
+    :param delay_stop: Time from stop signal being sent at back-end to signal
+        received at worker (which is running). Defaults to `DEFAULT_DELAY`
     """
 
     delay_on_trial_result: float = DEFAULT_DELAY
@@ -131,9 +129,10 @@ class SimulatorBackend(LocalBackend):
             return all results directly, and report elapsed time in the
             `elapsed_time_attr` field
         :param elapsed_time_attr: See above
-        :param simulator_config: Parameters for simulator
+        :param simulator_config: Parameters for simulator, optional
         :param tuner_sleep_time: Effective sleep time in `Tuner.run`. This
-            information is needed in :class:`SimulatorCallback`
+            information is needed in :class:`SimulatorCallback`. Defaults
+            to `DEFAULT_SLEEP_TIME`
         """
         super().__init__(entry_point=entry_point, rotate_gpus=False)
         self.elapsed_time_attr = elapsed_time_attr
@@ -188,10 +187,7 @@ class SimulatorBackend(LocalBackend):
         return trial
 
     def _process_events_until_now(self):
-        """
-        We process all events in the queue with times before
-        `time_keeper.time()`.
-        """
+        """Process all events in the queue with times before `time_keeper.time()`."""
         time_now = self._time_keeper.time()
         next_event = self._simulator_state.next_until(time_now)
         while next_event is not None:
@@ -476,6 +472,7 @@ class SimulatorBackend(LocalBackend):
         script to finish, then parse all its results and return them.
 
         :param trial_id: ID for trial to be run
+        :param config: Configuration, defaults to config of `trial_id`
         :return: `(final_status, list_of_results_reported)`
         """
         assert (

--- a/syne_tune/backend/simulator_backend/simulator_callback.py
+++ b/syne_tune/backend/simulator_backend/simulator_callback.py
@@ -33,7 +33,7 @@ class SimulatorCallback(StoreResultsCallback):
 
     Second, we need to make sure that results written out are annotated by
     simulated time, not real time. This is already catered for by
-    `SimulatorBackend` adding ST_TUNER_TIME entries to each result it
+    `SimulatorBackend` adding `ST_TUNER_TIME` entries to each result it
     receives.
 
     Third (and most subtle), we need to make sure the stop criterion in
@@ -41,10 +41,9 @@ class SimulatorCallback(StoreResultsCallback):
     a decision based on `max_wallclock_time`. By default, `StoppingCriterion`
     takes `TuningStatus` as an input, which counts real time and knows nothing
     about simulated time. To this end, we modify `stop_criterion` of the tuner
-    to instead depend on the ST_TUNER_TIME fields in the results received.
+    to instead depend on the `ST_TUNER_TIME` fields in the results received.
     This allows us to keep both `Tuner` and `TuningStatus` independent of the
     time keeper.
-
     """
 
     def __init__(self):

--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -65,6 +65,10 @@ _CONSTRAINTS = {
 
 
 class ResourceLevelsScheduler(TrialScheduler):
+    """
+    Implements helper method to infer value for `max_resource_level`.
+    """
+
     def _infer_max_resource_level_getval(self, name):
         if name in self.config_space and name not in self._hyperparameter_keys:
             return self.config_space[name]
@@ -74,13 +78,12 @@ class ResourceLevelsScheduler(TrialScheduler):
     def _infer_max_resource_level(
         self, max_resource_level: Optional[int], max_resource_attr: Optional[str]
     ):
-        """
-        Helper to infer `max_resource_level` if not explicitly given.
+        """Infer `max_resource_level` if not explicitly given.
 
         :param max_resource_level: Value explicitly provided, or None
         :param max_resource_attr: Name of max resource attribute in
-            `config_space` (optional)
-        :return:
+            `self.config_space` (optional)
+        :return: Inferred value for `max_resource_level`
         """
         inferred_max_t = None
         names = ("epochs", "max_t", "max_epochs")
@@ -109,62 +112,69 @@ class ResourceLevelsScheduler(TrialScheduler):
 
 
 class FIFOScheduler(ResourceLevelsScheduler):
-    r"""Simple scheduler that just runs trials in submission order.
+    r"""Scheduler which executes trials in submission order.
 
-    Parameters
-    ----------
-    config_space: dict
-        Configuration space for trial evaluation function
-    searcher : str or BaseSearcher
-        Searcher (get_config decisions). If str, this is passed to
-        searcher_factory along with search_options.
-    search_options : dict
-        If searcher is str, these arguments are passed to searcher_factory.
-    metric : str
-        Name of metric to optimize, key in result's obtained via
-        `on_trial_result`
-    mode : str
-        Mode to use for the metric given, can be 'min' or 'max', default to 'min'.
-    points_to_evaluate: list[dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
-        Note: If `searcher` is BaseSearcher, points_to_evaluate must be set
-        there.
-    random_seed : int
-        Master random seed. Generators used in the scheduler or searcher are
-        seeded using `RandomSeedGenerator`. If not given, the master random
-        seed is drawn at random here.
-    time_keeper : TimeKeeper
-        If passed, this will be used for timing here (see `_elapsed_time`). The
-        time keeper has to be started at the beginning of the experiment. If not
-        given, we use a local time keeper here, which is started with the first
-        call to `_suggest`.
-        Can also be set after construction, with `set_time_keeper`.
-        NOTE: If you use :class:`SimulatorBackend`, you need to pass its
-        `time_keeper` here.
-    max_t : int (optional)
-        Maximum resource (see resource_attr) to be used for a job. Mandatory
-        for multi-fidelity scheduling, and for fine-grained cost-aware
-        searchers.
-        Note: If this is not given, we try to infer its value from `config_space`,
-        checking `config_space['epochs']`, `config_space['max-t']`, and
-        `config_space['max-epochs']`. If `max_resource_attr` is given, we use
-        the value `config_space[max_resource_attr]`. But if `max_t` is given
-        here, it takes precedence.
-    max_resource_attr : str (optional)
-        Key name in config for fixed attribute containing the maximum resource.
-        Mandatory for promotion-based multi-fidelity scheduling (see
-        :class:`HyperbandScheduler`, type 'promotion'). If given here, it is
-        used to infer `max_t` if not given.
-
+    This is the most basic scheduler template. It can be configured to
+    many use cases by choosing `searcher` along with `search_options`.
     """
 
     def __init__(self, config_space: dict, **kwargs):
+        """
+        :param config_space: Configuration space for evaluation function
+        :type config_space: dict
+        :param searcher: Searcher for `get_config` decisions. String values
+            are passed to `searcher_factory` along with `search_options` and
+            extra information. Defaults to `random` (i.e., random search)
+        :type searcher: str or :class:`BaseSearcher`
+        :param search_options: If searcher is `str`, these arguments are
+            passed to `searcher_factory`
+        :type search_options: dict, optional
+        :param metric: Name of metric to optimize, key in results obtained via
+            `on_trial_result`
+        :type metric: str
+        :param mode: "min" if `metric` is minimized, "max" if `metric` is
+            maximized, defaults to "min"
+        :type mode: str, optional
+        :param points_to_evaluate: List of configurations to be evaluated
+            initially (in that order). Each config in the list
+            can be partially specified, or even be an empty dict. For each
+            hyperparameter not specified, the default value is determined using
+            a midpoint heuristic.
+            If not given, this is mapped to `[dict()]`, a single default config
+            determined by the midpoint heuristic. If `[]` (empty list), no initial
+            configurations are specified.
+            Note: If `searcher` is of type :class:`BaseSearcher`,
+            `points_to_evaluate` must be set there.
+        :type points_to_evaluate: `List[dict]`, optional
+        :param random_seed: Master random seed. Generators used in the
+            scheduler or searcher are seeded using :class:`RandomSeedGenerator`.
+            If not given, the master random seed is drawn at random here.
+        :type random_seed: int, optional
+        :param max_resource_attr: Key name in config for fixed attribute
+            containing the maximum resource. If this is given, `max_t` is not
+            needed. We recommend to use `max_resource_attr` over `max_t`.
+            If given, we use it to infer `max_resource_level`. It is also
+            used to limit trial executions in promotion-based multi-fidelity
+            schedulers (see class:`HyperbandScheduler`, type 'promotion').
+        :type max_resource_attr: str, optional
+        :param max_t: Value for `max_resource_level`. Needed for
+            schedulers which make use of intermediate reports via
+            `on_trial_result`. If this is not given, we try to infer its value
+            from `config_space` (see :class:`ResourceLevelsScheduler`).
+            checking `config_space['epochs']`, `config_space['max-t']`, and
+            `config_space['max-epochs']`. If `max_resource_attr` is given, we use
+            the value `config_space[max_resource_attr]`. But if `max_t` is given
+            here, it takes precedence.
+        :type max_t: int, optional
+        :param time_keeper: This will be used for timing here (see
+            `_elapsed_time`). The time keeper has to be started at the beginning
+            of the experiment. If not given, we use a local time keeper here,
+            which is started with the first call to `_suggest`. Can also be set
+            after construction, with `set_time_keeper`.
+            Note: If you use :class:`SimulatorBackend`, you need to pass its
+            `time_keeper` here.
+        :type time_keeper: :class:`TimeKeeper`, optional
+        """
         super().__init__(config_space)
         # Check values and impute default values
         assert_no_invalid_options(kwargs, _ARGUMENT_KEYS, name="FIFOScheduler")
@@ -235,10 +245,12 @@ class FIFOScheduler(ResourceLevelsScheduler):
             self.time_keeper = None
 
     def set_time_keeper(self, time_keeper: TimeKeeper):
-        """
-        Allows to assign the time keeper after instruction. This is possible
-        only if it was not assigned there already, and the experiment has
-        not yet started.
+        """Assign time keeper after construction.
+
+        This is possible only if the time keeper was not assigned at
+        construction, and the experiment has not yet started.
+
+        :param time_keeper: Time keeper to be used
         """
         assert self.time_keeper is None, "Time keeper has already been assigned"
         assert isinstance(
@@ -247,14 +259,31 @@ class FIFOScheduler(ResourceLevelsScheduler):
         self.time_keeper = time_keeper
 
     def _extend_search_options(self, search_options: dict) -> dict:
+        """Allows child classes to extend `search_options`.
+
+        :param search_options: Original dict of options
+        :return: Extended dict, to use instead of `search_options`
+        """
         return search_options
 
     def _initialize_searcher(self):
+        """Callback to initialize searcher based on scheduler, if not done already"""
         if not self._searcher_initialized:
             self.searcher.configure_scheduler(self)
             self._searcher_initialized = True
 
     def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        """Implements `suggest`, except for basic postprocessing of config.
+
+        We first check whether a paused trial can be promoted (by calling
+        `_promote_trial`). If this is not possible, we ask the searcher to
+        suggest a config (by `get_config`) for the new trial `trial_id`.
+
+        :param trial_id: ID for new trial to be started (ignored if existing
+            trial to be resumed)
+        :return: Suggestion for a trial to be started or to be resumed, see
+            above. If no suggestion can be made, None is returned
+        """
         self._initialize_searcher()
         # If no time keeper was provided at construction, we use a local
         # one which is started here
@@ -279,12 +308,20 @@ class FIFOScheduler(ResourceLevelsScheduler):
         return config
 
     def _on_config_suggest(self, config: dict, trial_id: str, **kwargs) -> dict:
-        # We register the config here, not in `on_trial_add`. While this risks
-        # registering a config which is not successfully started, this is the
-        # right thing to do for batch suggestions. There, `suggest` is called
-        # multiple times in a row, and the batch trials are started together.
-        # If we did not register pending configs after being suggested (but
-        # before getting started), fantasizing would not be used for them.
+        """Called by `suggest` to allow scheduler to register a new config.
+
+        We register the config here, not in `on_trial_add`. While this risks
+        registering a config which is not successfully started, this is the
+        right thing to do for batch suggestions. There, `suggest` is called
+        multiple times in a row, and the batch trials are started together.
+        If we did not register pending configs after being suggested (but
+        before getting started), fantasizing would not be used for them.
+
+        :param config: New config suggested for `trial_id`
+        :param trial_id: Input to `_suggest`
+        :param kwargs: Optional. Additional args
+        :return: Configuration, potentially modified
+        """
         self.searcher.register_pending(trial_id=trial_id, config=config)
         if self.searcher.debug_log is not None:
             # For log outputs:
@@ -292,26 +329,27 @@ class FIFOScheduler(ResourceLevelsScheduler):
         return config
 
     def _promote_trial(self) -> (Optional[str], Optional[dict]):
-        """
+        """Checks whether any paused trial can be promoted.
+
         Has to be implemented by pause/resume schedulers.
-        If a trial can be promoted, its trial_id is returned, otherwise None.
 
-        The second return argument, extra_kwargs, plays different roles
+        The second return argument, `extra_kwargs`, plays different roles
         depending on the first return argument:
-        - If trial_id = None (no promotion): extra_kwargs are args to be
+        * If `trial_id is None` (no promotion): `extra_kwargs` are args to be
             passed to `get_config` call of searcher.
-        - If trial_id not None (promotion): extra_kwargs may be None or a dict.
-            If a dict, extra_kwargs is used to update the config of the
-            trial to be promoted. In this case, `FIFOScheduler.suggest` will
-            return the tuple (trial_id, extra_kwargs).
+        * If `trial_id not None` (promotion): `extra_kwargs` may be None or a
+            dict. If a dict, `extra_kwargs` is used to update the config of the
+            trial to be promoted. In this case, `suggest` will return the
+            tuple `(trial_id, extra_kwargs)`.
 
-        :return: trial_id, extra_kwargs
+        :return: `(trial_id, extra_kwargs)`
         """
         return None, dict()
 
     def _elapsed_time(self):
         """
-        :return: Time elapsed since start of experiment (see 'run')
+        :return: Time elapsed since start of experiment, as measured by
+            `self.time_keeper`
         """
         assert self.time_keeper is not None, "Experiment has not been started yet"
         return self.time_keeper.time()
@@ -332,9 +370,11 @@ class FIFOScheduler(ResourceLevelsScheduler):
     def _check_result(self, result: dict):
         self._check_key_of_result(result, self.metric)
 
-    # Not doing much. Note the result at the end of the trial run is
-    # passed to `on_trial_complete`
     def on_trial_result(self, trial: Trial, result: dict) -> str:
+        """
+        We simply relay `result` to the searcher. Other decisions are done
+        in `on_trial_complete`.
+        """
         self._check_result(result)
         trial_id = str(trial.trial_id)
         trial_decision = SchedulerDecision.CONTINUE

--- a/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
+++ b/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
@@ -10,6 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+from typing import List, Optional
 import logging
 
 from syne_tune.optimizer.schedulers.hyperband_promotion import PromotionRungSystem
@@ -46,18 +47,17 @@ class CostPromotionRungSystem(PromotionRungSystem):
     Note that costs c(x, r) reported via `cost_attr` need to be total costs of
     a trial. If the trial is paused and resumed, partial costs have to be added
     up. See :class:`HyperbandScheduler` for how this works.
-
     """
 
     def __init__(
         self,
-        rung_levels,
-        promote_quantiles,
-        metric,
-        mode,
-        resource_attr,
-        cost_attr,
-        max_t,
+        rung_levels: List[int],
+        promote_quantiles: List[float],
+        metric: str,
+        mode: str,
+        resource_attr: str,
+        cost_attr: str,
+        max_t: int,
     ):
         super().__init__(
             rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
@@ -67,7 +67,9 @@ class CostPromotionRungSystem(PromotionRungSystem):
         # (metric_value, cost_value, was_promoted), where metric_value is
         # m(x, r), cost value is c(x, r).
 
-    def _find_promotable_trial(self, recorded, prom_quant, resource):
+    def _find_promotable_trial(
+        self, recorded: dict, prom_quant: float, resource: int
+    ) -> Optional[str]:
         """
         Check whether any not yet promoted entry in `recorded` is
         promotable (see header comment). If there are several such, the one

--- a/syne_tune/optimizer/schedulers/multiobjective/moasha.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/moasha.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 
 
 class MOASHA(TrialScheduler):
-    """Implements Multiojbective asynchronous successive halving with different multiobjective sort options.
+    """
+    Implements MultiObjective Asynchronous Successive HAlving with different
+    multiobjective sort options.
 
     References:
     A multi-objective perspective on jointly tuning hardware and hyperparameters
@@ -38,29 +40,9 @@ class MOASHA(TrialScheduler):
 
     and
 
-    Multi-objective multi-fidelity hyperparameter optimization with application to fairness
+    Multi-objective multi-fidelity hyperparameter optimization with application
+        to fairness
     Robin Schmucker, Michele Donini, Valerio Perrone, Cédric Archambeau
-
-
-    Args:
-        time_attr: A training result attr to use for comparing time.
-            Note that you can pass in something non-temporal such as
-            `training_iteration` as a measure of progress, the only requirement
-            is that the attribute should increase monotonically.
-        multiobjective_priority: The multiobjective priority that is used to sort multiobjectives candidates.
-        We support several choices such as non-dominated sort or linear scalarization, default is non-dominated sort.
-        metrics: The training result objectives to optimize. Stopping
-            procedures will use this attribute.
-        mode: One of {min, max} or a list of {min, max}. Determines whether objectives are minimized or maximized,
-        in a case of a list the specification is done per objective. By default, all objectives are minimized.
-        max_t: max time units per trial. Trials will be stopped after
-            max_t time units (determined by time_attr) have passed.
-        grace_period: Only stop trials at least this old in time.
-            The units are the same as the attribute named by `time_attr`.
-        reduction_factor: Used to set halving rate and amount. This
-            is simply a unit-less scalar.
-        brackets: Number of brackets. Each bracket has a different
-            halving rate, specified by the reduction factor.
     """
 
     def __init__(
@@ -75,6 +57,32 @@ class MOASHA(TrialScheduler):
         reduction_factor: float = 3,
         brackets: int = 1,
     ):
+        """
+        :param config_space: Configuration space
+        :param metrics: List of metric names MOASHA optimizes over
+        :param mode: One of `{"min", "max"}` or a list of these values (same
+            size as `metrics`. Determines whether objectives are minimized or
+            maximized. Defaults to "min"
+        :param time_attr: A training result attr to use for comparing time.
+            Note that you can pass in something non-temporal such as
+            `training_iteration` as a measure of progress, the only requirement
+            is that the attribute should increase monotonically.
+            Defaults to "training_iteration"
+        :param multiobjective_priority: The multiobjective priority that is used
+            to sort multiobjectives candidates. We support several choices such
+            as non-dominated sort or linear scalarization, default is
+            non-dominated sort.
+        :param max_t: max time units per trial. Trials will be stopped after
+            `max_t` time units (determined by `time_attr`) have passed.
+            Defaults to 100
+        :param grace_period: Only stop trials at least this old in time.
+            The units are the same as the attribute named by `time_attr`.
+            Defaults to 1
+        :param reduction_factor: Used to set halving rate and amount. This
+            is simply a unit-less scalar. Defaults to 3
+        :param brackets: Number of brackets. Each bracket has a different
+            `grace_period` and number of rung levels. Defaults to 1
+        """
         super(MOASHA, self).__init__(config_space=config_space)
         assert max_t > 0, "Max (time_attr) not valid!"
         assert max_t >= grace_period, "grace_period must be <= max_t!"
@@ -130,10 +138,6 @@ class MOASHA(TrialScheduler):
         return self._mode
 
     def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
-        """
-        Implements `suggest`, except for basic postprocessing of
-        config.
-        """
         config = {
             k: v.sample() if hasattr(v, "sample") else v
             for k, v in self.config_space.items()

--- a/syne_tune/optimizer/schedulers/ray_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ray_scheduler.py
@@ -23,6 +23,22 @@ logger = logging.getLogger(__name__)
 
 
 class RayTuneScheduler(TrialScheduler):
+    """
+    Allow to use Ray scheduler and searcher. Any searcher/scheduler should
+    work, except such which need access to `TrialRunner` (e.g., PBT), this
+    feature is not implemented in Syne Tune.
+
+    If `ray_searcher` is not given (defaults to random searcher), initial
+    configurations to evaluate can be passed in `points_to_evaluate`. If
+    `ray_searcher` is given, this argument is ignored (needs to be passed
+    to `ray_searcher` at construction). Note: Use
+
+    `syne_tune.optimizer.schedulers.searchers.impute_points_to_evaluate`
+
+    in order to preprocess `points_to_evaluate` specified by the user or
+    the benchmark.
+    """
+
     from ray.tune.schedulers import FIFOScheduler as RT_FIFOScheduler
     from ray.tune.search import Searcher as RT_Searcher
 
@@ -62,29 +78,7 @@ class RayTuneScheduler(TrialScheduler):
         points_to_evaluate: Optional[List[Dict]] = None,
     ):
         """
-        Allow to use Ray scheduler and searcher. Any searcher/scheduler should
-        work, except such which need access to TrialRunner (e.g., PBT), this
-        feature is not implemented yet.
-
-        If `ray_searcher` is not given (defaults to random searcher), initial
-        configurations to evaluate can be passed in `points_to_evaluate`. If
-        `ray_searcher` is given, this argument is ignored (needs to be passed
-        to `ray_searcher` at construction). Note: Use
-
-        syne_tune.optimizer.schedulers.searchers.impute_points_to_evaluate
-
-        in order to preprocess `points_to_evaluate` specified by the user or
-        the benchmark.
-
-        :param config_space: configuration of the sampled space, for instance
-        ```python
-        hyperparameters = {
-            "steps": max_steps,
-            "width": uniform(0, 20),
-            "height": uniform(-100, 100),
-            "activation": choice(["relu", "tanh"])
-        }
-        ```
+        :param config_space: Configuration space
         :param ray_scheduler: Ray scheduler, defaults to FIFO scheduler
         :param ray_searcher: Ray searcher, defaults to random search
         :param points_to_evaluate: See above

--- a/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
@@ -58,7 +58,7 @@ class MultiFidelityBore(Bore):
         """
         Additional arguments on top of parent class :class:`Bore`.
 
-        :param resource_attr: Name of resource attribute
+        :param resource_attr: Name of resource attribute. Defaults to "epoch"
         """
         if acq_optimizer is None:
             acq_optimizer = "rs_with_replacement"

--- a/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Optional, List
+from typing import List, Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.cost_aware.cost_aware_gp_fifo_searcher import (
@@ -34,10 +34,8 @@ logger = logging.getLogger(__name__)
 
 class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
     """
-    Gaussian process-based constrained hyperparameter optimization (to be used with a FIFO scheduler).
-
-    The searcher requires a constraint metric, which is given by `constraint_attr`.
-
+    Gaussian process-based constrained hyperparameter optimization (to be used
+    with :class:`FIFOScheduler`).
     """
 
     def __init__(
@@ -47,6 +45,12 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
         points_to_evaluate: Optional[List[dict]] = None,
         **kwargs,
     ):
+        """
+        Additional arguments on top of parent class :class:`MultiModelGPFIFOSearcher`.
+
+        :param constraint_attr: Name of constraint metric in `report` passed to
+            `_update`.
+        """
         assert kwargs.get("constraint_attr") is not None, (
             "This searcher needs a constraint attribute. Please specify its "
             + "name in search_options['constraint_attr']"

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_multifidelity_searcher.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Optional, List
+from typing import List, Optional
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.gp_multifidelity_searcher import (
@@ -44,7 +44,6 @@ class MultiModelGPMultiFidelitySearcher(GPMultiFidelitySearcher):
     We first call `ModelBasedSearcher._create_internal` passing factory and
     skip_optimization predicate for the `INTERNAL_METRIC_NAME` model, then
     replace the state transformer by a multi-model one.
-
     """
 
     def _call_create_internal(self, kwargs_int):
@@ -74,7 +73,6 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
 
     Cost values are read from each report and cost is modeled as c(x, r), the
     cost model being given by `kwargs['cost_model']`.
-
     """
 
     def __init__(
@@ -82,8 +80,23 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
         config_space: dict,
         metric: str,
         points_to_evaluate: Optional[List[dict]] = None,
-        **kwargs
+        **kwargs,
     ):
+        """
+        Additional arguments on top of parent class :class:`GPMultiFidelitySearcher`.
+
+        :param cost_attr: Mandatory. Name of cost attribute in data obtained
+            from reporter (e.g., elapsed training time). Depending on whether
+            `resource_attr` is given, cost values are read from each report or
+            only at the end.
+        :type cost_attr: str
+        :param resource_attr: Name of resource attribute in reports.
+            Cost values are read from each report and cost is modeled as
+            c(x, r), the cost model being given by `cost_model`.
+        :type resource_attr: str
+        :param cost_model: Model for c(x, r).
+        :type :class:`CostModel`
+        """
         assert kwargs.get("cost_attr") is not None, (
             "This searcher needs a cost attribute. Please specify its "
             + "name in search_options['cost_attr']"
@@ -96,7 +109,7 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
         _kwargs = check_and_merge_defaults(
             kwargs,
             *cost_aware_gp_multifidelity_searcher_defaults(),
-            dict_name="search_options"
+            dict_name="search_options",
         )
         kwargs_int = cost_aware_gp_multifidelity_searcher_factory(**_kwargs)
         self._copy_kwargs_to_kwargs_int(kwargs_int, kwargs)
@@ -125,7 +138,7 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
             init_state=init_state,
             output_skip_optimization=output_skip_optimization,
             config_space_ext=self.config_space_ext,
-            resource_for_acquisition=self.resource_for_acquisition
+            resource_for_acquisition=self.resource_for_acquisition,
         )
         new_searcher._restore_from_state(state)
         # Invalidate self (must not be used afterwards)

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -189,19 +189,24 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
             logger.info(deb_msg)
 
     def _copy_kwargs_to_kwargs_int(self, kwargs_int: dict, kwargs: dict):
+        """Copies extra arguments not dealt with by `gp_fifo_searcher_factory`
+
+        :param kwargs_int: Output of factory, to be passed to `searcher_factory`
+        :param kwargs: Input arguments
+        """
         # Extra arguments not parsed in factory
         for k in ("init_state", "local_minimizer_class", "cost_attr", "resource_attr"):
             kwargs_int[k] = kwargs.get(k)
 
     def _hp_ranges_in_state(self):
         """
-        :return: HyperparameterRanges to be used in self.state_transformer.state
+        :return: `HyperparameterRanges` to be used in `self.state_transformer.state`
         """
         return self.hp_ranges
 
     def _hp_ranges_for_prediction(self):
         """
-        :return: HyperparameterRanges to be used in predictions and acquisition
+        :return: `HyperparameterRanges` to be used in predictions and acquisition
             functions
         """
         return self._hp_ranges_in_state()
@@ -237,6 +242,7 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
 
     def _update(self, trial_id: str, config: dict, result: dict):
         metric_val = result[self._metric]
+        # Transform to criterion to be minimized
         if self.map_reward is not None:
             crit_val = self.map_reward(metric_val)
         else:
@@ -264,7 +270,17 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
     def _get_config_modelbased(
         self, exclusion_candidates: ExclusionList, **kwargs
     ) -> Optional[Configuration]:
-        raise NotImplementedError()
+        """
+        Implements `get_config` part if the surrogate model is used, instead
+        of initial choices from `points_to_evaluate` or initial random
+        choices.
+
+        :param exclusion_candidates: Configs to be avoided
+        :param kwargs: Extra arguments
+        :return: Suggested configuration, or None if configuration space is
+            exhausted
+        """
+        raise NotImplementedError
 
     def _get_exclusion_candidates(self, **kwargs) -> ExclusionList:
         return ExclusionList(
@@ -273,6 +289,10 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
         )
 
     def _should_pick_random_config(self, exclusion_candidates: ExclusionList) -> bool:
+        """
+        :param exclusion_candidates: Configs to be avoided
+        :return: Should config be drawn at random in `get_config`
+        """
         if len(exclusion_candidates) < self.num_initial_random_choices:
             return True
         # Determine whether there is any observed data after filtering
@@ -295,6 +315,8 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
         model-based search. If False is returned, model-based search must be
         called.
 
+        :param exclusion_candidates: Configs to be avoided
+        :return: `(config, use_get_config_modelbased)`
         """
         self._assign_random_searcher()
         config = self._next_initial_config()  # Ask for initial config
@@ -423,7 +445,7 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
     def _assign_random_searcher(self, random_seed=None):
         if self._random_searcher is None:
             # Used for initial random configs (if any)
-            # We do not have to deal with points_to_evaluate
+            # We do not have to deal with `points_to_evaluate`
             if random_seed is None:
                 random_seed = self.random_state.randint(0, 2**32)
             self._random_searcher = RandomSearcher(
@@ -438,17 +460,24 @@ class ModelBasedSearcher(SearcherWithRandomSeed):
 class GPFIFOSearcher(ModelBasedSearcher):
     """Gaussian process Bayesian optimization for FIFO scheduler
 
-    This searcher must be used with `FIFOScheduler`. It provides Bayesian
-    optimization, based on a Gaussian process surrogate model.
+    This searcher must be used with :class:`FIFOScheduler`. It provides
+    Bayesian optimization, based on a Gaussian process surrogate model.
 
-    NOTE: The searcher uses `map_reward` to map metric values to internal
-    criterion values, and *minimizes* the latter. If your metric is to be
-    maximized, you need to pass a strictly decreasing `map_reward`.
+    It is *not* recommended to create :class:`GPFIFOSearcher` searcher objects
+    directly, but rather to create :class:`FIFOScheduler` objects with
+    `searcher="bayesopt"`, and passing arguments here in `search_options`.
+    This will use the appropriate functions from `gp_searcher_factory.py` to
+    create components in a consistent way.
+
+    Note: The searcher uses `map_reward` to map metric values to internal
+    criterion values, and *minimizes* the latter. The default choice is
+    to multiply values by -1.
 
     Pending configurations (for which evaluation tasks are currently running)
     are dealt with by fantasizing (i.e., target values are drawn from the
     current posterior, and acquisition functions are averaged over this
     sample, see `num_fantasy_samples`).
+
     The GP surrogate model uses a Matern 5/2 covariance function with automatic
     relevance determination (ARD) of input attributes, and a constant mean
     function. The acquisition function is expected improvement (EI). All
@@ -457,134 +486,14 @@ class GPFIFOSearcher(ModelBasedSearcher):
     fitting is the most expensive part of a `get_config` call.
 
     The following happens in `get_config`. For the first `num_init_random` calls,
-    a config is drawn at random (the very first call results in the default
-    config of the space). Afterwards, Bayesian optimization is used, unless
-    there are no finished evaluations yet.
+    a config is drawn at random (after `points_to_evaluate`, which are included
+    in the `num_init_random` initial ones). Afterwards, Bayesian optimization
+    is used, unless there are no finished evaluations yet.
     First, model hyperparameter are refit. This step can be skipped (see
-    `opt_skip*` parameters). Next, `num_init_candidates` configs are sampled at
+    `opt_skip_*` parameters). Next, `num_init_candidates` configs are sampled at
     random, and ranked by a scoring function (`initial_scoring`). BFGS local
     optimization is then run starting from the top scoring config, where EI
-    is minimized.
-
-    Parameters
-    ----------
-    config_space : dict
-        Configuration space. Constant parameters are filtered out
-    metric : str
-        Name of metric reported by evaluation function.
-    points_to_evaluate: List[dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
-    random_seed_generator : RandomSeedGenerator (optional)
-        If given, the random_seed for `random_state` is obtained from there,
-        otherwise `random_seed` is used
-    random_seed : int (optional)
-        This is used if `random_seed_generator` is not given.
-    debug_log : bool (default: False)
-        If True, both searcher and scheduler output an informative log, from
-        which the configs chosen and decisions being made can be traced.
-    resource_attr : str (optional)
-        Name of resource attribute in reports. This is optional here, but
-        required for multi-fidelity searchers.
-        If `resource_attr` and `cost_attr` are given, cost values are read from
-        each report and stored in the state. This allows cost models to be fit
-        on more data.
-    cost_attr : str (optional)
-        Name of cost attribute in data obtained from reporter (e.g., elapsed
-        training time). Needed only by cost-aware searchers. Depending on
-        whether `resource_attr` is given, cost values are read from each
-        report or only at the end.
-    num_init_random : int
-        Number of initial `get_config` calls for which randomly sampled configs
-        are returned. Afterwards, Bayesian optimization is used
-    num_init_candidates : int
-        Number of initial candidates sampled at random in order to seed the
-        search for `get_config`
-    num_fantasy_samples : int
-        Number of samples drawn for fantasizing (latent target values for
-        pending evaluations)
-    no_fantasizing : bool
-        If True, fantasizing is not done and pending evaluations are ignored.
-        This may lead to loss of diversity in decisions
-    initial_scoring : str
-        Scoring function to rank initial candidates (local optimization of EI
-        is started from top scorer). Values are 'thompson_indep' (independent
-        Thompson sampling; randomized score, which can increase exploration),
-        'acq_func' (score is the same (EI) acquisition function which is afterwards
-        locally optimized).
-    skip_local_optimization : bool
-        If True, the local gradient-based optimization of the acquisition
-        function is skipped, and the top-tanked initial candidate is returned
-        instead. In this case, `initial_scoring='acq_func'` makes most sense,
-        otherwise the acquisition function will not be used.
-    opt_nstarts : int
-        Parameter for hyperparameter fitting. Number of random restarts
-    opt_maxiter : int
-        Parameter for hyperparameter fitting. Maximum number of iterations
-        per restart
-    opt_warmstart : bool
-        Parameter for hyperparameter fitting. If True, each fitting is started
-        from the previous optimum. Not recommended in general
-    opt_verbose : bool
-        Parameter for hyperparameter fitting. If True, lots of output
-    opt_skip_init_length : int
-        Parameter for hyperparameter fitting, skip predicate. Fitting is never
-        skipped as long as number of observations below this threshold
-    opt_skip_period : int
-        Parameter for hyperparameter fitting, skip predicate. If >1, and number
-        of observations above `opt_skip_init_length`, fitting is done only
-        K-th call, and skipped otherwise
-    map_reward : str or MapReward
-        If `mode == 'max'`, the scheduler maximizes reward, while
-        internally, Bayesian optimization is minimizing the criterion. States
-        how reward is mapped to criterion. If the mode is 'min', this
-        argument is ignored.
-        Built-in are `minus_x` (criterion = -reward) and `<a>_minus_x`, where
-        <a> is a constant (criterion = <a> - reward), for example `1_minus_x`.
-        From a technical standpoint, it does not matter what is chosen here,
-        because criterion is only used internally. Also note that criterion
-        data is always normalized to mean 0, variance 1 before fitted with a
-        GP.
-    transfer_learning_task_attr : str (optional)
-        Used to support transfer HPO, where the state contains observed data
-        from several tasks, one of which is the active one. To this end,
-        `config_space` must contain a categorical parameter of name
-        `transfer_learning_task_attr`, whose range are all task IDs. Also,
-        `transfer_learning_active_task` must denote the active task, and
-        `transfer_learning_active_config_space` is used as
-        `active_config_space` argument in :class:`HyperparameterRanges`. This
-        allows us to use a narrower search space for the active task than for
-        the union of all tasks (`config_space` must be that), which is needed
-        if some configurations of non-active tasks lie outside of the ranges
-        in `active_config_space`.
-        One of the implications is that `filter_observed_data` is selecting
-        configs of the active task, so that incumbents or exclusion lists are
-        restricted to data from the active task.
-    transfer_learning_active_task : str (optional)
-        See `transfer_learning_task_attr`.
-    transfer_learning_active_config_space : dict (optional)
-        See `transfer_learning_task_attr`. If not given, `config_space` is the
-        search space for the active task as well. This active config space need
-        not contain the `transfer_learning_task_attr` parameter. In fact, this
-        parameter is set to a categorical with `transfer_learning_active_task`
-        as single value, so that new configs are chosen for the active task
-        only.
-    transfer_learning_model : str (optional)
-        See `transfer_learning_task_attr`. Specifies the surrogate model to be
-        used for transfer lerning:
-        - 'matern52_product': Kernel is product of Matern 5/2 (not ARD) on
-            `transfer_learning_task_attr` and Matern 5/2 (ARD) on the rest.
-            Assumes that data from same task are more closely related than
-            data from different tasks
-        - 'matern52_same': Kernel is Matern 5/2 (ARD) on the rest of the
-            variables, `transfer_learning_task_attr` is ignored. Assumes
-            that data from all tasks can be merged together
-
+    is minimized (this is skipped if `skip_local_optimization=True`).
     """
 
     def __init__(
@@ -592,9 +501,131 @@ class GPFIFOSearcher(ModelBasedSearcher):
         config_space: dict,
         metric: str,
         points_to_evaluate: Optional[List[dict]] = None,
-        clone_from_state=False,
+        clone_from_state: bool = False,
         **kwargs,
     ):
+        """
+         Note that the full logic of construction based on arguments is given in
+         `gp_searcher_factory.py`. In particular, see `gp_fifo_searcher_defaults`
+         for default values.
+
+         Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
+
+         :param clone_from_state: Internal argument, do not use
+         :type clone_from_state: bool
+         :param resource_attr: Name of resource attribute in reports. This is
+             optional here, but required for multi-fidelity searchers.
+             If `resource_attr` and `cost_attr` are given, cost values are read from
+             each report and stored in the state. This allows cost models to be fit
+             on more data.
+         :type resource_attr: str, optional
+         :param cost_attr: Name of cost attribute in data obtained from reporter
+             (e.g., elapsed training time). Needed only by cost-aware searchers.
+             Depending on whether `resource_attr` is given, cost values are read
+             from each report or only at the end.
+         :type cost_attr: str, optional
+         :param num_init_random: Number of initial `get_config` calls for which
+             randomly sampled configs are returned. Afterwards, the model-based
+             searcher is used. Defaults to `DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS`
+         :type num_init_random: int, optional
+         :param num_init_candidates: Number of initial candidates sampled at
+             random in order to seed the model-based search in `get_config`.
+             Defaults to `DEFAULT_NUM_INITIAL_CANDIDATES`
+         :type num_init_candidates: int, optional
+         :param num_fantasy_samples: Number of samples drawn for fantasizing
+             (latent target values for pending evaluations), defaults to 20
+         :type num_fantasy_samples: int, optional
+         :param no_fantasizing: If True, fantasizing is not done and pending
+             evaluations are ignored. This may lead to loss of diversity in
+             decisions
+         :type no_fantasizing: Defaults to False
+         :param initial_scoring: Scoring function to rank initial candidates
+             (local optimization of EI is started from top scorer):
+             * "thompson_indep": Independent Thompson sampling; randomized score,
+                 which can increase exploration
+             * "acq_func": score is the same (EI) acquisition function which is
+                 used for local optimization afterwards
+             Defaults to `DEFAULT_INITIAL_SCORING`
+         :type initial_scoring: str, optional
+         :param skip_local_optimization: If True, the local gradient-based
+             optimization of the acquisition function is skipped, and the
+             top-tanked initial candidate (after initial scoring) is returned
+             instead. In this case, `initial_scoring="acq_func"` makes most
+             sense, otherwise the acquisition function will not be used.
+             Defaults to False
+         :type skip_local_optimization: bool, optional
+         :param opt_nstarts: Parameter for surrogate model fitting. Number of
+             random restarts. Defaults to 2
+         :type opt_nstarts: int, optional
+         :param opt_maxiter: Parameter for surrogate model fitting. Maximum
+             number of iterations per restart. Defaults to 50
+         :type opt_maxiter: int, optional
+         :param opt_warmstart: Parameter for surrogate model fitting. If True,
+             each fitting is started from the previous optimum. Not recommended
+             in general. Defaults to False
+         :type opt_warmstart: bool, optional
+         :param opt_verbose: Parameter for surrogate model fitting. If True,
+             lots of output. Defaults to False
+         :type opt_verbose: bool, optional
+         :param opt_skip_init_length: Parameter for surrogate model fitting,
+             skip predicate. Fitting is never skipped as long as number of
+             observations below this threshold. Defaults to 150
+          :type opt_skip_init_length: int, optional
+        :param opt_skip_period: Parameter for surrogate model fitting, skip
+             predicate. If `>1`, and number of observations above
+             `opt_skip_init_length`, fitting is done only K-th call, and skipped
+             otherwise. Defaults to 1 (no skipping)
+         :type opt_skip_period: int, optional
+         :param map_reward: In the scheduler, the metric may be minimized or
+             maximized, but internally, Bayesian optimization is minimizing
+             the criterion. `map_reward` converts from metric to internal
+             criterion:
+             * "minus_x": `criterion = -metric`
+             * "<a>_minus_x": `criterion = <a> - metric`. For example "1_minus_x"
+                 maps accuracy to zero-one error
+             From a technical standpoint, it does not matter what is chosen here,
+             because criterion is only used internally. Also note that criterion
+             data is always normalized to mean 0, variance 1 before fitted with a
+             Gaussian process.
+             Defaults to "1_minus_x"
+         :type map_reward: str or :class:`MapReward`, optional
+         :param transfer_learning_task_attr: Used to support transfer HPO, where
+             the state contains observed data from several tasks, one of which
+             is the active one. To this end, `config_space` must contain a
+             categorical parameter of name `transfer_learning_task_attr`, whose
+             range are all task IDs. Also, `transfer_learning_active_task` must
+             denote the active task, and `transfer_learning_active_config_space`
+             is used as `active_config_space` argument in
+             :class:`HyperparameterRanges`. This allows us to use a narrower
+             search space for the active task than for the union of all tasks
+             (`config_space` must be that), which is needed if some configurations
+             of non-active tasks lie outside of the ranges in `active_config_space`.
+             One of the implications is that `filter_observed_data` is selecting
+             configs of the active task, so that incumbents or exclusion lists are
+             restricted to data from the active task.
+         :type transfer_learning_task_attr: str, optional
+         :param transfer_learning_active_task: See `transfer_learning_task_attr`.
+         :type transfer_learning_active_task: str, optional
+         :param transfer_learning_active_config_space:
+             See `transfer_learning_task_attr`. If not given, `config_space` is the
+             search space for the active task as well. This active config space need
+             not contain the `transfer_learning_task_attr` parameter. In fact, this
+             parameter is set to a categorical with `transfer_learning_active_task`
+             as single value, so that new configs are chosen for the active task
+             only.
+         :type transfer_learning_active_config_space: dict, optional
+         :param transfer_learning_model: See `transfer_learning_task_attr`.
+             Specifies the surrogate model to be used for transfer lerning:
+             * "matern52_product": Kernel is product of Matern 5/2 (not ARD) on
+                 `transfer_learning_task_attr` and Matern 5/2 (ARD) on the rest.
+                 Assumes that data from same task are more closely related than
+                 data from different tasks
+             * "matern52_same": Kernel is Matern 5/2 (ARD) on the rest of the
+                 variables, `transfer_learning_task_attr` is ignored. Assumes
+                 that data from all tasks can be merged together
+             Defaults to "matern52_product"
+         :type transfer_learning_model: str, optional
+        """
         super().__init__(
             config_space,
             metric=metric,
@@ -726,7 +757,9 @@ class GPFIFOSearcher(ModelBasedSearcher):
         Asks for a batch of `batch_size` configurations to be suggested. This
         is roughly equivalent to calling `get_config` `batch_size` times,
         marking the suggested configs as pending in the state (but the state
-        is not modified here).
+        is not modified here). This means the batch is chosen sequentially,
+        at about the cost of calling `get_config` `batch_size` times.
+
         If `num_init_candidates_for_batch` is given, it is used instead
         of `num_init_candidates` for the selection of all but the first
         config in the batch. In order to speed up batch selection, choose
@@ -749,9 +782,9 @@ class GPFIFOSearcher(ModelBasedSearcher):
             # `DebugLogWriter` does not support batch selection right now,
             # must be switched off
             assert self.debug_log is None, (
-                "get_batch_configs does not support debug_log right now. "
-                + "Please set debug_log=False in search_options argument "
-                + "of scheduler, or create your searcher with debug_log=False"
+                "`get_batch_configs` does not support debug_log right now. "
+                + "Please set `debug_log=False` in search_options argument "
+                + "of scheduler, or create your searcher with `debug_log=False`"
             )
             exclusion_candidates = self._get_exclusion_candidates(**kwargs)
             pick_random = True

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -39,13 +39,19 @@ logger = logging.getLogger(__name__)
 
 
 class GPMultiFidelitySearcher(GPFIFOSearcher):
-    """Gaussian process Bayesian optimization for Hyperband scheduler
+    """
+    Gaussian process Bayesian optimization for asynchronous Hyperband scheduler.
 
-    This searcher must be used with `HyperbandScheduler`. It provides a novel
+    This searcher must be used with :class:`HyperbandScheduler`. It provides a novel
     combination of Bayesian optimization, based on a Gaussian process surrogate
     model, with Hyperband scheduling. In particular, observations across
-    resource levels are modelled jointly. It is created along with the
-    scheduler, using `searcher='bayesopt'`:
+    resource levels are modelled jointly.
+
+    It is *not* recommended to create :class:`GPMultiFidelitySearcher` searcher
+    objects directly, but rather to create :class:`HyperbandScheduler` objects
+    with `searcher="bayesopt"`, and passing arguments here in `search_options`.
+    This will use the appropriate functions from `gp_searcher_factory.py` to
+    create components in a consistent way.
 
     Most of `GPFIFOSearcher` comments apply here as well.
     In multi-fidelity HPO, we optimize a function f(x, r), x the configuration,
@@ -69,101 +75,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
     <= max_t, where we have seen >= dimension(x) metric values. If
     `resource_acq` == 'first', r is the first milestone which config x would
     reach when started.
-
-    Parameters
-    ----------
-    config_space : dict
-        Configuration space. Constant parameters are filtered out
-    metric : str
-        Name of reward attribute reported by evaluation function
-    points_to_evaluate: List[dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
-    random_seed_generator : RandomSeedGenerator (optional)
-        If given, the random_seed for `random_state` is obtained from there,
-        otherwise `random_seed` is used
-    random_seed : int (optional)
-        This is used if `random_seed_generator` is not given.
-    resource_attr : str
-        Name of resource attribute in reports, equal to `resource_attr` of
-        scheduler
-    debug_log : bool (default: False)
-        If True, both searcher and scheduler output an informative log, from
-        which the configs chosen and decisions being made can be traced.
-    cost_attr : str (optional)
-        Name of cost attribute in data obtained from reporter (e.g., elapsed
-        training time). Needed only by cost-aware searchers.
-    model : str
-        Selects surrogate model (learning curve model) to be used. Choices
-        are 'gp_multitask' (default), 'gp_independent', 'gp_issm',
-        'gp_expdecay'
-    num_init_random : int
-        See :class:`GPFIFOSearcher`
-    num_init_candidates : int
-        See :class:`GPFIFOSearcher`
-    num_fantasy_samples : int
-        See :class:`GPFIFOSearcher`
-    no_fantasizing : bool
-        See :class:`GPFIFOSearcher`
-    initial_scoring : str
-        See :class:`GPFIFOSearcher`
-    skip_local_optimization : str
-        See :class:`GPFIFOSearcher`
-    opt_nstarts : int
-        See :class:`GPFIFOSearcher`
-    opt_maxiter : int
-        See :class:`GPFIFOSearcher`
-    opt_warmstart : bool
-        See :class:`GPFIFOSearcher`
-    opt_verbose : bool
-        See :class:`GPFIFOSearcher`
-    opt_skip_init_length : int
-        See :class:`GPFIFOSearcher`
-    opt_skip_period : int
-        See `:class:GPFIFOSearcher`
-    map_reward : str or MapReward
-        See :class:`GPFIFOSearcher`
-    gp_resource_kernel : str
-        Only relevant for `model == 'gp_multitask'`.
-        Surrogate model over criterion function f(x, r), x the config, r the
-        resource. Note that x is encoded to be a vector with entries in [0, 1],
-        and r is linearly mapped to [0, 1], while the criterion data is
-        normalized to mean 0, variance 1. The reference above provides details
-        on the models supported here. For the exponential decay kernel, the
-        base kernel over x is Matern 5/2 ARD.
-        Values are 'matern52' (Matern 5/2 ARD kernel over [x, r]),
-        'matern52-res-warp' (Matern 5/2 ARD kernel over [x, r], with additional
-        warping on r),
-        'exp-decay-sum' (exponential decay kernel, with delta=0. This is the
-        additive kernel from Freeze-Thaw Bayesian Optimization),
-        'exp-decay-delta1' (exponential decay kernel, with delta=1),
-        'exp-decay-combined' (exponential decay kernel, with delta in [0, 1]
-        a hyperparameter).
-    resource_acq : str
-        Only relevant for `model in {'gp_multitask', 'gp_independent'}`
-        Determines how the EI acquisition function is used (see above).
-        Values: 'bohb', 'first'
-    opt_skip_num_max_resource : bool
-        Parameter for hyperparameter fitting, skip predicate. If True, and
-        number of observations above `opt_skip_init_length`, fitting is done
-        only when there is a new datapoint at r = max_t, and skipped otherwise.
-    issm_gamma_one : bool
-        Only relevant for `model == 'gp_issm'`.
-        If True, the gamma parameter of the ISSM is fixed to 1, otherwise it
-        is optimized over.
-    expdecay_normalize_inputs : bool
-        Only relevant for `model == 'gp_expdecay'`.
-        If True, resource values r are normalized to [0, 1] as input to the
-        exponential decay surrogate model.
-
-    See Also
-    --------
-    GPFIFOSearcher
     """
 
     def __init__(
@@ -173,6 +84,46 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         points_to_evaluate: Optional[List[dict]] = None,
         **kwargs,
     ):
+        """
+        Additional arguments on top of parent class :class:`GPFIFOSearcher`.
+
+        :param model: Selects surrogate model (learning curve model) to be used.
+            Choices are:
+            * "gp_multitask" (default): GP multi-task surrogate model
+            * "gp_independent": Independent GPs for each rung level, sharing
+                an ARD kernel
+            * "gp_issm": Gaussian-additive model of ISSM type
+            * "gp_expdecay": Gaussian-additive model of exponential decay type
+                (as in "Freeze Thaw Bayesian Optimization")
+        :type model: str, optional
+        :param gp_resource_kernel: Only relevant for `model == "gp_multitask"`.
+            Surrogate model over criterion function f(x, r), x the config, r the
+            resource. Note that x is encoded to be a vector with entries in [0, 1],
+            and r is linearly mapped to [0, 1], while the criterion data is
+            normalized to mean 0, variance 1. The reference above provides details
+            on the models supported here. For the exponential decay kernel, the
+            base kernel over x is Matern 5/2 ARD.
+            See `SUPPORTED_RESOURCE_MODELS` fur supported choices.
+            Defaults to "exp-decay-sum"
+        :type gp_resource_kernel: str, optional
+        :param resource_acq: Only relevant for `model in {"gp_multitask",
+            "gp_independent"}`. Determines how the EI acquisition function is
+            used. Values: "bohb", "first". Defaults to "bohb"
+        :type resource_acq:
+        :param opt_skip_num_max_resource: Parameter for surrogate model fitting,
+            skip predicate. If True, and number of observations above
+            `opt_skip_init_length`, fitting is done only when there is a new
+             datapoint at `r = max_t`, and skipped otherwise. Defaults to False
+        :type opt_skip_num_max_resource: bool, optional
+        :param issm_gamma_one: Only relevant for `model == "gp_issm"`.
+            If True, the gamma parameter of the ISSM is fixed to 1, otherwise it
+            is optimized over. Defaults to False
+        :type issm_gamma_one: bool, optional
+        :param expdecay_normalize_inputs: Only relevant for `model ==
+            "gp_expdecay"`. If True, resource values r are normalized to [0, 1]
+            as input to the exponential decay surrogate model. Defaults to False
+        :type expdecay_normalize_inputs: bool, optional
+        """
         super().__init__(
             config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs
         )
@@ -203,12 +154,11 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
             SynchronousHyperbandScheduler,
         )
 
-        super().configure_scheduler(scheduler)
         assert isinstance(
             scheduler, (HyperbandScheduler, SynchronousHyperbandScheduler)
         ), (
-            "This searcher requires HyperbandScheduler scheduler or "
-            "SynchronousHyperbandScheduler scheduler"
+            "This searcher requires HyperbandScheduler or "
+            + "SynchronousHyperbandScheduler scheduler"
         )
         self._resource_attr = scheduler.resource_attr
         model_factory = self.state_transformer.model_factory
@@ -243,12 +193,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         config: Optional[dict] = None,
         milestone: Optional[int] = None,
     ):
-        """
-        Registers trial as pending for resource level `milestone`. This means
-        the corresponding evaluation task is running and should reach that
-        level later, when update is called for it.
-
-        """
         assert (
             milestone is not None
         ), "This searcher works with a multi-fidelity scheduler only"
@@ -273,9 +217,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         job for GP surrogate models. But if in subclasses, other surrogate
         models are involved, they need to get informed separately (see
         :class:`CostAwareGPMultiFidelitySearcher` for an example).
-
-        :param kwargs:
-        :return:
         """
         if self.resource_for_acquisition is not None:
             # Only have to do this for 'gp_multitask' or 'gp_independent' model
@@ -304,15 +245,6 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         self.state_transformer.mark_trial_failed(trial_id)
 
     def cleanup_pending(self, trial_id: str):
-        """
-        Removes all pending evaluations for a trial.
-        This should be called after an evaluation terminates. For various
-        reasons (e.g., termination due to convergence), pending candidates
-        for this evaluation may still be present.
-        It is also called for a failed evaluation.
-
-        """
-
         def filter_pred(x: PendingEvaluation) -> bool:
             return x.trial_id == trial_id
 

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -154,6 +154,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
             SynchronousHyperbandScheduler,
         )
 
+        super().configure_scheduler(scheduler)
         assert isinstance(
             scheduler, (HyperbandScheduler, SynchronousHyperbandScheduler)
         ), (

--- a/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_bracket_distribution.py
+++ b/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_bracket_distribution.py
@@ -48,8 +48,8 @@ class HyperTuneBracketDistribution(DefaultHyperbandBracketDistribution):
         assert isinstance(
             scheduler, (HyperbandScheduler, SynchronousHyperbandScheduler)
         ), (
-            "This searcher requires HyperbandScheduler scheduler or "
-            "SynchronousHyperbandScheduler scheduler"
+            "This searcher requires HyperbandScheduler or "
+            + "SynchronousHyperbandScheduler scheduler"
         )
         self._searcher = scheduler.searcher
         assert isinstance(self._searcher, GPMultiFidelitySearcher)

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -45,47 +45,6 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
     BOHB: Robust and Efficient Hyperparameter Optimization at Scale
     S. Falkner and A. Klein and F. Hutter
     Proceedings of the 35th International Conference on Machine Learning
-
-    Parameters
-    ----------
-    config_space: dict
-        Configuration space for trial evaluation function
-    metric : str
-        Name of metric to optimize, key in result's obtained via
-        `on_trial_result`
-    mode : str
-        Mode to use for the metric given, can be 'min' or 'max'. Is obtained
-        scheduler in `configure_scheduler`
-    random_seed_generator : RandomSeedGenerator (optional)
-        If given, the random_seed for `random_state` is obtained from there,
-        otherwise `random_seed` is used
-    random_seed : int (optional)
-        This is used if `random_seed_generator` is not given.
-    num_min_data_points: int
-        Minimum number of data points that we use to fit the KDEs. If set to None
-        than we set this to the number of hyperparameters.
-    top_n_percent: int
-        Determines how many datapoints we use to fit the first KDE model for
-        modeling the well performing configurations.
-    min_bandwidth: float
-        The minimum bandwidth for the KDE models
-    num_candidates: int
-        Number of candidates that are sampled to optimize the acquisition function
-    bandwidth_factor: int
-        We sample continuous hyperparameter from a truncated Normal. This factor
-        is multiplied to the bandwidth to define the standard deviation of this
-        trunacted Normal.
-    random_fraction: float
-        Defines the fraction of configurations that are drawn uniformly at random
-        instead of sampling from the model
-    points_to_evaluate: List[dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
     """
 
     def __init__(
@@ -102,6 +61,28 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
         random_fraction: Optional[float] = None,
         **kwargs,
     ):
+        """
+        Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
+
+        :param mode: Mode to use for the metric given, can be "min" or "max". Is
+            obtained from scheduler in `configure_scheduler`. Defaults to "min"
+        :param num_min_data_points: Minimum number of data points that we use to fit
+            the KDEs. If set to None, we set this to the number of hyperparameters.
+            Defaults to None.
+        :param top_n_percent: Determines how many datapoints we use to fit the first
+            KDE model for modeling the well performing configurations.
+            Defaults to 15
+        :param min_bandwidth: The minimum bandwidth for the KDE models. Defaults
+            to 1e-3
+        :param num_candidates: Number of candidates that are sampled to optimize
+            the acquisition function. Defaults to 64
+        :param bandwidth_factor: We sample continuous hyperparameter from a
+            truncated Normal. This factor is multiplied to the bandwidth to define
+            the standard deviation of this truncated Normal. Defaults to 3
+        :param random_fraction: Defines the fraction of configurations that are
+            drawn uniformly at random instead of sampling from the model.
+            Defaults to 0.33
+        """
         super().__init__(
             config_space=config_space,
             metric=metric,
@@ -272,7 +253,6 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
 
     def get_config(self, **kwargs) -> Optional[dict]:
         suggestion = self._next_initial_config()
-
         if suggestion is None:
             models = self._train_kde(np.array(self.X), np.array(self.y))
 
@@ -349,7 +329,6 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
         return suggestion
 
     def _train_kde(self, train_data, train_targets):
-
         if train_data.shape[0] < self.num_min_data_points:
             return None
 

--- a/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
     """
-    Adapts the KernelDensityEstimator to the multi-fidelity setting as proposed
+    Adapts :class:`KernelDensityEstimator` to the multi-fidelity setting as proposed
     by Falkner et al such that we can use it with Hyperband. Following Falkner
     et al, we fit the KDE only on the highest resource level where we have at
     least num_min_data_points. Code is based on the implementation by Falkner
@@ -32,53 +32,13 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
     BOHB: Robust and Efficient Hyperparameter Optimization at Scale
     S. Falkner and A. Klein and F. Hutter
     Proceedings of the 35th International Conference on Machine Learning
-
-    Parameters
-    ----------
-    config_space: dict
-        Configuration space for trial evaluation function
-    metric : str
-        Name of metric to optimize, key in result's obtained via
-        `on_trial_result`
-    random_seed_generator : RandomSeedGenerator (optional)
-        If given, the random_seed for `random_state` is obtained from there,
-        otherwise `random_seed` is used
-    random_seed : int (optional)
-        This is used if `random_seed_generator` is not given.
-    mode : str
-        Mode to use for the metric given, can be 'min' or 'max', default to 'min'.
-    num_min_data_points: int
-        Minimum number of data points that we use to fit the KDEs. If set to None
-        than we set this to the number of hyperparameters.
-    top_n_percent: int
-        Determines how many datapoints we use use to fit the first KDE model for
-        modeling the well performing configurations.
-    min_bandwidth: float
-        The minimum bandwidth for the KDE models
-    num_candidates: int
-        Number of candidates that are sampled to optimize the acquisition function
-    bandwidth_factor: int
-        We sample continuous hyperparameter from a truncated Normal. This factor is
-        multiplied to the bandwidth to define the standard deviation of this
-        trunacted Normal.
-    random_fraction: float
-        Defines the fraction of configurations that are drawn uniformly at random
-        instead of sampling from the model
-    points_to_evaluate: List[Dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
     """
 
     def __init__(
         self,
-        config_space: Dict,
+        config_space: dict,
         metric: str,
-        points_to_evaluate: Optional[List[Dict]] = None,
+        points_to_evaluate: Optional[List[dict]] = None,
         mode: Optional[str] = None,
         num_min_data_points: Optional[int] = None,
         top_n_percent: Optional[int] = None,
@@ -89,8 +49,14 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
         resource_attr: Optional[str] = None,
         **kwargs
     ):
+        """
+        Additional arguments on top of parent class :class:`KernelDensityEstimator`.
+
+        :param resource_attr: Name of resource attribute. Defaults to
+            `scheduler.resource_attr` in `configure_scheduler`
+        """
         if min_bandwidth is None:
-            min_bandwidth = 0.1  # Different default value
+            min_bandwidth = 0.1
         super().__init__(
             config_space,
             metric=metric,
@@ -122,7 +88,6 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
         self.resource_attr = scheduler.resource_attr
 
     def _train_kde(self, train_data, train_targets):
-
         # find the highest resource level we have at least num_min_data_points data points
         unique_resource_levels, counts = np.unique(
             self.resource_levels, return_counts=True

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -28,44 +28,38 @@ class PopulationElement:
 
 
 class RegularizedEvolution(SearcherWithRandomSeed):
+    """
+    Implements the regularized evolution algorithm. The original implementation
+    only considers categorical hyperparameters. For integer and float parameters
+    we sample a new value uniformly at random.
+
+    Real, E., Aggarwal, A., Huang, Y., and Le, Q. V.
+    Regularized Evolution for Image Classifier Architecture Search.
+    In Proceedings of the Conference on Artificial Intelligence (AAAI’19)
+
+    The code is based one the original regularized evolution open-source
+    implementation:
+    https://colab.research.google.com/github/google-research/google-research/blob/master/evolution/regularized_evolution_algorithm/regularized_evolution.ipynb
+    """
+
     def __init__(
         self,
         config_space,
         metric: str,
+        points_to_evaluate: Optional[List[dict]] = None,
         mode: str = "min",
         population_size: int = 100,
         sample_size: int = 10,
-        points_to_evaluate: Optional[List[dict]] = None,
         **kwargs,
     ):
         """
-        Implements the regularized evolution algorithm proposed by Real et al. The original implementation only
-        considers categorical hyperparameters. For integer and float parameters we sample a new value uniformly
-        at random.
+        Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
 
-        Real, E., Aggarwal, A., Huang, Y., and Le, Q. V.
-        Regularized Evolution for Image Classifier Architecture Search.
-        In Proceedings of the Conference on Artificial Intelligence (AAAI’19)
-
-        The code is based one the original regularized evolution open-source implementation:
-        https://colab.research.google.com/github/google-research/google-research/blob/master/evolution/regularized_evolution_algorithm/regularized_evolution.ipynb
-
-
-        Parameters
-        ----------
-        config_space: dict
-            Configuration space for trial evaluation function
-        metric : str
-            Name of metric to optimize, key in result's obtained via
-            `on_trial_result`
-        mode : str
-            Mode to use for the metric given, can be 'min' or 'max', default to 'min'.
-        population_size : int
-            Size of the population.
-        sample_size : int
-            Size of the candidate set to obtain a parent for the mutation.
-        random_seed : int
-            Seed for the random number generation. If set to None, use random seed.
+        :param mode: Mode to use for the metric given, can be "min" or "max",
+            defaults to "min"
+        :param population_size: Size of the population, defaults to 100
+        :param sample_size: Size of the candidate set to obtain a parent for the
+            mutation, defaults to 10
         """
 
         super(RegularizedEvolution, self).__init__(
@@ -78,7 +72,6 @@ class RegularizedEvolution(SearcherWithRandomSeed):
         self.num_sample_try = 1000  # number of times allowed to sample a mutation
 
     def _mutate_config(self, config: dict) -> dict:
-
         child_config = copy.deepcopy(config)
 
         # sample mutation until a different configuration is found
@@ -115,9 +108,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
         }
 
     def get_config(self, **kwargs) -> Optional[dict]:
-
         initial_config = self._next_initial_config()
-
         if initial_config is not None:
             return initial_config
 
@@ -134,7 +125,6 @@ class RegularizedEvolution(SearcherWithRandomSeed):
         return config
 
     def _update(self, trial_id: str, config: dict, result: dict):
-
         score = result[self._metric]
 
         if self.mode == "max":

--- a/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/default_arguments.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Set, Tuple, Dict
+from typing import Set, Tuple, Dict, Optional
 import logging
 import numbers
 
@@ -101,21 +101,21 @@ def check_and_merge_defaults(
     options: dict,
     mandatory: Set[str],
     default_options: dict,
-    constraints: Dict[str, CheckType] = None,
-    dict_name=None,
+    constraints: Optional[Dict[str, CheckType]] = None,
+    dict_name: Optional[str] = None,
 ) -> dict:
     """
     First, check that all keys in mandatory appear in options. Second, create
-    result_options by merging options and default_options, where entries in
-    options have precedence. Finally, if constraints is given, this is used to
+    result_options by merging `options` and `default_options`, where entries in
+    `options` have precedence. Finally, if `constraints` is given, this is used to
     check validity of values.
 
-    :param options:
-    :param mandatory:
-    :param default_options:
-    :param constraints:
-    :param dict_name:
-    :return: result_options
+    :param options: Input arguments
+    :param mandatory: Set of mandatory argument names
+    :param default_options: Default values for `options`
+    :param constraints: See above, optional
+    :param dict_name: Prefix used in assert messages, optional
+    :return: Output arguments
     """
     prefix = "" if dict_name is None else "{}: ".format(dict_name)
     for key in mandatory:
@@ -159,12 +159,12 @@ def check_and_merge_defaults(
 
 def filter_by_key(options: dict, remove_keys: Set[str]) -> dict:
     """
-    Filter options by removing entries whose keys are in remove_keys.
+    Filter options by removing entries whose keys are in `remove_keys`.
     Used to filter kwargs passed to a constructor, before passing it to
     the superclass constructor.
 
-    :param options:
-    :param remove_keys:
+    :param options: Arguments to be filtered
+    :param remove_keys: See above
     :return: Filtered options
     """
     return {k: v for k, v in options.items() if k not in remove_keys}

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
@@ -30,6 +30,16 @@ def make_hyperparameter_ranges(
     active_config_space: Optional[Dict] = None,
     prefix_keys: Optional[List[str]] = None,
 ) -> HyperparameterRanges:
+    """Default method to create `HyperparameterRanges` from `config_space`
+
+    :param config_space: Configuration space
+    :param name_last_pos: See :class:`HyperparameterRanges`, optional
+    :param value_for_last_pos: See :class:`HyperparameterRanges`, optional
+    :param active_config_space: See :class:`HyperparameterRanges`, optional
+    :param prefix_keys: See :class:`HyperparameterRanges`, optional
+    :return: New object
+    :rtype: :class:`HyperparameterRanges`
+    """
     hp_ranges = HyperparameterRangesImpl(
         config_space,
         name_last_pos=name_last_pos,

--- a/syne_tune/optimizer/schedulers/synchronous/dehb.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb.py
@@ -140,64 +140,12 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
     differ slightly from the implementation of the authors.
 
     Main differences to synchronous Hyperband:
-
     * In DEHB, trials are not paused and potentially promoted (except in the
         very first bracket). Therefore, checkpointing is not used (except in
         the very first bracket, if `support_pause_resume` is True)
     * Only the initial configurations are drawn at random (or drawn from the
         searcher). Whenever possible, new configurations (in their internal
         encoding) are derived from earlier ones by way of differential evolution
-
-    Parameters
-    ----------
-    config_space : dict
-        Configuration space for trial evaluation function
-    rungs_first_bracket : List[Tuple[int, int]]
-        Determines rung level systems for each bracket, see
-        :class:`DifferentialEvolutionHyperbandBracketManager`
-    num_brackets_per_iteration : Optional[int]
-        Number of brackets per iteration. The algorithm cycles through
-        these brackets in one iteration. If not given, the maximum
-        number is used (i.e., `len(rungs_first_bracket)`)
-    searcher : str
-        Selects searcher. Passed to `searcher_factory`.
-        If searcher == "random_encoded", the encoded configs are
-        sampled directly, each entry independent from U([0, 1]).
-        This distribution has higher entropy than for "random" if
-        there are discrete hyperparameters in `config_space`. Note that
-        `points_to_evaluate` is stll used in this case.
-    search_options : dict
-        Passed to `searcher_factory`
-    metric : str
-        Name of metric to optimize, key in result's obtained via
-        `on_trial_result`
-    mode : str
-        Mode to use for the metric given, can be 'min' or 'max'
-    points_to_evaluate: list[dict] or None
-        See :class:`SynchronousHyperbandScheduler`.
-        Note that this list is only used for initial configurations. Once
-        DEHB starts to combine new configs from earlier ones, the list here
-        is ignored, even if it still contains entries.
-    random_seed : int
-        Master random seed. Generators used in the scheduler or searcher are
-        seeded using `RandomSeedGenerator`. If not given, the master random
-        seed is drawn at random here.
-    max_resource_attr : str
-        Key name in config for fixed attribute containing the maximum resource.
-        If given, trials need not be stopped, which can run more efficiently.
-    resource_attr : str
-        Name of resource attribute in result's obtained via `on_trial_result`.
-        Note: The type of resource must be int.
-    mutation_factor : float, in (0, 1]
-        Factor F used in the rand/1 mutation operation of DE
-    crossover_probability : float, in (0, 1)
-        Probability p used in crossover operation (child entries are chosen
-        with probability p)
-    support_pause_resume : bool
-        If True, `_suggest` supports pause and resume in the first bracket. If
-        the objective supports checkpointing, this is made use of.
-        Note: The resumed trial still gets assigned a new trial_id, but it
-        starts from the earlier checkpoint.
     """
 
     MAX_RETRIES = 50
@@ -209,6 +157,62 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         num_brackets_per_iteration: Optional[int] = None,
         **kwargs,
     ):
+        """
+         :param config_space: Configuration space for trial evaluation function
+         :param rungs_first_bracket: Determines rung level systems for each
+             bracket, see :class:`DifferentialEvolutionHyperbandBracketManager`
+         :param num_brackets_per_iteration: Number of brackets per iteration. The
+             algorithm cycles through these brackets in one iteration. If not
+             given, the maximum number is used (i.e., `len(rungs_first_bracket)`)
+         :param metric: Name of metric to optimize, key in result's obtained via
+             `on_trial_result`
+         :type metric: str
+         :param searcher: Selects searcher. Passed to `searcher_factory`.
+             Must be `str`, we do not accept a :class:`BaseSearcher` object here.
+             If searcher == "random_encoded" (default), the encoded configs are
+             sampled directly, each entry independently from U([0, 1]).
+             This distribution has higher entropy than for "random" if
+             there are discrete hyperparameters in `config_space`. Note that
+             `points_to_evaluate` is still used in this case.
+         :type searcher: str, optional
+         :param search_options: Passed to `searcher_factory`
+         :type search_options: dict, optional
+         :param mode: Mode to use for the metric given, can be "min" (default) or
+             "max"
+         :type mode: str, optional
+         :param points_to_evaluate: List of configurations to be evaluated
+             initially (in that order). Each config in the list can be partially
+             specified, or even be an empty dict. For each hyperparameter not
+             specified, the default value is determined using a midpoint heuristic.
+             If None (default), this is mapped to `[dict()]`, a single default config
+             determined by the midpoint heuristic. If `[]` (empty list), no initial
+             configurations are specified.
+         :type points_to_evaluate: `List[dict]`, optional
+         :param random_seed: Master random seed. Generators used in the scheduler
+             or searcher are seeded using :class:`RandomSeedGenerator`. If not
+             given, the master random seed is drawn at random here.
+         :type random_seed: int, optional
+         :param max_resource_attr: Key name in config for fixed attribute
+             containing the maximum resource. If given, trials need not be
+             stopped, which can run more efficiently.
+         :type max_resource_attr: str, optional
+         :param resource_attr: Name of resource attribute in results obtained via
+             `on_trial_result`. The type of resource must be int. Default to
+             "epoch"
+         :type resource_attr: str, optional
+         :param mutation_factor: In `(0, 1]`. Factor F used in the rand/1 mutation
+             operation of DE. Default to 0.5
+         :type mutation_factor: float, optional
+        :param crossover_probability: In `(0, 1)`. Probability p used in crossover
+             operation (child entries are chosen with probability p). Defaults to 0.5
+         :type crossover_probability: float, optional
+         :param support_pause_resume: If True, `_suggest` supports pause and resume
+             in the first bracket (this is the default). If the objective supports
+             checkpointing, this is made use of. Defaults to True.
+             Note: The resumed trial still gets assigned a new `trial_id`, but it
+             starts from the earlier checkpoint.
+         :type support_pause_resume: bool, optional
+        """
         super().__init__(config_space)
         self._create_internal(rungs_first_bracket, num_brackets_per_iteration, **kwargs)
 

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -72,72 +72,70 @@ _CONSTRAINTS = {
 
 class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
     """
-    Synchronous Hyperband. This is still scheduling jobs asynchronously, but
-    decision-making is synchronized, in that trials are only promoted to the
-    next milestone once the rung they are currently paused at, is completely
-    occupied.
+    Synchronous Hyperband. Compared to :class:`HyperbandScheduler`, this is
+    still scheduling jobs asynchronously, but decision-making is synchronized,
+    in that trials are only promoted to the next milestone once the rung they
+    are currently paused at, is completely occupied.
 
     Our implementation never delays scheduling of a job. If the currently
     active bracket does not accept jobs, we assign the job to a later bracket.
     This means that at any point in time, several brackets can be active, but
     jobs are preferentially assigned to the first one (the "primary" active
     bracket).
-
-    Parameters
-    ----------
-    config_space : dict
-        Configuration space for trial evaluation function
-    bracket_rungs : RungSystemsPerBracket
-        Determines rung level systems for each bracket, see
-        :class:`SynchronousHyperbandBracketManager`
-    searcher : str
-        Selects searcher. Passed to `searcher_factory`.
-        NOTE: Different to :class:`FIFOScheduler`, we do not accept a
-        `BaseSearcher` object here.
-    search_options : dict
-        Passed to `searcher_factory`
-    metric : str
-        Name of metric to optimize, key in result's obtained via
-        `on_trial_result`
-    mode : str
-        Mode to use for the metric given, can be 'min' or 'max'
-    points_to_evaluate: list[dict] or None
-        List of configurations to be evaluated initially (in that order).
-        Each config in the list can be partially specified, or even be an
-        empty dict. For each hyperparameter not specified, the default value
-        is determined using a midpoint heuristic.
-        If None (default), this is mapped to [dict()], a single default config
-        determined by the midpoint heuristic. If [] (empty list), no initial
-        configurations are specified.
-        Note: If `searcher` is BaseSearcher, points_to_evaluate must be set
-        there.
-    random_seed : int
-        Master random seed. Generators used in the scheduler or searcher are
-        seeded using `RandomSeedGenerator`. If not given, the master random
-        seed is drawn at random here.
-    max_resource_attr : str
-        Key name in config for fixed attribute containing the maximum resource.
-        If given, trials need not be stopped, which can run more efficiently.
-    resource_attr : str
-        Name of resource attribute in result's obtained via `on_trial_result`.
-        Note: The type of resource must be int.
-    searcher_data : str
-        Relevant only if a model-based searcher is used.
-        Example: For NN tuning and `resource_attr == epoch', we receive a
-        result for each epoch, but not all epoch values are also rung levels.
-        searcher_data determines which of these results are passed to the
-        searcher. As a rule, the more data the searcher receives, the better
-        its fit, but also the more expensive get_config may become. Choices:
-        - 'rungs' (default): Only results at rung levels. Cheapest
-        - 'all': All results. Most expensive
-        Note: For a Gaussian additive learning curve surrogate model, this
-        has to be set to 'all'.
-
     """
 
     def __init__(
         self, config_space: dict, bracket_rungs: RungSystemsPerBracket, **kwargs
     ):
+        """
+        :param config_space: Configuration space for trial evaluation function
+        :param bracket_rungs: :class:`RungSystemsPerBracket`. Determines rung
+            level systems for each bracket, see
+            :class:`SynchronousHyperbandBracketManager`
+        :param metric: Name of metric to optimize, key in result's obtained via
+            `on_trial_result`
+        :type metric: str
+        :param searcher: Selects searcher. Passed to `searcher_factory`.
+            Must be `str`, we do not accept a :class:`BaseSearcher` object here.
+            Defaults to "random"
+        :type searcher: str, optional
+        :param search_options: Passed to `searcher_factory`
+        :type search_options: dict, optional
+        :param mode: Mode to use for the metric given, can be "min" (default) or
+            "max"
+        :type mode: str, optional
+        :param points_to_evaluate: List of configurations to be evaluated
+            initially (in that order). Each config in the list can be partially
+            specified, or even be an empty dict. For each hyperparameter not
+            specified, the default value is determined using a midpoint heuristic.
+            If None (default), this is mapped to `[dict()]`, a single default config
+            determined by the midpoint heuristic. If `[]` (empty list), no initial
+            configurations are specified.
+        :type points_to_evaluate: `List[dict]`, optional
+        :param random_seed: Master random seed. Generators used in the scheduler
+            or searcher are seeded using :class:`RandomSeedGenerator`. If not
+            given, the master random seed is drawn at random here.
+        :type random_seed: int, optional
+        :param max_resource_attr: Key name in config for fixed attribute
+            containing the maximum resource. If given, trials need not be
+            stopped, which can run more efficiently.
+        :type max_resource_attr: str, optional
+        :param resource_attr: Name of resource attribute in results obtained via
+            `on_trial_result`. The type of resource must be int. Default to
+            "epoch"
+        :type resource_attr: str, optional
+        :param searcher_data: Relevant only if a model-based searcher is used.
+            Example: For NN tuning and `resource_attr == epoch', we receive a
+            result for each epoch, but not all epoch values are also rung levels.
+            searcher_data determines which of these results are passed to the
+            searcher. As a rule, the more data the searcher receives, the better
+            its fit, but also the more expensive get_config may become. Choices:
+            * "rungs" (default): Only results at rung levels. Cheapest
+            * "all": All results. Most expensive
+            Note: For a Gaussian additive learning curve surrogate model, this
+            has to be set to "all".
+        :type searcher_data: str, optional
+        """
         super().__init__(config_space)
         self._create_internal(bracket_rungs, **kwargs)
 

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -49,25 +49,65 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
     defined by geometric sequences (see
     `SynchronousHyperbandRungSystem.geometric`). This is the most frequently
     used case.
-
-    Additional parameters
-    ---------------------
-    grace_period : int
-        Smallest (resource) rung level. Must be positive int.
-    reduction_factor : float
-        Approximate ratio of successive rung levels. Must be >= 2.
-    max_resource_level : int (optional)
-        Largest rung level, corresponds to `max_t` in
-        :class:`FIFOScheduler`. Must be positive int larger than
-        `grace_period`. If this is not given, it is inferred like in
-        :class:`FIFOScheduler`.
-    brackets : int (optional)
-        Number of brackets to be used. The default is to use the maximum
-        number of brackets per iteration. Pass 1 for successive halving.
-
     """
 
     def __init__(self, config_space: dict, **kwargs):
+        """
+        :param config_space: Configuration space for trial evaluation function
+        :param grace_period: Smallest (resource) rung level. Must be positive int.
+        :param reduction_factor: Approximate ratio of successive rung levels. Must
+            be >= 2.
+        :param max_resource_level: Largest rung level, corresponds to `max_t` in
+            :class:`FIFOScheduler`. Must be positive int larger than
+            `grace_period`. If this is not given, it is inferred like in
+            :class:`FIFOScheduler`.
+        :param brackets: Number of brackets to be used. The default is to use the
+            maximum number of brackets per iteration. Pass 1 for successive halving.
+        :param metric: Name of metric to optimize, key in result's obtained via
+            `on_trial_result`
+        :type metric: str
+        :param searcher: Selects searcher. Passed to `searcher_factory`.
+            Must be `str`, we do not accept a :class:`BaseSearcher` object here.
+            Defaults to "random"
+        :type searcher: str, optional
+        :param search_options: Passed to `searcher_factory`
+        :type search_options: dict, optional
+        :param mode: Mode to use for the metric given, can be "min" (default) or
+            "max"
+        :type mode: str, optional
+        :param points_to_evaluate: List of configurations to be evaluated
+            initially (in that order). Each config in the list can be partially
+            specified, or even be an empty dict. For each hyperparameter not
+            specified, the default value is determined using a midpoint heuristic.
+            If None (default), this is mapped to `[dict()]`, a single default config
+            determined by the midpoint heuristic. If `[]` (empty list), no initial
+            configurations are specified.
+        :type points_to_evaluate: `List[dict]`, optional
+        :param random_seed: Master random seed. Generators used in the scheduler
+            or searcher are seeded using :class:`RandomSeedGenerator`. If not
+            given, the master random seed is drawn at random here.
+        :type random_seed: int, optional
+        :param max_resource_attr: Key name in config for fixed attribute
+            containing the maximum resource. If given, trials need not be
+            stopped, which can run more efficiently.
+        :type max_resource_attr: str, optional
+        :param resource_attr: Name of resource attribute in results obtained via
+            `on_trial_result`. The type of resource must be int. Default to
+            "epoch"
+        :type resource_attr: str, optional
+        :param searcher_data: Relevant only if a model-based searcher is used.
+            Example: For NN tuning and `resource_attr == epoch', we receive a
+            result for each epoch, but not all epoch values are also rung levels.
+            searcher_data determines which of these results are passed to the
+            searcher. As a rule, the more data the searcher receives, the better
+            its fit, but also the more expensive get_config may become. Choices:
+            * "rungs" (default): Only results at rung levels. Cheapest
+            * "all": All results. Most expensive
+            Note: For a Gaussian additive learning curve surrogate model, this
+            has to be set to "all".
+        :type searcher_data: str, optional
+
+        """
         TrialScheduler.__init__(self, config_space)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(
@@ -101,25 +141,69 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
     Special case of :class:`DifferentialEvolutionHyperbandScheduler` with
     rung system defined by geometric sequences. This is the most frequently
     used case.
-
-    Additional parameters
-    ---------------------
-    grace_period : int
-        Smallest (resource) rung level. Must be positive int.
-    reduction_factor : float
-        Approximate ratio of successive rung levels. Must be >= 2.
-    max_resource_level : int (optional)
-        Largest rung level, corresponds to `max_t` in
-        :class:`FIFOScheduler`. Must be positive int larger than
-        `grace_period`. If this is not given, it is inferred like in
-        :class:`FIFOScheduler`.
-    brackets : int (optional)
-        Number of brackets to be used. The default is to use the maximum
-        number of brackets per iteration, which is recommended for DEHB
-
     """
 
     def __init__(self, config_space: dict, **kwargs):
+        """
+         :param config_space: Configuration space for trial evaluation function
+         :param grace_period: Smallest (resource) rung level. Must be positive int.
+         :param reduction_factor: Approximate ratio of successive rung levels. Must
+             be >= 2.
+         :param max_resource_level: Largest rung level, corresponds to `max_t` in
+             :class:`FIFOScheduler`. Must be positive int larger than
+             `grace_period`. If this is not given, it is inferred like in
+             :class:`FIFOScheduler`.
+         :param brackets: Number of brackets to be used. The default is to use the
+             maximum number of brackets per iteration. Pass 1 for successive halving.
+         :param metric: Name of metric to optimize, key in result's obtained via
+             `on_trial_result`
+         :type metric: str
+         :param searcher: Selects searcher. Passed to `searcher_factory`.
+             Must be `str`, we do not accept a :class:`BaseSearcher` object here.
+             If searcher == "random_encoded" (default), the encoded configs are
+             sampled directly, each entry independently from U([0, 1]).
+             This distribution has higher entropy than for "random" if
+             there are discrete hyperparameters in `config_space`. Note that
+             `points_to_evaluate` is still used in this case.
+         :type searcher: str, optional
+         :param search_options: Passed to `searcher_factory`
+         :type search_options: dict, optional
+         :param mode: Mode to use for the metric given, can be "min" (default) or
+             "max"
+         :type mode: str, optional
+         :param points_to_evaluate: List of configurations to be evaluated
+             initially (in that order). Each config in the list can be partially
+             specified, or even be an empty dict. For each hyperparameter not
+             specified, the default value is determined using a midpoint heuristic.
+             If None (default), this is mapped to `[dict()]`, a single default config
+             determined by the midpoint heuristic. If `[]` (empty list), no initial
+             configurations are specified.
+         :type points_to_evaluate: `List[dict]`, optional
+         :param random_seed: Master random seed. Generators used in the scheduler
+             or searcher are seeded using :class:`RandomSeedGenerator`. If not
+             given, the master random seed is drawn at random here.
+         :type random_seed: int, optional
+         :param max_resource_attr: Key name in config for fixed attribute
+             containing the maximum resource. If given, trials need not be
+             stopped, which can run more efficiently.
+         :type max_resource_attr: str, optional
+         :param resource_attr: Name of resource attribute in results obtained via
+             `on_trial_result`. The type of resource must be int. Default to
+             "epoch"
+         :type resource_attr: str, optional
+         :param mutation_factor: In `(0, 1]`. Factor F used in the rand/1 mutation
+             operation of DE. Default to 0.5
+         :type mutation_factor: float, optional
+        :param crossover_probability: In `(0, 1)`. Probability p used in crossover
+             operation (child entries are chosen with probability p). Defaults to 0.5
+         :type crossover_probability: float, optional
+         :param support_pause_resume: If True, `_suggest` supports pause and resume
+             in the first bracket (this is the default). If the objective supports
+             checkpointing, this is made use of. Defaults to True.
+             Note: The resumed trial still gets assigned a new `trial_id`, but it
+             starts from the earlier checkpoint.
+         :type support_pause_resume: bool, optional
+        """
         TrialScheduler.__init__(self, config_space)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(

--- a/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/bounding_box.py
@@ -30,6 +30,20 @@ from syne_tune.config_space import (
 
 
 class BoundingBox(TransferLearningMixin, TrialScheduler):
+    """
+    Simple baseline that computes a bounding-box of the best candidate found in
+    previous tasks to restrict the search space to only good candidates. The
+    bounding-box is obtained by restricting to the min-max of best numerical
+    hyperparameters and restricting to the set of best candidates on categorical
+    parameters.
+
+    Reference:
+    Learning search spaces for Bayesian optimization: Another view of
+        hyperparameter transfer learning.
+    Valerio Perrone, Huibin Shen, Matthias Seeger, Cédric Archambeau,
+        Rodolphe Jenatton. NeurIPS 2019.
+    """
+
     def __init__(
         self,
         scheduler_fun: Callable[[dict, str, str], TrialScheduler],
@@ -40,26 +54,26 @@ class BoundingBox(TransferLearningMixin, TrialScheduler):
         num_hyperparameters_per_task: int = 1,
     ):
         """
-        Simple baseline that computes a bounding-box of the best candidate found in previous tasks to restrict the
-         search space to only good candidates. The bounding-box is obtained by restricting to the min-max of best
-         numerical hyperparameters and restricting to the set of best candidates on categorical parameters.
+        `scheduler_fun` is used to create the scheduler to be used here, feeding
+        it with the modified config space. Any additional scheduler arguments
+        (such as `points_to_evaluate`) should be encoded inside this function.
 
-        Reference: Learning search spaces for Bayesian optimization: Another view of hyperparameter transfer learning.
-        Valerio Perrone, Huibin Shen, Matthias Seeger, Cédric Archambeau, Rodolphe Jenatton. Neurips 2019.
-
-        :param scheduler_fun: function that takes a configuration space (dict), a mode (str) and a metric (str)
-        and returns a scheduler. This is required since the final configuration space is known only after computing
-        a bounding-box. For instance,
-        `scheduler_fun=lambda new_config_space, mode, metric: RandomSearch(new_config_space, metric, mode)`
-        will consider a random-search on the config-space is restricted to the bounding of best evaluations of previous
-        tasks.
-        :param config_space: initial search-space to consider, will be updated to the bounding of best evaluations of
-        previous tasks
-        :param metric: objective name to optimize, must be present in transfer learning evaluations.
-        :param transfer_learning_evaluations: dictionary from task name to offline evaluations.
-        :param mode: mode to be considered, default to min.
-        :param num_hyperparameters_per_task: number of best hyperparameter to take per task when computing the bounding
-        box, default to 1.
+        :param scheduler_fun: Maps tuple of configuration space (dict), mode (str),
+            metric (str) to a scheduler. This is required since the final
+            configuration space is known only after computing a bounding-box. For
+            instance:
+            `scheduler_fun=lambda new_config_space, mode, metric: RandomSearch(new_config_space, metric, mode)`
+            will consider a random-search on the config-space is restricted to
+            the bounding of best evaluations of previous tasks.
+        :param config_space: Initial search-space to consider, will be updated
+            to the bounding of best evaluations of previous tasks
+        :param metric: Objective name to optimize, must be present in transfer
+            learning evaluations.
+        :param mode: Mode to be considered, default to "min".
+        :param transfer_learning_evaluations: Dictionary from task name to
+            offline evaluations.
+        :param num_hyperparameters_per_task: Number of best hyperparameter to
+            take per task when computing the bounding box, default to 1.
         """
         super().__init__(
             config_space=config_space,

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
@@ -110,6 +110,18 @@ def subsample(
 
 
 class QuantileBasedSurrogateSearcher(SearcherWithRandomSeed):
+    """
+    Implements the transfer-learning method:
+
+    A Quantile-based Approach for Hyperparameter Transfer Learning.
+    David Salinas, Huibin Shen, Valerio Perrone. ICML 2020.
+
+    This is the Copula Thompson Sampling approach described in the paper where a
+    surrogate is fitted on the transfer learning data to predict mean/variance of
+    configuration performance given a hyperparameter. The surrogate is then sampled
+    from and the best configurations are returned as next candidate to evaluate.
+    """
+
     def __init__(
         self,
         config_space: dict,
@@ -121,20 +133,17 @@ class QuantileBasedSurrogateSearcher(SearcherWithRandomSeed):
         **kwargs,
     ):
         """
-        Implement the transfer-learning method:
-        A Quantile-based Approach for Hyperparameter Transfer Learning.
-        David Salinas, Huibin Shen, Valerio Perrone. ICML 2020.
-        This is the Copula Thompson Sampling approach described in the paper where a surrogate is fitted on the
-        transfer learning data to predict mean/variance of configuration performance given a hyperparameter.
-        The surrogate is then sampled from and the best configurations are returned as next candidate to evaluate.
-        :param config_space:
-        :param mode: whether to minimize or maximize, default to 'min'.
-        :param metric: metric to optimize
-        :param transfer_learning_evaluations: dictionary from task name to offline evaluations.
-        :param max_fit_samples: maximum number to use when fitting the method.
-        :param normalization: default to "gaussian" which first computes the rank and then applies Gaussian inverse CDF.
-        "standard" applies just standard normalization (remove mean and divide by variance) but performs significanly
-        worse.
+        Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
+
+        :param mode: Whether to minimize or maximize, default to "min".
+        :param transfer_learning_evaluations: Dictionary from task name to offline
+            evaluations.
+        :param max_fit_samples: Maximum number to use when fitting the method.
+            Defaults to 100000
+        :param normalization: Default to "gaussian" which first computes the rank
+            and then applies Gaussian inverse CDF. "standard" applies just
+            standard normalization (remove mean and divide by variance) but can
+            perform significantly worse.
         """
         super(QuantileBasedSurrogateSearcher, self).__init__(
             config_space=config_space,

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -28,6 +28,18 @@ logger = logging.getLogger(__name__)
 
 
 class ZeroShotTransfer(TransferLearningMixin, SearcherWithRandomSeed):
+    """
+    A zero-shot transfer hyperparameter optimization method which jointly selects
+    configurations that minimize the average rank obtained on historic metadata
+    (`transfer_learning_evaluations`). This is a searcher which can be used
+    with :class:`FIFOScheduler`.
+
+    Reference:
+    Sequential Model-Free Hyperparameter Tuning.
+    Martin Wistuba, Nicolas Schilling, Lars Schmidt-Thieme.
+    IEEE International Conference on Data Mining (ICDM) 2015.
+    """
+
     def __init__(
         self,
         config_space: dict,
@@ -39,21 +51,19 @@ class ZeroShotTransfer(TransferLearningMixin, SearcherWithRandomSeed):
         **kwargs,
     ) -> None:
         """
-        A zero-shot transfer hyperparameter optimization method which jointly selects configurations that minimize the
-        average rank obtained on historic metadata (transfer_learning_evaluations).
+        Additional arguments on top of parent class :class:`BaseSearcher`.
 
-        Reference: Sequential Model-Free Hyperparameter Tuning.
-        Martin Wistuba, Nicolas Schilling, Lars Schmidt-Thieme.
-        IEEE International Conference on Data Mining (ICDM) 2015.
-
-        :param config_space: Configuration space for trial evaluation function.
-        :param transfer_learning_evaluations: dictionary from task name to offline evaluations.
-        :param metric: Objective name to optimize, must be present in transfer learning evaluations.
-        :param mode: Whether to minimize (min) or maximize (max)
-        :param sort_transfer_learning_evaluations: Use False if the hyperparameters for each task in
-        transfer_learning_evaluations Are already in the same order. If set to True, hyperparameters are sorted.
-        :param use_surrogates: If the same configuration is not evaluated on all tasks, set this to true. This will
-        generate a set of configurations and will impute their performance using surrogate models.
+        :param transfer_learning_evaluations: Dictionary from task name to
+            offline evaluations.
+        :param mode: Whether to minimize ("min", default) or maximize ("max")
+        :param sort_transfer_learning_evaluations: Use False if the
+            hyperparameters for each task in `transfer_learning_evaluations` are
+            already in the same order. If set to True, hyperparameters are sorted.
+            Defaults to True
+        :param use_surrogates: If the same configuration is not evaluated on all
+            tasks, set this to True. This will generate a set of configurations
+            and will impute their performance using surrogate models.
+            Defaults to False
         """
         super().__init__(
             config_space=config_space,
@@ -178,6 +188,3 @@ class ZeroShotTransfer(TransferLearningMixin, SearcherWithRandomSeed):
 
     def _update(self, trial_id: str, config: dict, result: dict) -> None:
         pass
-
-    def clone_from_state(self, state: dict):
-        raise NotImplementedError


### PR DESCRIPTION
…hinx API docs

*Issue #, if available:*

*Description of changes:*
This is the second PR towards hosting API docs. It refactors and extends the docstrings of all user-facing code.

Note that the docstrings do not contain types for each argument. According to Martin, we can use this tool:

`https://github.com/tox-dev/sphinx-autodoc-typehints`

in order to get the types in the API docs if we use `typing` annotation (which we generally do).

The docstrings should include defaults.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
