### PR TITLE
Add example showing how to retrieve a checkpoint from an xgboost model.

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -208,18 +208,13 @@ More details are found in
 `this tutorial <tutorials/benchmarking/bm_sagemaker.rst#using-sageMaker-managed-warm-pools>`__.
 
 Retrieving the best checkpoint
-=================================
+==============================
 
-.. literalinclude:: ../../examples/launch_standalone_bayesian_optimization.py
-   :caption: examples/launch_standalone_bayesian_optimization.py
+.. literalinclude:: ../../examples/launch_checkpoint_example.py
+   :caption: examples/launch_checkpoint_example.py
    :lines: 13-
 
-Syne Tune combines a scheduler (HPO algorithm) with a backend to provide a
-complete HPO solution. If you already have a system in place for job
-scheduling and managing the state of the tuning problem, you may want to
-call the scheduler on its own. This example demonstrates how to do this
-for Gaussian process based Bayesian optimization.
-
+Example showing how to retrieve the best checkpoint obtained after tuning.
 
 Launch with SageMaker Backend and Custom Docker Image
 =====================================================

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -207,6 +207,19 @@ are strongly recommended for multi-fidelity HPO with the SageMaker backend.
 More details are found in
 `this tutorial <tutorials/benchmarking/bm_sagemaker.rst#using-sageMaker-managed-warm-pools>`__.
 
+Retrieving the best checkpoint
+=================================
+
+.. literalinclude:: ../../examples/launch_standalone_bayesian_optimization.py
+   :caption: examples/launch_standalone_bayesian_optimization.py
+   :lines: 13-
+
+Syne Tune combines a scheduler (HPO algorithm) with a backend to provide a
+complete HPO solution. If you already have a system in place for job
+scheduling and managing the state of the tuning problem, you may want to
+call the scheduler on its own. This example demonstrates how to do this
+for Gaussian process based Bayesian optimization.
+
 
 Launch with SageMaker Backend and Custom Docker Image
 =====================================================

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -269,6 +269,14 @@ Finally, the scheduler provides additional information about checkpointing in
 this: ``add_checkpointing_to_argparse(parser)`` adds corresponding arguments to
 the parser.
 
+
+How can I retrieve the best checkpoint obtained after tuning?
+===========================================
+
+You can take a look at this example
+`examples/launch_checkpoint_example.py <examples.html#retrieving-the-best-checkpoint>`__
+which shows how to retrieve the best checkpoint obtained after tuning an XGBoost model.
+
 Which schedulers make use of checkpointing?
 ===========================================
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -271,7 +271,7 @@ the parser.
 
 
 How can I retrieve the best checkpoint obtained after tuning?
-===========================================
+=============================================================
 
 You can take a look at this example
 `examples/launch_checkpoint_example.py <examples.html#retrieving-the-best-checkpoint>`__

--- a/examples/launch_checkpoint_example.py
+++ b/examples/launch_checkpoint_example.py
@@ -1,8 +1,3 @@
-"""
-An example showing how to retrieve the best checkpoint of an XGBoost model.
-The script being tuned `xgboost_checkpoint.py` stores the checkpoint obtained after each trial evaluation.
-After the tuning is done, this example loads the best checkpoint and evaluate the model.
-"""
 # Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -15,6 +10,12 @@ After the tuning is done, this example loads the best checkpoint and evaluate th
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+"""
+An example showing how to retrieve the best checkpoint of an XGBoost model.
+The script being tuned `xgboost_checkpoint.py` stores the checkpoint obtained after each trial evaluation.
+After the tuning is done, this example loads the best checkpoint and evaluate the model.
+"""
+
 import logging
 from pathlib import Path
 
@@ -55,7 +56,7 @@ if __name__ == "__main__":
 
     exp = load_experiment(tuner.name)
     best_config = exp.best_config()
-    checkpoint = exp.path / str(best_config["trial_id"]) / "checkpoints"
+    checkpoint = trial_backend.checkpoint_trial_path(best_config['trial_id'])
     assert checkpoint.exists()
 
     print(f"Best config found {best_config} checkpointed at {checkpoint}")

--- a/examples/launch_checkpoint_example.py
+++ b/examples/launch_checkpoint_example.py
@@ -1,0 +1,65 @@
+"""
+An example showing how to retrieve the best checkpoint of an XGBoost model.
+The script being tuned `xgboost_checkpoint.py` stores the checkpoint obtained after each trial evaluation.
+"""
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+from pathlib import Path
+
+from examples.training_scripts.xgboost.xgboost_checkpoint import evaluate_accuracy
+from syne_tune.backend import LocalBackend
+from syne_tune.experiments import load_experiment
+from syne_tune.optimizer.baselines import BayesianOptimization
+from syne_tune import Tuner, StoppingCriterion
+import syne_tune.config_space as cs
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+
+    n_workers = 4
+
+    config_space = {
+        "max_depth": cs.randint(2, 5),
+        "gamma": cs.uniform(1, 9),
+        "reg_lambda": cs.loguniform(1e-6, 1),
+        "n_estimators": cs.randint(1, 10),
+    }
+
+    entry_point = (
+        Path(__file__).parent / "training_scripts" / "xgboost" / "xgboost_checkpoint.py"
+    )
+
+    trial_backend = LocalBackend(entry_point=str(entry_point))
+
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        scheduler=BayesianOptimization(config_space, metric="merror", mode="min"),
+        stop_criterion=StoppingCriterion(max_wallclock_time=10),
+        n_workers=n_workers,
+    )
+
+    tuner.run()
+
+    exp = load_experiment(tuner.name)
+    best_config = exp.best_config()
+    checkpoint = exp.path / str(best_config["trial_id"]) / "checkpoints"
+    assert checkpoint.exists()
+
+    print(f"Best config found {best_config} checkpointed at {checkpoint}")
+
+    print(
+        f"Retrieve best checkpoint and evaluate accuracy of best model: "
+        f"found {evaluate_accuracy(checkpoint_dir=checkpoint)}"
+    )

--- a/examples/launch_checkpoint_example.py
+++ b/examples/launch_checkpoint_example.py
@@ -1,6 +1,7 @@
 """
 An example showing how to retrieve the best checkpoint of an XGBoost model.
 The script being tuned `xgboost_checkpoint.py` stores the checkpoint obtained after each trial evaluation.
+After the tuning is done, this example loads the best checkpoint and evaluate the model.
 """
 # Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/examples/training_scripts/xgboost/xgboost_checkpoint.py
+++ b/examples/training_scripts/xgboost/xgboost_checkpoint.py
@@ -1,0 +1,107 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+
+import numpy as np
+import xgboost
+from sklearn.datasets import load_digits
+
+from syne_tune import Reporter
+from syne_tune.constants import ST_CHECKPOINT_DIR
+
+
+class SyneTuneCallback(xgboost.callback.TrainingCallback):
+    def __init__(self, error_metric: str) -> None:
+        self.reporter = Reporter()
+        self.error_metric = error_metric
+
+    def after_iteration(self, model, epoch, evals_log):
+        metrics = list(evals_log.values())[-1][self.error_metric]
+        self.reporter(**{self.error_metric: metrics[-1]})
+        pass
+
+
+def train(
+    checkpoint_dir: str,
+    n_estimators: int,
+    max_depth: int,
+    gamma: float,
+    reg_lambda: float,
+    early_stopping_rounds: int = 5,
+) -> None:
+    eval_metric = "merror"
+    early_stop = xgboost.callback.EarlyStopping(
+        rounds=early_stopping_rounds, save_best=True
+    )
+    X, y = load_digits(return_X_y=True)
+
+    clf = xgboost.XGBClassifier(
+        n_estimators=n_estimators,
+        reg_lambda=reg_lambda,
+        gamma=gamma,
+        max_depth=max_depth,
+        eval_metric=eval_metric,
+        callbacks=[early_stop, SyneTuneCallback(error_metric=eval_metric)],
+    )
+    clf.fit(
+        X,
+        y,
+        eval_set=[(X, y)],
+    )
+    print("Total boosted rounds:", clf.get_booster().num_boosted_rounds())
+
+    save_model(clf, checkpoint_dir=checkpoint_dir)
+
+
+def save_model(clf, checkpoint_dir):
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    path = os.path.join(checkpoint_dir, "model.json")
+    clf.save_model(path)
+
+
+def load_model(checkpoint_dir):
+    path = os.path.join(checkpoint_dir, "model.json")
+    loaded = xgboost.XGBClassifier()
+    loaded.load_model(path)
+    return loaded
+
+
+def evaluate_accuracy(checkpoint_dir):
+    X, y = load_digits(return_X_y=True)
+
+    clf = load_model(checkpoint_dir=checkpoint_dir)
+    y_pred = clf.predict(X)
+    return (np.equal(y, y_pred) * 1.0).mean()
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--max_depth", type=int, required=False, default=1)
+    parser.add_argument("--gamma", type=float, required=False, default=2)
+    parser.add_argument("--reg_lambda", type=float, required=False, default=0.001)
+    parser.add_argument("--n_estimators", type=int, required=False, default=10)
+    parser.add_argument(f"--{ST_CHECKPOINT_DIR}", type=str, default="./")
+
+    args, _ = parser.parse_known_args()
+
+    checkpoint_dir = Path(vars(args)[ST_CHECKPOINT_DIR])
+
+    train(
+        checkpoint_dir=checkpoint_dir,
+        max_depth=args.max_depth,
+        gamma=args.gamma,
+        reg_lambda=args.reg_lambda,
+        n_estimators=args.n_estimators,
+    )

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -89,16 +89,16 @@ class LocalBackend(TrialBackend):
     def trial_path(self, trial_id: int) -> Path:
         return self.local_path / str(trial_id)
 
-    def _checkpoint_trial_path(self, trial_id: int):
+    def checkpoint_trial_path(self, trial_id: int):
         return self.trial_path(trial_id) / "checkpoints"
 
     def copy_checkpoint(self, src_trial_id: int, tgt_trial_id: int):
-        src_checkpoint_path = self._checkpoint_trial_path(src_trial_id)
-        tgt_checkpoint_path = self._checkpoint_trial_path(tgt_trial_id)
+        src_checkpoint_path = self.checkpoint_trial_path(src_trial_id)
+        tgt_checkpoint_path = self.checkpoint_trial_path(tgt_trial_id)
         shutil.copytree(src_checkpoint_path, tgt_checkpoint_path)
 
     def delete_checkpoint(self, trial_id: int):
-        checkpoint_path = self._checkpoint_trial_path(trial_id)
+        checkpoint_path = self.checkpoint_trial_path(trial_id)
         shutil.rmtree(checkpoint_path, ignore_errors=True)
 
     def _prepare_for_schedule(self, num_gpus=None):

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -46,6 +46,7 @@ class ExperimentResult:
     results: pd.DataFrame
     metadata: dict
     tuner: Tuner
+    path: Path
 
     def __str__(self):
         res = f"Experiment {self.name}"
@@ -198,6 +199,7 @@ def load_experiment(
         results=results,
         tuner=tuner,
         metadata=metadata,
+        path=path,
     )
 
 

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -40,6 +40,7 @@ class ExperimentResult:
     :param results: Dataframe containing results of experiment
     :param metadata: Metadata stored along with results
     :param tuner: :class:`syne_tune.Tuner` object stored along with results
+    :param path: local path where the experiment is stored
     """
 
     name: str


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/syne-tune/issues/422

*Description of changes:* Provides an example to retrieve the best checkpoint of a model after tuning. Also show log of trials to user when no metrics are emitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
