### PR TITLE
Update the number of random retires to a larger value

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -90,7 +90,7 @@ from syne_tune.optimizer.schedulers.utils.simple_profiler import SimpleProfiler
 logger = logging.getLogger(__name__)
 
 
-GET_CONFIG_RANDOM_RETRIES = 50
+GET_CONFIG_RANDOM_RETRIES = 100000
 
 
 def create_initial_candidates_scorer(


### PR DESCRIPTION
*Description of changes:*
When we are setting a fixed seed, random sampling always have the same behaviors. and It would be running out of search space if we run a large number of training jobs. 
This can be reproduced by testing large budget (e.g. max_training_jobs: 100, batch_size: 1) and setting the seed to a fixed value.
So we are increasing the number of random retries (Exclusion List size) to 100k. which is above our config limit(10k).

Closes #430 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
