### PR TITLE
Fix conditional dependencies for backends

### DIFF
--- a/.github/workflows/check-standalone-bayesian-optimization.yml
+++ b/.github/workflows/check-standalone-bayesian-optimization.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements-gpsearchers.txt -r requirements.txt --upgrade pip
+        python -m pip install -r requirements-gpsearchers.txt --upgrade pip
         python -m pip install typing_extensions
     - name: Check that stand-alone bayesian-optimation example runs
       run: |

--- a/.github/workflows/check-standalone-bayesian-optimization.yml
+++ b/.github/workflows/check-standalone-bayesian-optimization.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements-gpsearchers.txt --upgrade pip
+        python -m pip install -r requirements-gpsearchers.txt -r requirements.txt --upgrade pip
         python -m pip install typing_extensions
     - name: Check that stand-alone bayesian-optimation example runs
       run: |

--- a/syne_tune/backend/__init__.py
+++ b/syne_tune/backend/__init__.py
@@ -11,27 +11,13 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__all__ = []
+__all__ = ["LocalBackend", "PythonBackend"]
 
 import logging
 
-from syne_tune.try_import import try_import_backend_message
-
-try:
-    from syne_tune.backend.local_backend import LocalBackend  # noqa: F401
-
-    __all__.append("LocalBackend")
-except ImportError:
-    logging.info(try_import_backend_message("LocalBackend"))
-
-try:
-    from syne_tune.backend.python_backend.python_backend import (  # noqa: F401
-        PythonBackend,
-    )
-
-    __all__.append("PythonBackend")
-except ImportError:
-    logging.info(try_import_backend_message("PythonBackend"))
+from syne_tune.try_import import try_import_aws_message
+from syne_tune.backend.local_backend import LocalBackend  # noqa: F401
+from syne_tune.backend.python_backend.python_backend import PythonBackend  # noqa: F401
 
 try:
     from syne_tune.backend.sagemaker_backend.sagemaker_backend import (  # noqa: F401
@@ -40,4 +26,4 @@ try:
 
     __all__.append("SageMakerBackend")
 except ImportError:
-    logging.info(try_import_backend_message("SageMakerBackend"))
+    logging.info(try_import_aws_message())

--- a/syne_tune/backend/__init__.py
+++ b/syne_tune/backend/__init__.py
@@ -11,13 +11,21 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__all__ = ["LocalBackend", "PythonBackend"]
+__all__ = []
 
 import logging
 
-from syne_tune.try_import import try_import_aws_message
-from syne_tune.backend.local_backend import LocalBackend  # noqa: F401
-from syne_tune.backend.python_backend.python_backend import PythonBackend  # noqa: F401
+from syne_tune.try_import import try_import_aws_message, try_import_backends_message
+
+try:
+    from syne_tune.backend.local_backend import LocalBackend  # noqa: F401
+    from syne_tune.backend.python_backend.python_backend import (
+        PythonBackend,
+    )  # noqa: F401
+
+    __all__ = ["LocalBackend", "PythonBackend"]
+except ImportError:
+    logging.info(try_import_backends_message())
 
 try:
     from syne_tune.backend.sagemaker_backend.sagemaker_backend import (  # noqa: F401

--- a/syne_tune/backend/local_backend.py
+++ b/syne_tune/backend/local_backend.py
@@ -22,8 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from syne_tune.backend.trial_backend import TrialBackend
-from syne_tune.backend.sagemaker_backend.sagemaker_backend import BUSY_STATUS
+from syne_tune.backend.trial_backend import TrialBackend, BUSY_STATUS
 from syne_tune.num_gpu import get_num_gpus
 from syne_tune.report import retrieve
 from syne_tune.backend.trial_status import TrialResult, Status

--- a/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
@@ -23,7 +23,7 @@ import time
 from sagemaker import LocalSession
 from sagemaker.estimator import Framework
 
-from syne_tune.backend.trial_backend import TrialBackend
+from syne_tune.backend.trial_backend import TrialBackend, BUSY_STATUS
 from syne_tune.constants import ST_INSTANCE_TYPE, ST_INSTANCE_COUNT, ST_CHECKPOINT_DIR
 from syne_tune.util import s3_experiment_path
 from syne_tune.backend.trial_status import TrialResult, Status
@@ -42,9 +42,6 @@ from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
 
 
 logger = logging.getLogger(__name__)
-
-
-BUSY_STATUS = {Status.in_progress, Status.stopping}
 
 
 class SageMakerBackend(TrialBackend):

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -29,6 +29,9 @@ TrialAndStatusInformation = Dict[int, Tuple[Trial, str]]
 TrialIdAndResultList = List[Tuple[int, dict]]
 
 
+BUSY_STATUS = {Status.in_progress, Status.stopping}
+
+
 class TrialBackend:
     """
     Interface for back-end to execute evaluations of trials.

--- a/syne_tune/try_import.py
+++ b/syne_tune/try_import.py
@@ -10,6 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+from typing import Optional
 
 
 def try_import_gpsearchers_message() -> str:

--- a/syne_tune/try_import.py
+++ b/syne_tune/try_import.py
@@ -60,14 +60,6 @@ def try_import_yahpo_message() -> str:
     )
 
 
-def try_import_backend_message(backend_type: str) -> str:
-    return (
-        f"{backend_type} is not imported"
-        + " since dependencies are missing. You can install them with\n"
-        + "   pip install 'syne-tune[extra]'"
-    )
-
-
 def _try_import_message(message_text: str, tag: str) -> str:
     return (
         message_text

--- a/syne_tune/try_import.py
+++ b/syne_tune/try_import.py
@@ -60,11 +60,21 @@ def try_import_yahpo_message() -> str:
     )
 
 
-def _try_import_message(message_text: str, tag: str) -> str:
+def try_import_backends_message() -> str:
+    return _try_import_message(
+        "LocalBackend / PythonBackend are not imported", tag=None
+    )
+
+
+def _try_import_message(message_text: str, tag: Optional[str]) -> str:
+    if tag is None:
+        insert = ""
+    else:
+        insert = "[" + tag + "]"
     return (
         message_text
         + " since dependencies are missing. You can install them with\n"
-        + f"   pip install 'syne-tune[{tag}]'\n"
+        + f"   pip install 'syne-tune{insert}'\n"
         + "or (for everything)\n"
         + "   pip install 'syne-tune[extra]'"
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous checks were too wide. `LocalBackend` and `PythonBackend` work with core dependencies only, while `SageMakerBackend` just needs `aws`. None of them need `extra`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
