### PR TITLE
Shorten links in docs by using ~ prefix

### DIFF
--- a/docs/source/benchmarking/launch_local.rst
+++ b/docs/source/benchmarking/launch_local.rst
@@ -2,7 +2,7 @@ Code in benchmarking/nursery/launch_local
 =========================================
 
 Comparison of baseline methods on real benchmark, using the
-:class:`syne_tune.backend.LocalBackend`.
+:class:`~syne_tune.backend.LocalBackend`.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_local/baselines.py
    :caption: benchmarking/nursery/launch_local/baselines.py

--- a/docs/source/benchmarking/launch_sagemaker.rst
+++ b/docs/source/benchmarking/launch_sagemaker.rst
@@ -2,7 +2,7 @@ Code in benchmarking/nursery/launch_sagemaker
 =============================================
 
 Comparison of baseline methods on real benchmark, using the
-:class:`syne_tune.backend.SageMakerBackend`.
+:class:`~syne_tune.backend.SageMakerBackend`.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_sagemaker/baselines.py
    :caption: benchmarking/nursery/launch_sagemaker/baselines.py

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -74,8 +74,8 @@ Visualize Tuning Progress with Tensorboard
 Makes use of :ref:`train_height.py <train_height_script>`.
 
 Tensorboard visualization works by using a callback, for example
-:class:`syne_tune.callbacks.tensorboard_callback.TensorboardCallback`,
-which is passed to the :class:`syne_tune.Tuner`. In order to visualize
+:class:`~syne_tune.callbacks.tensorboard_callback.TensorboardCallback`,
+which is passed to the :class:`~syne_tune.Tuner`. In order to visualize
 other metrics, you may have to modify this callback.
 
 
@@ -105,7 +105,7 @@ SageMaker Hugging Face framework in order to fine-tune a DistilBERT
 model on the IMDB sentiment classification task:
 
 * Instead of optimizing a single objective, we use
-  :class:`syne_tune.optimizer.schedulers.multiobjective.MOASHA` in order
+  :class:`~syne_tune.optimizer.schedulers.multiobjective.MOASHA` in order
   to sample the Pareto frontier w.r.t. three objectives
 * We not only tune hyperparameters such as learning rate and weight
   decay, but also the AWS instance type to be used for training. Here,
@@ -195,12 +195,12 @@ training script:
    :caption: examples/training_scripts/checkpoint_example/train_height_checkpoint.py
    :lines: 13-
 
-Note that :class:`syne_tune.backend.SageMakerBackend` is configured to use
+Note that :class:`~syne_tune.backend.SageMakerBackend` is configured to use
 SageMaker managed warm pools:
 
 * `keep_alive_period_in_seconds=300` in the definition of the SageMaker
   estimator
-* `start_jobs_without_delay=False` when creating :class:`syne_tune.Tuner`
+* `start_jobs_without_delay=False` when creating :class:`~syne_tune.Tuner`
 
 Managed warm pools reduce both start-up and stop delays substantially, they
 are strongly recommended for multi-fidelity HPO with the SageMaker backend.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -122,11 +122,11 @@ What are the metrics reported by default when calling the ``Reporter``?
 Whenever you call the reporter to log a result, the worker time-stamp, the
 worker time since the creation of the reporter and the number of times the
 reporter was called are logged under the fields
-:const:`syne_tune.constants.ST_WORKER_TIMESTAMP`,
-:const:`syne_tune.constants.ST_WORKER_TIME`, and
-:const:`syne_tune.constants.ST_WORKER_ITER`. In addition, when running on
+:const:`~syne_tune.constants.ST_WORKER_TIMESTAMP`,
+:const:`~syne_tune.constants.ST_WORKER_TIME`, and
+:const:`~syne_tune.constants.ST_WORKER_ITER`. In addition, when running on
 SageMaker, a dollar-cost estimate is logged under the field
-:const:`syne_tune.constants.ST_WORKER_COST`.
+:const:`~syne_tune.constants.ST_WORKER_COST`.
 
 To see this behavior, you can simply call the reporter to see those
 metrics:
@@ -146,15 +146,15 @@ How can I utilize multiple GPUs?
 ================================
 
 To utilize multiple GPUs you can either use the backend
-:class:`syne_tune.backend.LocalBackend`, which will run on the GPU available
+:class:`~syne_tune.backend.LocalBackend`, which will run on the GPU available
 in a local machine. You can also run on a remote AWS instance with multiple GPUs
 using the local backend and the remote launcher, see
 `here <#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`__,
-or run with the :class:`syne_tune.backend.SageMakerBackend` which spins-up one
+or run with the :class:`~syne_tune.backend.SageMakerBackend` which spins-up one
 training job per trial.
 
 When evaluating trials on a local machine with
-:class:`syne_tune.backend.LocalBackend`, by default each trial is allocated to
+:class:`~syne_tune.backend.LocalBackend`, by default each trial is allocated to
 the least occupied GPU by setting ``CUDA_VISIBLE_DEVICES`` environment
 variable.
 
@@ -168,10 +168,10 @@ How are trials evaluated on a local machine?
 ============================================
 
 When trials are executed locally (e.g., when
-:class:`syne_tune.backend.LocalBackend` is used), each trial is evaluated as a
+:class:`~syne_tune.backend.LocalBackend` is used), each trial is evaluated as a
 different sub-process. As such the number of concurrent configurations evaluated
 at the same time (set by ``n_workers`` when creating the
-:class:`syne_tune.Tuner`) should account for the capacity of the machine where
+:class:`~syne_tune.Tuner`) should account for the capacity of the machine where
 the trials are executed.
 
 Where can I find the output of the tuning?
@@ -210,7 +210,7 @@ What does the output of the tuning contain?
 Syne Tune stores the following files ``metadata.json``, ``results.csv.zip``,
 and ``tuner.dill`` which are respectively metadata of the tuning job, results
 obtained at each time-step and state of the tuner. If you create the
-:class:`syne_tune.Tuner` with ``save_tuner=False``, the ``tuner.dill`` file is
+:class:`~syne_tune.Tuner` with ``save_tuner=False``, the ``tuner.dill`` file is
 not written.
 
 How can I enable trial checkpointing?
@@ -220,7 +220,7 @@ Since trials may be paused and resumed (either by schedulers or when using
 spot-instances), the user may checkpoint intermediate results to avoid starting
 computation from scratch. Model outputs and checkpoints must be written into a
 specific local path given by the command line argument
-:const:`syne_tune.constants.ST_CHECKPOINT_DIR`. Saving/loading model checkpoint
+:const:`~syne_tune.constants.ST_CHECKPOINT_DIR`. Saving/loading model checkpoint
 from this directory enables to save/load the state when the job is
 stopped/resumed (setting the folder correctly and uniquely per trial is the
 responsibility of the backend). Here is an example of a tuning script with
@@ -265,7 +265,7 @@ include the model, the optimizer, and the learning rate scheduler.
 
 Finally, the scheduler provides additional information about checkpointing in
 ``config`` (most importantly, the path in
-:const:`syne_tune.constants.ST_CHECKPOINT_DIR`). You don’t have to worry about
+:const:`~syne_tune.constants.ST_CHECKPOINT_DIR`). You don’t have to worry about
 this: ``add_checkpointing_to_argparse(parser)`` adds corresponding arguments to
 the parser.
 
@@ -286,7 +286,7 @@ potentially resumed at a later point in time, without having to start training
 from scratch. The following schedulers make use of checkpointing:
 
 * Promotion-based asynchronous Hyperband:
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
   `type="promotion"`, as well as other asynchronous multi-fidelity schedulers.
   The code runs without checkpointing, but in this case, any trial which is
   resumed is started from scratch. For example, if a trial was paused after 9
@@ -296,10 +296,10 @@ from scratch. The following schedulers make use of checkpointing:
   differently. It is not recommended running promotion-based Hyperband
   without checkpointing.
 * Population-based training (PBT):
-  :class:`syne_tune.optimizer.schedulers.PopulationBasedTraining` does not
+  :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining` does not
   work without checkpointing.
 * Synchronous Hyperband:
-  :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`,
+  :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`,
   as well as other synchronous multi-fidelity schedulers. This code runs
   without checkpointing, but wastes effort in the same sense as
   promotion-based asynchronous Hyperband
@@ -309,7 +309,7 @@ Is the tuner checkpointed?
 
 Yes. When performing the tuning, the tuner state is regularly saved on the
 experiment path under ``tuner.dill`` (every 10 seconds, which can be configured
-with ``results_update_interval`` when creating the :class:`syne_tune.Tuner`).
+with ``results_update_interval`` when creating the :class:`~syne_tune.Tuner`).
 This allows to use spot-instances when running a tuning remotely with the remote
 launcher. It also allows to resume a past experiment or analyse the state of
 scheduler at any point.
@@ -448,7 +448,7 @@ in parallel, as detailed in
 How can I access results after tuning remotely?
 ===============================================
 
-You can either call :func:`syne_tune.experiments.load_experiment`, which will
+You can either call :func:`~syne_tune.experiments.load_experiment`, which will
 download files from S3 if the experiment is not found locally. You can also
 sync directly files from s3 under ``~/syne-tune/`` folder in batch for instance
 by running:

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -23,9 +23,9 @@ from evaluations.
    There are two ways to create many of the schedulers of Syne Tune:
 
    * Import wrapper class from :mod:`syne_tune.optimizer.baselines`, for example
-     :class:`syne_tune.optimizer.baselines.RandomSearch` for random search
-   * Use template classes :class:`syne_tune.optimizer.schedulers.FIFOScheduler`
-     or :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` together with
+     :class:`~syne_tune.optimizer.baselines.RandomSearch` for random search
+   * Use template classes :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
+     or :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` together with
      the ``searcher`` argument, for example ``FIFOScheduler`` with
      ``searcher="random"`` for random search
 
@@ -49,7 +49,7 @@ supports:
 * Bore [``searcher="bore"``]
 
 We will only consider the first two searchers in this tutorial. Here is a
-launcher script using :class:`syne_tune.optimizer.schedulers.FIFOScheduler`:
+launcher script using :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`:
 
 .. code-block:: python
 
@@ -120,7 +120,7 @@ What happens in this launcher script?
   well as the stopping criterion for the experiment (stop after 120 seconds)
   and the number of workers. The experiment is started by ``tuner.run()``.
 
-:class:`syne_tune.optimizer.schedulers.FIFOScheduler` provides the full range
+:class:`~syne_tune.optimizer.schedulers.FIFOScheduler` provides the full range
 of arguments. Here, we list the most important ones:
 
 * ``config_space``: Hyperparameter search space. This argument is mandatory.
@@ -155,7 +155,7 @@ Random Search
 
 The simplest HPO baseline is **random search**, which you obtain with
 ``searcher="random"``, or by using
-:class:`syne_tune.optimizer.baselines.RandomSearch` instead of
+:class:`~syne_tune.optimizer.baselines.RandomSearch` instead of
 ``FIFOScheduler``. Search decisions are not based on past data, a new
 configuration is chosen by sampling attribute values at random, from
 distributions specified in ``config_space``. These distributions are detailed
@@ -172,13 +172,13 @@ Bayesian Optimization
 ~~~~~~~~~~~~~~~~~~~~~
 
 **Bayesian optimization** is obtained by ``searcher='bayesopt'``, or by using
-:class:`syne_tune.optimizer.baselines.BayesianOptimization` instead of
+:class:`~syne_tune.optimizer.baselines.BayesianOptimization` instead of
 ``FIFOScheduler``. More information about Bayesian optimization is provided
 `here <tutorials/basics/basics_bayesopt.html>`__.
 
 Options for configuring the searcher are given in ``search_options``. These
 include options for the random searcher.
-:class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` provides the
+:class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` provides the
 full range of arguments. We list the most important ones:
 
 * ``num_init_random``: Number of initial configurations chosen at random (or
@@ -215,7 +215,7 @@ details about synchronous and asynchronous variants of successive halving and
 Hyperband.
 
 Here is a launcher script using
-:class:`syne_tune.optimizer.schedulers.HyperbandScheduler`:
+:class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`:
 
 .. code-block:: python
 
@@ -271,7 +271,7 @@ Here is a launcher script using
        tuner.run()
 
 Much of this launcher script is the same as for ``FIFOScheduler``, but
-:class:`syne_tune.optimizer.schedulers.HyperbandScheduler` comes with a number
+:class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` comes with a number
 of extra arguments we will explain in the sequel (``type``,
 ``max_resource_attr``, ``grace_period``, ``reduction_factor``,
 ``resource_attr``). The ``mlp_fashionmnist`` benchmark trains a two-layer MLP
@@ -290,7 +290,7 @@ While ``metric="accuracy"`` is the criterion to be optimized,
 ``resource_attr="epoch"`` is the resource attribute. In the schedulers
 discussed here, the resource attribute must be a positive integer.
 
-:class:`syne_tune.optimizer.schedulers.HyperbandScheduler` maintains reported
+:class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` maintains reported
 metrics for all trials at certain **rung levels** (levels of resource attribute
 ``epoch`` at which scheduling decisions are done). When a trial reports
 ``(epoch, accuracy)`` for a rung level ``== epoch``, the scheduler makes a

--- a/docs/source/tutorials/basics/basics_asha.rst
+++ b/docs/source/tutorials/basics/basics_asha.rst
@@ -84,7 +84,7 @@ rung requires a single trial to train for 54 epochs, while all other workers
 are idle. This can be compensated to some extent by free workers running
 trials for the next iteration already, but scheduling becomes rather complex at
 this point. Syne Tune provides synchronous Hyperband as
-:class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
+:class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 However, we can usually do much better with asynchronous scheduling.
 
 Asynchronous Successive Halving

--- a/docs/source/tutorials/basics/basics_backend.rst
+++ b/docs/source/tutorials/basics/basics_backend.rst
@@ -4,7 +4,7 @@ SageMaker Back-end
 Limitations of the Local Back-end
 ---------------------------------
 
-We have been using the local back-end :class:`syne_tune.backend.LocalBackend`
+We have been using the local back-end :class:`~syne_tune.backend.LocalBackend`
 in this tutorial so far. Due to its simplicity and very low overheads for
 starting, stopping, or resuming trials, this is the preferred choice for
 getting started. But with models and datasets getting larger, some
@@ -28,7 +28,7 @@ Launcher Script for SageMaker Back-end
 --------------------------------------
 
 Syne Tune offers the SageMaker back-end
-:class:`syne_tune.backend.SageMakerBackend` as alternative to the local one.
+:class:`~syne_tune.backend.SageMakerBackend` as alternative to the local one.
 Using it requires some preparation, as is detailed
 `here <../../faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 
@@ -58,7 +58,7 @@ differently:
        metrics_names=[metric],
    )
 
-In essence, the :class:`syne_tune.backend.SageMakerBackend` is parameterized
+In essence, the :class:`~syne_tune.backend.SageMakerBackend` is parameterized
 with a SageMaker estimator, which executes the training script. In our example,
 we use the ``PyTorch`` SageMaker framework as a pre-built container for the
 dependencies our training scripts requires. However, any other type of

--- a/docs/source/tutorials/basics/basics_bayesopt.rst
+++ b/docs/source/tutorials/basics/basics_bayesopt.rst
@@ -83,7 +83,7 @@ GP-based Bayesian optimization is run by our
 `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__
 with the argument ``--method BO``. Many options can be specified via
 ``search_options``, but we use the defaults here. See
-:class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` for all
+:class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` for all
 details. In our example, we set ``num_init_random`` to ``n_workers + 2``, which
 is the number of initial decisions made by random search, before switching
 over to maximizing the acquisition function.

--- a/docs/source/tutorials/basics/basics_outlook.rst
+++ b/docs/source/tutorials/basics/basics_outlook.rst
@@ -23,7 +23,7 @@ experimental. Here is an incomplete overview:
   reinforcement learning, where optimization hyperparameters like learning rate
   can be changed at certain points during the training. An example is at
   ``examples/launch_pbt.py``, see also
-  :class:`syne_tune.optimizer.schedulers.PopulationBasedTraining`. Note that
+  :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining`. Note that
   `checkpointing <basics_promotion.html#pause-and-resume-checkpointing-of-trials>`__
   is mandatory for PBT.
 * **Constrained HPO**: In many applications, more than a single metric play a
@@ -37,7 +37,7 @@ experimental. Here is an incomplete overview:
   as ``constraint_attr`` in ``search_options``. More details on constrained HPO
   and methodology adopted in Syne Tune can be found
   `here <https://arxiv.org/abs/1910.07003>`__, see also
-  :class:`syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher`.
+  :class:`~syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher`.
 * **Multi-objective HPO**: Another way to approach tuning problems with multiple
   metrics is trying to sample the Pareto frontier, i.e. identifying
   configurations whose performance along one metric cannot be improved without
@@ -45,4 +45,4 @@ experimental. Here is an incomplete overview:
   in this direction. An example is at ``examples/launch_height_moasha.py``.
   More details on multi-objective HPO and methodology adopted in Syne Tune can
   be found `here <https://arxiv.org/abs/2106.12639>`__, see also
-  :class:`syne_tune.optimizer.schedulers.multiobjective.MOASHA`.
+  :class:`~syne_tune.optimizer.schedulers.multiobjective.MOASHA`.

--- a/docs/source/tutorials/basics/basics_promotion.rst
+++ b/docs/source/tutorials/basics/basics_promotion.rst
@@ -139,7 +139,7 @@ runs promotion-based ASHA with the argument ``--method ASHA-PROM``, and
 promotion-based MOBSTER with ``--method MOBSTER-PROM``:
 
 * Recall that the argument ``max_resource_attr`` for
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` allows the
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` allows the
   scheduler to infer the maximum resource level ``r_max``. For
   promotion-based scheduling, this argument has a second function. Namely, it
   allows the scheduler to inform the training script until which epoch it has

--- a/docs/source/tutorials/basics/basics_randomsearch.rst
+++ b/docs/source/tutorials/basics/basics_randomsearch.rst
@@ -31,7 +31,7 @@ grid search is particularly inefficient if some HPs are more important for the
 objective values than others. For all of these reasons, grid search is not a
 recommended baseline for HPO, unless very few parameters have to be tuned.
 Nevertheless, Syne provides an implementation in
-:class:`syne_tune.optimizer.schedulers.searchers.GridSearcher`.
+:class:`~syne_tune.optimizer.schedulers.searchers.GridSearcher`.
 
 In *random search*, the sequence of configurations is chosen by independent
 sampling. In the simple case of interest here, each value in a configuration is
@@ -229,8 +229,8 @@ Let us walk through the script, keeping this special case in mind:
   configurations for new trials, and also to make scheduling decisions about
   running trials. Most schedulers supported in Syne Tune can be imported from
   :mod:`syne_tune.optimizer.baselines`. In our example, we use
-  :class:`syne_tune.optimizer.baselines.RandomSearch`, see also
-  :class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`.
+  :class:`~syne_tune.optimizer.baselines.RandomSearch`, see also
+  :class:`~syne_tune.optimizer.schedulers.searchers.RandomSearcher`.
 
   Schedulers need to know how the target metric is referred to in the ``report``
   call of the training script (``metric``), and whether this criterion is to
@@ -239,7 +239,7 @@ Let us walk through the script, keeping this special case in mind:
 
 * [5] Finally, we need to specify a stopping criterion. In our example, we run
   random search for ``max_wallclock_time`` seconds, the default being 3 hours.
-  :class:`syne_tune.StoppingCriterion` can also use other attributes, such as
+  :class:`~syne_tune.StoppingCriterion` can also use other attributes, such as
   ``max_num_trials_started`` or ``max_num_trials_completed``. If several
   attributes are used, you get the *or* combination.
 * Everything comes together in the ``Tuner``. Here, we can also specify
@@ -287,7 +287,7 @@ Recommendations
 ---------------
 
 One important parameter of
-:class:`syne_tune.optimizers.schedulers.searchers.RandomSearcher` (and the
+:class:`~syne_tune.optimizers.schedulers.searchers.RandomSearcher` (and the
 other schedulers we use in this tutorial) we did not use is
 ``points_to_evaluate``, which allows specifying initial configurations to
 suggest first. For example:

--- a/docs/source/tutorials/basics/basics_setup.rst
+++ b/docs/source/tutorials/basics/basics_setup.rst
@@ -246,7 +246,7 @@ script for our experiments, to be introduced below:
 
 The configuration space is a dictionary with key names corresponding to command
 line input parameters of our training script. For each parameter you would like
-to tune, you need to specify a :class:`syne_tune.config_space.Domain`, imported
+to tune, you need to specify a :class:`~syne_tune.config_space.Domain`, imported
 from :mod:`syne_tune.config_space`. A domain consists of a type (float, int,
 categorical), a range (inclusive on both ends), and an encoding (linear or
 logarithmic). In our example, ``n_units_1``, ``n_units_2``, ``batch_size`` are

--- a/docs/source/tutorials/benchmarking/bm_contributing.rst
+++ b/docs/source/tutorials/benchmarking/bm_contributing.rst
@@ -41,7 +41,7 @@ to be done:
 
   * Your script needs to report relevant metrics back to Syne Tune at the end
     of each epoch (or only once, at the end, if your script does not support
-    multi-fidelity tuning), using an instance of :class:`syne_tune.Reporter`.
+    multi-fidelity tuning), using an instance of :class:`~syne_tune.Reporter`.
   * We strongly recommend your script to support checkpointing, and the
     ``resnet_cifar10`` script is a good example for how to do this with
     ``PyTorch`` training scripts. If checkpointing is not supported, all
@@ -53,7 +53,7 @@ to be done:
   You need to define some meta-data for your benchmark in
   :mod:`benchmarking.commons.benchmark_definitions`. This should be a
   function returning a
-  :class:`benchmarking.commons.benchmark_definitions.RealBenchmarkDefinition`
+  :class:`~benchmarking.commons.benchmark_definitions.RealBenchmarkDefinition`
   object. Arguments should be a flag ``sagemaker_backend`` (``True`` for
   SageMaker back-end experiment, ``False`` otherwise), and ``**kwargs``
   overwriting values in ``RealBenchmarkDefinition``. Hints:

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -59,7 +59,7 @@ GPU with PyTorch being installed):
   ``~/syne-tune/{experiment_tag}/*/{experiment_tag}-*/``. This name should
   confirm to S3 conventions (alphanumerical and ``-``; no underscores).
 * ``benchmark``: Selects benchmark from keys of
-  :func:`benchmarking.commons.benchmark_definitions.real_benchmark_definitions`.
+  :func:`~benchmarking.commons.benchmark_definitions.real_benchmark_definitions`.
   The default is ``resnet_cifar10``.
 * ``method``: Selects HPO method to run from keys of ``methods``. If this is
   not given, experiments for all keys in ``methods`` are run in sequence.
@@ -93,13 +93,13 @@ Benchmark Definitions
 
 In the example above, we select a benchmark via ``--benchmark resnet_cifar10``.
 All currently supported real benchmarks are collected in
-:func:`benchmarking.commons.benchmark_definitions.real_benchmark_definitions`,
+:func:`~benchmarking.commons.benchmark_definitions.real_benchmark_definitions`,
 a function which returns the dictionary of real benchmarks, configured by some
 extra arguments. If you are happy with selecting one of these existing benchmarks,
 you may safely skip this subsection.
 
 For ``resnet_cifar10``, this selects
-:func:`benchmarking.commons.benchmark_definitions.resnet_cifar10.resnet_cifar10_benchmark`,
+:func:`~benchmarking.commons.benchmark_definitions.resnet_cifar10.resnet_cifar10_benchmark`,
 which returns meta-data for the benchmark as a
 :class:`benchmarking.commons.benchmark_definitions.RealBenchmarkDefinition`
 object. Here, the argument ``sagemaker_backend`` is ``False`` in our case,

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -31,12 +31,12 @@ Syne Tune dependencies need to be specified in
 
 In terms of benchmarks, the same definitions can be used for the SageMaker
 back-end, in particular you can select from
-:func:`benchmarking.commons.benchmark_definitions.real_benchmark_definitions`.
+:func:`~benchmarking.commons.benchmark_definitions.real_benchmark_definitions`.
 However, the functions there are called with ``sagemaker_backend=True``, which
 can lead to different values in
 :class:`benchmarking.commons.benchmark_definitions.RealBenchmarkDefinition`.
 For example,
-:func:`benchmarking.commons.benchmark_definitions.resnet_cifar10.resnet_cifar10_benchmark`
+:func:`~benchmarking.commons.benchmark_definitions.resnet_cifar10.resnet_cifar10_benchmark`
 returns ``instance_type=ml.g4dn.xlarge`` for the SageMaker back-end (1 GPU per
 instance), but ``instance_type=ml.g4dn.12xlarge`` for the local back-end (4 GPUs
 per instance). This is because for the local back-end to support ``n_workers=4``,

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -50,7 +50,7 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   the Hyper-Tune methods only. Apart from ``extra_args``, you also need to
   define ``map_extra_args``, which maps these command line arguments
   to class:`benchmarking.commons.baselines.MethodArguments` entries. Finally,
-  :func:`benchmarking.commons.hpo_main_simulator.main` is called with your
+  :func:`~benchmarking.commons.hpo_main_simulator.main` is called with your
   ``methods`` and ``benchmark_definitions`` dictionaries, and (optionally) with
   ``extra_args`` and ``map_extra_args``. We will see shortly how the launcher
   is called, and what happens inside.

--- a/docs/source/tutorials/developer/extend_async_hb.rst
+++ b/docs/source/tutorials/developer/extend_async_hb.rst
@@ -8,13 +8,13 @@ templates at the moment are:
 
 * `FIFOScheduler <random_search.md#fifoscheduler-and-randomsearcher>`__:
   *Full evaluation* scheduler, baseclass for many others. See also
-  :class:`syne_tune.optimizer.schedulers.FIFOScheduler`.
+  :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
 * `HyperbandScheduler <extend_async_hb.md#hyperbandscheduler>`__:
   Asynchronous successive halving and Hyperband. See also
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 * `SynchronousHyperbandScheduler <extend_sync_hb.md#synchronous-hyperband>`__:
   Synchronous successive halving and Hyperband. See also
-  :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
+  :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 
 Chances are your idea for a new scheduler maps to one of these templates, in
 which case you can save a lot of time and headache by just extending the
@@ -53,7 +53,7 @@ class:`syne_tune.optimizer.schedulers.FIFOScheduler`:
   name should be passed in ``max_resource_attr``. Now, every configuration sent
   to the training script contains :math:`r_{max}`, which should not be hardcoded
   in the script. Moreover, if ``max_resource_attr`` is used, a pause-and-resume
-  scheduler (e.g., :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+  scheduler (e.g., :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
   with ``type="stopping"``) can modify this field in the configuration of a trial
   which is only to be run until a certain resource less than :math:`r_{max}`.
   Nevertheless, if ``max_resource_attr`` is not used, then :math:`r_{max}` has
@@ -75,12 +75,12 @@ Kernel Density Estimator Searcher
 ---------------------------------
 
 One of the most flexible ways of extending
-:class:`syne_tune.optimizer.schedulers.HyperbandScheduler` is to provide it with
+:class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` is to provide it with
 a novel `searcher <first_example.html#searchers-and-schedulers>`__. In order to
 understand how this is done, we will walk through
-:class:`syne_tune.optimizer.schedulers.searchers.kde.MultiFidelityKernelDensityEstimator`
+:class:`~syne_tune.optimizer.schedulers.searchers.kde.MultiFidelityKernelDensityEstimator`
 and
-:class:`syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`.
+:class:`~syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`.
 This searcher implements ``suggest`` as in
 `BOHB <https://arxiv.org/abs/1807.01774>`__, as also detailed in
 `this tutorial <../multifidelity/mf_sync_model.html#synchronous-bohb>`__. In a
@@ -91,14 +91,14 @@ based on a particular ratio of these densities, which is approximating a
 variant of the expected improvement acquisition function.
 
 We begin with the base class
-:class:`syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`,
-which works together with :class:`syne_tune.optimizer.schedulers.FIFOScheduler`,
+:class:`~syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`,
+which works together with :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`,
 but already implements most of what is needed in the multi-fidelity context.
 
 * The code does quite some bookkeeping concerned with mapping configurations to
   feature vectors. If you want to do this from scratch for your searcher, we
   recommend to use
-  :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
+  :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
   However, ``KernelDensityEstimator`` was extracted from the original BOHB
   implementation.
 * Observation data is collected in ``self.X`` (feature vectors for
@@ -110,7 +110,7 @@ but already implements most of what is needed in the multi-fidelity context.
   the TPE acquisition function for each candidate, and returns the best one.
 
 The class
-:class:`syne_tune.optimizer.schedulers.searchers.kde.MultiFidelityKernelDensityEstimator`
+:class:`~syne_tune.optimizer.schedulers.searchers.kde.MultiFidelityKernelDensityEstimator`
 inherits from ``KernelDensityEstimator``:
 
 * On top of ``self.X`` and ``self.y``, it also maintains resource values
@@ -120,9 +120,9 @@ inherits from ``KernelDensityEstimator``:
   these to data from a single rung level, namely the largest level at which we
   have observed at least ``self.num_min_data_points`` points.
 * ``configure_scheduler`` restricts usage to
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` (asynchronous
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` (asynchronous
   Hyperband) and
-  :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
+  :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
   (synchronous Hyperband). Also, ``self.resource_attr`` is obtained from the
   scheduler, so does not have to be passed.
 
@@ -137,8 +137,8 @@ particular:
   this searcher are not properly serialized.
 
 For a more complete and advanced example, the reader is invited to study
-:class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher` and
-:class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`.
+:class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher` and
+:class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`.
 This searcher takes pending evaluations into account (by way of fantasizing).
 Moreover, it can be configured with a Gaussian process model and an acquisition
 function, which is optimized in a gradient-based manner.
@@ -147,8 +147,8 @@ Moreover, as already noted `here <first_example.html#searchers-and-schedulers>`_
 ``HyperbandScheduler`` also allows to configure the decision rule for
 stop/continue or pause/resume as part of ``on_trial_report``. Examples for this
 are found in
-:class:`syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`,
-:class:`syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`,
+:class:`~syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`,
+:class:`~syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`,
 :class:`syne_tune.optimizer.schedulers.hyperband_rush.RUSHStoppingRungSystem`,
 :class:`syne_tune.optimizer.schedulers.hyperband_pasha.PASHARungSystem`,
 :class:`syne_tune.optimizer.schedulers.hyperband_cost_promotion.CostPromotionRungSystem`.

--- a/docs/source/tutorials/developer/extend_sync_hb.rst
+++ b/docs/source/tutorials/developer/extend_sync_hb.rst
@@ -26,12 +26,12 @@ asynchronously. This requirement poses slight additional challenges for an
 implementation, over what is said in
 `published work <https://jmlr.org/papers/v18/16-558.html>`__. We start with an
 overview of
-:class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
+:class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 Concepts such as resource, rung, bracket, grace period :math:`r_{min}`,
 reduction factor :math:`\eta` are detailed in
 `this tutorial <../multifidelity/README.html>`__.
 
-:class:`syne_tune.optimizer.schedulers.synchronous.hyperband_bracket.SynchronousHyperbandBracket`
+:class:`~syne_tune.optimizer.schedulers.synchronous.hyperband_bracket.SynchronousHyperbandBracket`
 represents a bracket, consisting of a list of rungs, where each rung is
 defined by ``(rung_size, level)``, ``rung_size`` is the number of slots,
 ``level`` the resource level. Any system of rungs is admissible, as long
@@ -59,7 +59,7 @@ increasing.
   assigned to ``None`` at the beginning, they are set by the caller (using
   new ``trial_id`` values provided by the back-end).
 
-:class:`syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager.SynchronousHyperbandBracketManager`
+:class:`~syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager.SynchronousHyperbandBracketManager`
 maintains all brackets during an experiment. It is configured by a list
 of brackets, where each bracket has one less rungs than its predecessor.
 The Hyperband algorithm cycles through this ``RungSystemsPerBracket`` in
@@ -74,15 +74,15 @@ first bracket which is not yet complete, is the *primary bracket*.
   bracket can take the job, a new bracket is created.
 
 Given these classes,
-:class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
+:class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
 is straightforward. It is a pause-and-resume scheduler.
 
 * ``_suggest`` polls ``self.bracket_manager.next_job()``. If the ``SlotInRung``
   returned has ``trial_id`` assigned, it corresponds to a trial to be
   promoted, so the decision is
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`
   Otherwise, the scheduler decides for
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`
   with a new ``trial_id``, which also updates the ``SlotInRung.trial_id`` field.
   In any case, the scheduler maintains the curently pending slots in
   ``self._trial_to_pending_slot``.
@@ -101,7 +101,7 @@ trials are chosen by evolutionary computations (mutation, cross-over,
 selection). This example is more advanced than the
 `one above <extend_async_hb.html>`__, in that we need to do more than
 furnishing
-:class:`syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
+:class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
 with a new searcher. The only time when a searcher suggests configurations is
 at the very start, when the first rung of the first bracket is filled. All
 further configurations are obtained by evolutionary means.
@@ -154,7 +154,7 @@ Once this is done, we can map mutation and cross-over to ``suggest``,
 and selection to ``on_trial_report``. It becomes clear that we can use
 most of the infrastructure for synchronous Hyperband without change.
 
-:class:`syne_tune.optimizer.schedulers.synchronous.dehb_bracket.DifferentialEvolutionHyperbandBracket`
+:class:`~syne_tune.optimizer.schedulers.synchronous.dehb_bracket.DifferentialEvolutionHyperbandBracket`
 has only minor differences to ``SynchronousHyperbandBracket``. First,
 ``_promote_trials_at_rung_complete`` does nothing, because promotion
 (i.e., determining the trials for a rung from the one above) is a more
@@ -185,7 +185,7 @@ are not allowed to wait.
   changes between cross-over and selection. Also, in rare cases, the target may
   not have a metric at selection time. In this case, the candidate wins.
 
-:class:`syne_tune.optimizer.schedulers.synchronous.dehb_bracket_manager.DifferentialEvolutionHyperbandBracketManager`
+:class:`~syne_tune.optimizer.schedulers.synchronous.dehb_bracket_manager.DifferentialEvolutionHyperbandBracketManager`
 is very similar to ``SynchronousHyperbandBracketManager``. Differences include:
 
 * The system of brackets is more rigid in DEHB, in that subsequent brackets are
@@ -196,7 +196,7 @@ is very similar to ``SynchronousHyperbandBracketManager``. Differences include:
 * ``trial_id_from_parent_slot`` selects the ``trial_id`` for the target for
   cross-over and selection.
 
-:class:`syne_tune.optimizer.schedulers.synchronous.DifferentialEvolutionHyperbandScheduler`
+:class:`~syne_tune.optimizer.schedulers.synchronous.DifferentialEvolutionHyperbandScheduler`
 implements the DEHB scheduler.
 
 * On top of ``SynchronousHyperbandScheduler``, it also maps ``trial_id`` to
@@ -208,7 +208,7 @@ implements the DEHB scheduler.
   because many encoded vectors map to the same configuration. In this
   case, we retry and may ultimately draw encoded configs at random. Except
   for a special case in the very first bracket, we return with
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`.
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`.
 * New encoded configurations are chosen only for the first rung of the first
   bracket. Our implementation allows a searcher to be specified for this choice.
   However, the default is to sample the new vector uniformly at random, see

--- a/docs/source/tutorials/developer/first_example.rst
+++ b/docs/source/tutorials/developer/first_example.rst
@@ -107,31 +107,31 @@ the following script, which can be found in
        tuner.run()
 
 All schedulers are subclasses of
-:class:`syne_tune.optimizer.scheduler.TrialScheduler`. Important methods
+:class:`~syne_tune.optimizer.scheduler.TrialScheduler`. Important methods
 include:
 
 * Constructor: Needs to be passed the configuration space. Most schedulers also
   have ``metric`` (name of metric to be optimized) and ``mode`` (whether metric
   is to be minimized or maximized; default is ``"min"``).
 * ``_suggest`` (internal version of ``suggest``): Called by the
-  :class:``syne_tune.Tuner`` whenever a worker is available. Returns trial to
+  :class:`~`syne_tune.Tuner`` whenever a worker is available. Returns trial to
   execute next, which in most cases will start a new configuration using
   trial ID ``trial_id`` (as
-  :const:`syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`).
+  :const:`~syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`).
   Some schedulers may also suggest to resume a paused trial (as
-  :const:`syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`).
+  :const:`~syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`).
   Our ``SimpleScheduler`` simply draws a new configuration at random from the
   configuration space.
-* ``on_trial_result``: Called by the :class:`syne_tune.Tuner` whenever a new
+* ``on_trial_result``: Called by the :class:`~syne_tune.Tuner` whenever a new
   result reported
   by a running trial has been received. Here, ``trial`` provides information
   about the trial (most important is ``trial.trial_id``), and ``result``
-  contains the arguments passed to :class:`syne_tune.Reporter` by the
+  contains the arguments passed to :class:`~syne_tune.Reporter` by the
   underlying training script. All but the simplest schedulers maintain a
   state which is modified based on this information. The scheduler also
   decides what to do with this trial, returning a
-  :class:`syne_tune.optimizer.scheduler.SchedulerDecision` to the
-  :class:`syne_tune.Tuner`, which in turn relays this decision to the back-end.
+  :class:`~syne_tune.optimizer.scheduler.SchedulerDecision` to the
+  :class:`~syne_tune.Tuner`, which in turn relays this decision to the back-end.
   Our ``SimpleScheduler`` maintains a sorted list of all metric values
   reported in ``self.sorted_results``. Whenever a trial reports a metric
   value which is worse than 4/5 of all previous reports (across all trials),
@@ -147,7 +147,7 @@ include:
   ``on_trial_result``.
 
 There are further methods in
-:class:`syne_tune.optimizer.scheduler.TrialScheduler`, which will be discussed
+:class:`~syne_tune.optimizer.scheduler.TrialScheduler`, which will be discussed
 in detail `below <trial_scheduler_api.html>`__. This simple scheduler is also
 missing the ``points_to_evaluate`` argument, which we recommend every new
 scheduler to support, and which is discussed in more detail
@@ -158,7 +158,7 @@ Basic Concepts
 
 Recall from `Basics of Syne Tune <../basics/README.html>`__ that an HPO
 experiment is run as interplay between a *back-end* and a *scheduler*, which is
-orchestrated by the :class:`syne_tune.Tuner`. The back-end starts, stops,
+orchestrated by the :class:`~syne_tune.Tuner`. The back-end starts, stops,
 pauses, or resumes training jobs and relays their reports. A *trial* abstracts
 the evaluation of a hyperparameter *configuration*. There is a diverse range of
 schedulers which can be implemented in Syne Tune, some examples are:
@@ -166,18 +166,18 @@ schedulers which can be implemented in Syne Tune, some examples are:
 * Simple “full evaluation” schedulers. These suggest configurations for new
   trials, but do not try to interact with running trials, even if the latter
   post intermediate results. A basic example is
-  :class:`syne_tune.optimizer.schedulers.FIFOScheduler`, to be discussed
+  :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`, to be discussed
   `below <random_search.html#fifoscheduler-and-randomsearcher>`__.
 * Early-stopping schedulers. These require trials to post intermediate results
   (e.g., validation errors after every epoch), and their ``on_trial_result``
   may stop underperforming trials early. An example is
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
   ``type="stopping"``.
 * Pause-and-resume schedulers. These require trials to post intermediate
   results (e.g., validation errors after every epoch). Their ``on_trial_result``
   may pause trials at certain points in time, and their ``_suggest`` may decide
   to resume a paused trial instead of starting a new one. An example is
-  :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+  :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
   ``type="promotion"``.
 
 Asynchronous Job Execution
@@ -238,7 +238,7 @@ Syne Tune is this: **be lazy!**
 * Does your idea involve changing the stop/continue or pause/resume decisions
   in asynchronous successive halving or Hyperband? All you need to do is to
   implement a new
-  :class:`syne_tune.optimizer.schedulers.hyperband_stopping.RungSystem`.
+  :class:`~syne_tune.optimizer.schedulers.hyperband_stopping.RungSystem`.
   Examples:
   :class:`syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`,
   :class:`syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`,

--- a/docs/source/tutorials/developer/new_searcher.rst
+++ b/docs/source/tutorials/developer/new_searcher.rst
@@ -34,19 +34,19 @@ name. For example:
   :mod:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory`.
 
 It is the purpose of
-:func:`syne_tune.optimizer.schedulers.searchers.searcher_factory.searcher_factory`
+:func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory.searcher_factory`
 to create the correct
-:class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher` object for given
+:class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher` object for given
 scheduler arguments, including ``searcher`` (name) and ``search_options``. Let
 us have a look how the constructor of
-:class:`syne_tune.optimizer.schedulers.FIFOScheduler` calls the factory. We see
+:class:`~syne_tune.optimizer.schedulers.FIFOScheduler` calls the factory. We see
 how scheduler arguments like ``metric``, ``mode``, ``points_to_evaluate`` are
 just passed through to the factory. We also need to set
 ``search_options["scheduler"]`` in order to tell ``searcher_factory`` which
 generic scheduler is calling it.
 
 The
-:func:`syne_tune.optimizer.schedulers.searchers.searcher_factory.searcher_factory`
+:func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory.searcher_factory`
 code should be straightforward to understand and extend. Pick a name for your
 new searcher and set ``searcher_cls`` and ``supported_schedulers`` (the latter
 can be left to ``None`` if your searcher works with all generic schedulers). The

--- a/docs/source/tutorials/developer/random_search.rst
+++ b/docs/source/tutorials/developer/random_search.rst
@@ -10,8 +10,8 @@ would make sure that the same configuration is not suggested twice.
 In this section, we walk through the Syne Tune implementation of random search,
 thereby discussing some additional concepts. This will also be a first example
 of the modular concept just described: random search is implemented as generic
-:class:`syne_tune.optimizer.schedulers.FIFOScheduler` configured by a
-:class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`.
+:class:`~syne_tune.optimizer.schedulers.FIFOScheduler` configured by a
+:class:`~syne_tune.optimizer.schedulers.searchers.RandomSearcher`.
 A self-contained implementation of random search would be shorter. On the other
 hand, as seen in
 :mod:`syne_tune.optimizer.baselines`, ``FIFOScheduler`` also powers GP-based
@@ -24,8 +24,8 @@ FIFOScheduler and RandomSearcher
 --------------------------------
 
 We will have a close look at
-:class:`syne_tune.optimizer.schedulers.FIFOScheduler` and
-:class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`. Let us first
+:class:`~syne_tune.optimizer.schedulers.FIFOScheduler` and
+:class:`~syne_tune.optimizer.schedulers.searchers.RandomSearcher`. Let us first
 consider the arguments of ``FIFOScheduler``:
 
 * ``searcher``, ``search_options``: These are used to configure the scheduler
@@ -33,12 +33,12 @@ consider the arguments of ``FIFOScheduler``:
   arguments can be passed via ``search_options``. In this case, the searcher is
   created by a factory, as detailed `below <new_searcher.html>`__. Alternatively,
   ``searcher`` can also be a
-  :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher` object.
+  :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher` object.
 * ``metric``, ``mode``: As discussed `above <first_example.html#first-example>`__
   in ``SimpleScheduler``.
 * ``random_seed``: Several pseudo-random number generators may be used in
   scheduler and searcher. Seeds for these are drawn from a random seed generator
-  maintained in :class:`syne_tune.optimizer.schedulers.FIFOScheduler`, whose
+  maintained in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`, whose
   seed can be passed here. As a general rule, all schedulers and searchers
   implemented in Syne Tune carefully manage such generators (and contributed
   schedulers are strongly encourage to adopt this pattern).
@@ -54,7 +54,7 @@ consider the arguments of ``FIFOScheduler``:
 
 The most important use case is to configure ``FIFOScheduler`` with a new
 searcher, and we will concentrate on this one. First, the base class of all
-searchers is :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher`:
+searchers is :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher`:
 
 * ``points_to_evaluate``: A list of configurations to be suggested first. This
   is initialized and (possibly) imputed in the base class, but needs to be used
@@ -96,21 +96,21 @@ searchers is :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher`:
   ``FIFOScheduler`` and the Syne Tune searchers.
 
 Below ``BaseSearcher``, there is
-:class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`, which
+:class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`, which
 should be used by all searchers which make random decisions. It maintains a PRN
 generator and provides methods to serialize and de-serialize its state.
 
 Finally, let us walk through
-:class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`:
+:class:`~syne_tune.optimizer.schedulers.searchers.RandomSearcher`:
 
 * There are a few features beyond ``SimpleScheduler`` above. The searcher does
   not suggest the same configuration twice, and also warns if a finite
   configuration space has been exhausted. It also uses
-  :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`
+  :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`
   for random sampling and comparing configurations (to spot duplicates). This
   is a useful helper class, also for encoding configurations as vectors.
   Detecting duplicates is done by a
-  :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common.ExclusionList`.
+  :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common.ExclusionList`.
   Finally, ``debug_log`` is used for diagnostic logs.
 * ``get_config`` first asks for another entry from ``points_to_evaluate`` by
   way of ``_next_initial_config``. It then samples a new configuration at

--- a/docs/source/tutorials/developer/trial_scheduler_api.rst
+++ b/docs/source/tutorials/developer/trial_scheduler_api.rst
@@ -2,7 +2,7 @@ The TrialScheduler API
 ======================
 
 In this section, we have a closer look at the
-:class:`syne_tune.optimizer.scheduler.TrialScheduler` API, and how a scheduler
+:class:`~syne_tune.optimizer.scheduler.TrialScheduler` API, and how a scheduler
 interacts with the trial back-end.
 
 Interaction between TrialScheduler and TrialBackend
@@ -28,11 +28,11 @@ pause-and-resume scheduling is done via
 code to write and load checkpoints locally must be provided by the training
 script, the back-end makes them available when needed. There are two basic
 events which happen repeatedly during an HPO experiment, as orchestrated by the
-:class:`syne_tune.Tuner`:
+:class:`~syne_tune.Tuner`:
 
 * The ``Tuner`` polls the back-end, which signals that one or more workers are
   available. For each free worker, it calls
-  :meth:`syne_tune.optimizer.scheduler.TrialScheduler.suggest`, asking for
+  :meth:`~syne_tune.optimizer.scheduler.TrialScheduler.suggest`, asking for
   what to do next. As already seen in our
   `first example <first_example.html#first-example>`__, the scheduler will
   typically suggest a configuration for a new trial to be started. On the
@@ -42,7 +42,7 @@ events which happen repeatedly during an HPO experiment, as orchestrated by the
   back-end to start a new trial, or to resume an existing one.
 * The ``Tuner`` polls the back-end for new results, having been reported since
   the last recent poll. For each such result,
-  :meth:`syne_tune.optimizer.scheduler.TrialScheduler.on_trial_result`
+  :meth:`~syne_tune.optimizer.scheduler.TrialScheduler.on_trial_result`
   is called. The scheduler makes a decision of what to do with the reporting
   trial. Based on this decision, the ``Tuner`` asks the back-end to stop or
   pause the trial (or does nothing, in case the trial is to continue).
@@ -60,20 +60,20 @@ TrialScheduler API
 ------------------
 
 We now discuss additional aspects of the
-:class:`syne_tune.optimizer.scheduler.TrialScheduler` API, beyond what has
+:class:`~syne_tune.optimizer.scheduler.TrialScheduler` API, beyond what has
 already been covered `here <first_example.html#first-example>`__:
 
 * ``suggest`` returns a
-  :class:`syne_tune.optimizer.scheduler.TrialSuggestion` object with fields
+  :class:`~syne_tune.optimizer.scheduler.TrialSuggestion` object with fields
   ``spawn_new_trial_id``, ``checkpoint_trial_id``, ``config``. Here,
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion` has
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion` has
   ``spawn_new_trial_id=True`` and requires ``config``. A new trial is to be
   started with configuration ``config``. Typically, this trial starts training
   from scratch. However, some specific schedulers allow the trial to warm-start
   from a checkpoint written for a different trial (an example is
   class:`syne_tune.optimizer.schedulers.PopulationBasedTraining`).
   A pause-and-resume scheduler may also return
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`,
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.resume_suggestion`,
   where ``spawn_new_trial_id=False`` and ``checkpoint_trial_id`` is mandatory.
   In this case, a currently paused trial with ID ``checkpoint_trial_id`` is to
   be resumed. Typically, the configuration of the trial does not change, but if
@@ -89,7 +89,7 @@ already been covered `here <first_example.html#first-example>`__:
   used when interfacing with a searcher. Namely, the configuration space
   (member ``config_space``) may contain any number of fixed attributes
   alongside the hyperparameters to be tuned (the latter have values of type
-  :class:`syne_tune.config_space.Domain`), and each hyperparameter has a
+  :class:`~syne_tune.config_space.Domain`), and each hyperparameter has a
   specific ``value_type`` (mostly ``float``, ``int`` or ``str``). Searchers
   require clean configurations, containing only hyperparameters with the
   correct value types, which is ensured by ``_preprocess_config``. Also,
@@ -98,7 +98,7 @@ already been covered `here <first_example.html#first-example>`__:
 * ``on_trial_add``: This method is called by ``Tuner`` once a new trial has
   been scheduled to be started. In general, a scheduler may assume that if
   ``suggest`` returns
-  :meth:`syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`, the
+  :meth:`~syne_tune.optimizer.scheduler.TrialSuggestion.start_suggestion`, the
   corresponding trial is going to be started, so ``on_trial_add`` is not
   mandatory.
 * ``on_trial_error``: This method is called by ``Tuner`` if the back-end

--- a/examples/launch_checkpoint_example.py
+++ b/examples/launch_checkpoint_example.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     exp = load_experiment(tuner.name)
     best_config = exp.best_config()
-    checkpoint = trial_backend.checkpoint_trial_path(best_config['trial_id'])
+    checkpoint = trial_backend.checkpoint_trial_path(best_config["trial_id"])
     assert checkpoint.exists()
 
     print(f"Best config found {best_config} checkpointed at {checkpoint}")

--- a/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
+++ b/syne_tune/backend/sagemaker_backend/sagemaker_backend.py
@@ -58,8 +58,8 @@ class SageMakerBackend(TrialBackend):
 
     This back-end allows to select the instance type and count for a trial
     evaluation, by passing values in the configuration, using names
-    :const:`syne_tune.constants.ST_INSTANCE_TYPE` and
-    :const:`syne_tune.constants.ST_INSTANCE_COUNT`. If these are given in the
+    :const:`~syne_tune.constants.ST_INSTANCE_TYPE` and
+    :const:`~syne_tune.constants.ST_INSTANCE_COUNT`. If these are given in the
     configuration, they overwrite the default in `sm_estimator`. This allows
     for tuning instance type and count along with the hyperparameter
     configuration.

--- a/syne_tune/backend/simulator_backend/simulator_backend.py
+++ b/syne_tune/backend/simulator_backend/simulator_backend.py
@@ -115,7 +115,7 @@ class SimulatorBackend(LocalBackend):
        metrics by looking them up or running a surrogate. This is flexible,
        but has the overhead of loading a table at every call. For fast and
        convenient simulations, use
-       ::class:`syne_tune.blackbox_repository.BlackboxRepositoryBackend` after
+       ::class:`~syne_tune.blackbox_repository.BlackboxRepositoryBackend` after
        bringing your tabulated data or surrogate benchmark into the blackbox
        repository.
 
@@ -125,9 +125,9 @@ class SimulatorBackend(LocalBackend):
     :param elapsed_time_attr: See above
     :param simulator_config: Parameters for simulator, optional
     :param tuner_sleep_time: Effective sleep time in
-        :meth:`syne_tune.Tuner.run`. This information is needed in
-        :class:`syne_tune.backend.simulator_backend.SimulatorCallback`.
-        Defaults to :const:`syne_tune.tuner.DEFAULT_SLEEP_TIME`
+        :meth:`~syne_tune.Tuner.run`. This information is needed in
+        :class:`~syne_tune.backend.simulator_backend.SimulatorCallback`.
+        Defaults to :const:`~syne_tune.tuner.DEFAULT_SLEEP_TIME`
     """
 
     def __init__(

--- a/syne_tune/backend/simulator_backend/simulator_callback.py
+++ b/syne_tune/backend/simulator_backend/simulator_callback.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 class SimulatorCallback(StoreResultsCallback):
     """
     Callback to be used in `Tuner.run` in order to support the
-    :class:`syne_tune.backend.simulator_backend.SimulatorBackend`.
+    :class:`~syne_tune.backend.simulator_backend.SimulatorBackend`.
 
     This is doing two things. First, :meth:`on_tuning_sleep` is advancing the
     `time_keeper` of the simulator back-end by `tuner_sleep_time` (also
-    defined in the back-end). The real sleep time in :class:`syne_tune.Tuner`
+    defined in the back-end). The real sleep time in :class:`~syne_tune.Tuner`
     must be 0.
 
     Second, we need to make sure that results written out are annotated by
@@ -40,11 +40,11 @@ class SimulatorCallback(StoreResultsCallback):
     Third (and most subtle), we need to make sure the stop criterion in
     `Tuner.run` is using simulated time instead of real time when making
     a decision based on `max_wallclock_time`. By default,
-    :class:`syne_tune.StoppingCriterion` takes `TuningStatus` as an input,
+    :class:`~syne_tune.StoppingCriterion` takes `TuningStatus` as an input,
     which counts real time and knows nothing about simulated time. To this
     end, we modify `stop_criterion` of the tuner to instead depend on the
     `ST_TUNER_TIME` fields in the results received. This allows us to keep
-    both :class:`syne_tune.Tuner` and `TuningStatus` independent of the time
+    both :class:`~syne_tune.Tuner` and `TuningStatus` independent of the time
     keeper.
     """
 

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -254,8 +254,8 @@ class TrialBackend:
         """Returns list of ids for currently busy trials
 
         A trial is busy if its status is
-        :const:`syne_tune.backend.trial_status.Status.in_progress` or
-        :const:`syne_tune.backend.trial_status.Status.stopping`.
+        :const:`~syne_tune.backend.trial_status.Status.in_progress` or
+        :const:`~syne_tune.backend.trial_status.Status.stopping`.
         If the execution setup is able to run `n_workers` jobs in parallel,
         then if this method returns a list of size `n`, the tuner may start
         `n_workers - n` new jobs.
@@ -299,7 +299,7 @@ class TrialBackend:
     ):
         """
         :param results_root: The local folder that should contain the results of
-            the tuning experiment. Used by :class:`syne_tune.Tuner` to indicate
+            the tuning experiment. Used by :class:`~syne_tune.Tuner` to indicate
             a desired path where the results should be written to. This is used
             to unify the location of backend files and `Tuner` results when
             possible (in the local backend). By default, the backend does not do
@@ -325,6 +325,6 @@ class TrialBackend:
 
     def on_tuner_save(self):
         """
-        Called at the end of :meth:`syne_tune.Tuner.save`.
+        Called at the end of :meth:`~syne_tune.Tuner.save`.
         """
         pass

--- a/syne_tune/blackbox_repository/blackbox.py
+++ b/syne_tune/blackbox_repository/blackbox.py
@@ -51,7 +51,7 @@ class Blackbox:
     ) -> ObjectiveFunctionResult:
         """Returns an evaluation of the blackbox.
 
-        First perform data check and then call :meth:`_objective_function` that
+        First perform data check and then call :meth:`~_objective_function` that
         should be overriden in the child class.
 
         :param configuration: configuration to be evaluated, should belong to

--- a/syne_tune/blackbox_repository/blackbox_offline.py
+++ b/syne_tune/blackbox_repository/blackbox_offline.py
@@ -36,7 +36,7 @@ class BlackboxOffline(Blackbox):
     to be metrics but this can be overridden by providing metric columns.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.blackbox_repository.Blackbox`:
+    :class:`~syne_tune.blackbox_repository.Blackbox`:
 
     :param df_evaluations: Data frame with evaluations data
     :param seed_col: optional, can be used when multiple seeds are recorded

--- a/syne_tune/blackbox_repository/blackbox_surrogate.py
+++ b/syne_tune/blackbox_repository/blackbox_surrogate.py
@@ -82,7 +82,7 @@ class BlackboxSurrogate(Blackbox):
     fidelities.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.blackbox_repository.Blackbox`:
+    :class:`~syne_tune.blackbox_repository.Blackbox`:
 
     :param X: dataframe containing hyperparameters values. Shape is
         `(num_seeds * num_evals, num_hps)` if `predict_curves` is `True`,
@@ -101,7 +101,7 @@ class BlackboxSurrogate(Blackbox):
         The model is fit on top of pipeline that applies basic feature-processing
         to convert rows in `X` to vectors. We use the configuration_space
         hyperparameters types to deduce the types of columns in `X` (for instance,
-        :class:`syne_tune.config_space.Categorical` values are one-hot encoded).
+        :class:`~syne_tune.config_space.Categorical` values are one-hot encoded).
     :param predict_curves: See above. Default is `False` (backwards compatible)
     :param num_seeds: See above
     :param fit_differences: See above
@@ -445,7 +445,7 @@ def add_surrogate(
     for supporting interpolation/extrapolation.
 
     :param blackbox: the blackbox must implement
-        :meth:`syne_tune.blackbox_repository.Blackbox.hyperparameter_objectives_values`
+        :meth:`~syne_tune.blackbox_repository.Blackbox.hyperparameter_objectives_values`
         so that input/output are passed to estimate the model
     :param surrogate: the model that is fitted to predict objectives given any
         configuration. Possible examples: :code:`KNeighborsRegressor(n_neighbors=1)`,
@@ -462,7 +462,7 @@ def add_surrogate(
         as input. The latter can lead to inconsistent predictions along
         fidelity and is typically more expensive.
         If not given, the default value is `False` if `blackbox` is of type
-        :class:`syne_tune.blackbox_repository.BlackboxOffline`, otherwise `True`.
+        :class:`~syne_tune.blackbox_repository.BlackboxOffline`, otherwise `True`.
     :param separate_seeds: If `True`, seeds in `blackbox` map to seeds in the
         surrogate blackbox, which fits different models to each seed. If `False`,
         the data from `blackbox` is merged for all seeds, and the surrogate

--- a/syne_tune/blackbox_repository/blackbox_tabular.py
+++ b/syne_tune/blackbox_repository/blackbox_tabular.py
@@ -31,12 +31,12 @@ class BlackboxTabular(Blackbox):
     """
     Blackbox that contains tabular evaluations (e.g. all hyperparameters
     evaluated on all fidelities). We use a separate class than
-    :class:`syne_tune.blackbox_repository.BlackboxOffline`, as performance
+    :class:`~syne_tune.blackbox_repository.BlackboxOffline`, as performance
     improvement can be made by avoiding to repeat hyperparameters and by storing
     all evaluations in a single table.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.blackbox_repository.Blackbox`:
+    :class:`~syne_tune.blackbox_repository.Blackbox`:
 
     :param hyperparameters: dataframe of hyperparameters, shape
         `(num_evals, num_hps)`, columns must match hyperparameter names of
@@ -363,7 +363,7 @@ def deserialize(path: str) -> Dict[str, BlackboxTabular]:
     above.
 
     TODO: the API is currently dissonant with :func:`serialize`,
-    :func:`deserialize` for :class:`syne_tune.blackbox_repository.BlackboxOffline`
+    :func:`deserialize` for :class:`~syne_tune.blackbox_repository.BlackboxOffline`
     as `serialize` is a member function there. A possible way to unify is to
     have serialize also be a free function for `BlackboxOffline`.
 

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -94,7 +94,7 @@ class BlackBoxYAHPO(Blackbox):
         Even though YAHPO interpolates between fidelities, it can make sense
         to restrict them to the values which have really been acquired in the
         data. Note that this restricts multi-fidelity schedulers like
-        :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`, in that all
+        :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`, in that all
         their rungs levels have to be fidelity values.
 
         For example, for YAHPO `iaml`, the fidelity `trainsize` has been

--- a/syne_tune/blackbox_repository/simulated_tabular_backend.py
+++ b/syne_tune/blackbox_repository/simulated_tabular_backend.py
@@ -227,7 +227,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
     .. note::
        If the blackbox maintains cumulative time (elapsed_time), this is
        different from what
-       :class:`syne_tune.backend.simulator_backend.SimulatorBackend` requires
+       :class:`~syne_tune.backend.simulator_backend.SimulatorBackend` requires
        for `elapsed_time_attr`, if a pause-and-resume scheduler is used. Namely,
        the back-end requires the time since the start of the last recent
        resume. This conversion is done here internally in
@@ -236,7 +236,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
        from the blackbox table, but instead what the back-end needs.
 
     `max_resource_attr` plays the same role as in
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
     If given, it is the key in a configuration `config` for the maximum
     resource. This is used by schedulers which limit each evaluation by
     setting this argument (e.g., promotion-based Hyperband).
@@ -272,7 +272,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         `surrogate="KNeighborsRegressor"` is chosen.
         If `blackbox_name` is a YAHPO blackbox, then `surrogate_kwargs` is passed
         as `yahpo_kwargs` to
-        :func:`syne_tune.blackbox_repository.load_blackbox`. In this case,
+        :func:`~syne_tune.blackbox_repository.load_blackbox`. In this case,
         `surrogate` is ignored (YAHPO always uses surrogates).
     :param config_space_surrogate: If `surrogate` is given, this is the
         configuration space for the surrogate blackbox. If not given, the
@@ -280,7 +280,7 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         have finite domains (categorical or ordinal), which is usually not what
         we want for a surrogate.
     :param simulatorbackend_kwargs: Additional arguments to parent
-        :class:`syne_tune.backend.simulator_backend.SimulatorBackend`
+        :class:`~syne_tune.backend.simulator_backend.SimulatorBackend`
     """
 
     def __init__(

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -39,7 +39,7 @@ class ExperimentResult:
     :param name: Name of experiment
     :param results: Dataframe containing results of experiment
     :param metadata: Metadata stored along with results
-    :param tuner: :class:`syne_tune.Tuner` object stored along with results
+    :param tuner: :class:`~syne_tune.Tuner` object stored along with results
     :param path: local path where the experiment is stored
     """
 
@@ -57,7 +57,7 @@ class ExperimentResult:
 
     def creation_date(self):
         """
-        :return: Timestamp when :class:`syne_tune.Tuner` was created
+        :return: Timestamp when :class:`~syne_tune.Tuner` was created
         """
         return datetime.fromtimestamp(self.metadata[ST_TUNER_CREATION_TIMESTAMP])
 
@@ -312,7 +312,7 @@ def load_experiments_df(
     :param load_tuner: Whether to load the tuner in addition to metadata and results
     :return: Dataframe that contains all evaluations reported by tuners according
         to the filter given. The columns contain trial-id, hyperparameter
-        evaluated, metrics reported via :class:`syne_tune.Reporter`. These metrics
+        evaluated, metrics reported via :class:`~syne_tune.Reporter`. These metrics
         are collected automatically:
 
         * `st_worker_time` (indicating time spent in the worker when report was

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -40,13 +40,13 @@ from syne_tune.try_import import (
 class RandomSearch(FIFOScheduler):
     """Random search.
 
-    See :class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`
+    See :class:`~syne_tune.optimizer.schedulers.searchers.RandomSearcher`
     for `kwargs["search_options"]` parameters.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, **kwargs):
@@ -61,13 +61,13 @@ class RandomSearch(FIFOScheduler):
 class GridSearch(FIFOScheduler):
     """Grid search.
 
-    See :class:`syne_tune.optimizer.schedulers.searchers.GridSearcher`
+    See :class:`~syne_tune.optimizer.schedulers.searchers.GridSearcher`
     for `kwargs["search_options"]` parameters.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, **kwargs):
@@ -82,13 +82,13 @@ class GridSearch(FIFOScheduler):
 class BayesianOptimization(FIFOScheduler):
     """Gaussian process based Bayesian optimization.
 
-    See :class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`
+    See :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`
     for `kwargs["search_options"]` parameters.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, **kwargs):
@@ -111,12 +111,12 @@ class ASHA(HyperbandScheduler):
 
     One of `max_t`, `max_resource_attr` needs to be in `kwargs`. For
     `type="promotion"`, the latter is more useful, see also
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
-    :param kwargs: Additional arguments to :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, resource_attr: str, **kwargs):
@@ -135,7 +135,7 @@ class MOBSTER(HyperbandScheduler):
 
     One of `max_t`, `max_resource_attr` needs to be in `kwargs`. For
     `type="promotion"`, the latter is more useful, see also
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     MOBSTER can be run with different surrogate models. The model is selected
     by `search_options["model"]` in `kwargs`. The default is `"gp_multitask"`
@@ -143,13 +143,13 @@ class MOBSTER(HyperbandScheduler):
     `"gp_independent"` (independent GP models at each rung level, with shared
     ARD kernel).
 
-    See :class:`syne_tune.optimizer.schedulers.searchers.GPMultifidelitySearcher`
+    See :class:`~syne_tune.optimizer.schedulers.searchers.GPMultifidelitySearcher`
     for `kwargs["search_options"]` parameters.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
-    :param kwargs: Additional arguments to :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, resource_attr: str, **kwargs):
@@ -167,7 +167,7 @@ class HyperTune(HyperbandScheduler):
     """
     One of `max_t`, `max_resource_attr` needs to be in `kwargs`. For
     `type="promotion"`, the latter is more useful, see also
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     Hyper-Tune is a model-based variant of ASHA with more than one bracket.
     It can be seen as extension of MOBSTER and can be used with
@@ -182,15 +182,15 @@ class HyperTune(HyperbandScheduler):
         | https://arxiv.org/abs/2201.06834
 
     See also
-    :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune.gp_model.HyperTuneIndependentGPModel`,
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune.gp_model.HyperTuneIndependentGPModel`,
     and see
-    :class:`syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher`
+    :class:`~syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher`
     for `kwargs["search_options"]` parameters.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
-    :param kwargs: Additional arguments to :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     """
 
     def __init__(self, config_space: Dict, metric: str, resource_attr: str, **kwargs):
@@ -223,12 +223,12 @@ class PASHA(HyperbandScheduler):
     """Progressive ASHA.
 
     One of `max_t`, `max_resource_attr` needs to be in `kwargs`. The latter is
-    more useful, see also :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
-    :param kwargs: Additional arguments to :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param kwargs: Additional arguments to :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     """
 
     def __init__(self, config_space: dict, metric: str, resource_attr: str, **kwargs):
@@ -247,13 +247,13 @@ class SyncHyperband(SynchronousGeometricHyperbandScheduler):
     """Synchronous Hyperband.
 
     One of `max_resource_level`, `max_resource_attr` needs to be in `kwargs`.
-    The latter is more useful, see also :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    The latter is more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
+        :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
     """
 
     def __init__(
@@ -280,13 +280,13 @@ class SyncBOHB(SynchronousGeometricHyperbandScheduler):
     kernel density estimators.
 
     One of `max_resource_level`, `max_resource_attr` needs to be in `kwargs`.
-    The latter is more useful, see also :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    The latter is more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
+        :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
     """
 
     def __init__(
@@ -312,13 +312,13 @@ class DEHB(GeometricDifferentialEvolutionHyperbandScheduler):
     Combines :class:`SyncHyperband` with ideas from evolutionary algorithms.
 
     One of `max_resource_level`, `max_resource_attr` needs to be in `kwargs`.
-    The latter is more useful, see also :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    The latter is more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param config_space: Configuration space for evaluation function
     :param metric: Name of metric to optimize
     :param resource_attr: Name of resource attribute
     :param kwargs: Additional arguments to
-        :class:`syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
+        :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousGeometricHyperbandScheduler`
     """
 
     def __init__(
@@ -346,7 +346,7 @@ class SyncMOBSTER(SynchronousGeometricHyperbandScheduler):
     the asynchronous case.
 
     One of `max_resource_level`, `max_resource_attr` needs to be in `kwargs`.
-    The latter is more useful, see also :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    The latter is more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     The default surrogate model (`search_options["model"]` in `kwargs`) is
     `"gp_independent"`, different to :class:`MOBSTER`.

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -128,7 +128,7 @@ class TrialScheduler:
         start from there. In this case, `suggestion.config` is optional. If not
         given (default), the config of the resumed trial does not change.
         Otherwise, its config is overwritten by `suggestion.config` (see
-        :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+        :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
         `type="promotion"` for an example why this can be useful).
 
         Apart from the HP config, additional fields can be appended to the
@@ -186,7 +186,7 @@ class TrialScheduler:
 
         Note that the config returned here may also contain values for constant
         parameters in the config space. If so, these values take precedence.
-        See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+        See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
         `type="promotion"` for an example how this is used.
 
         :param trial_id: ID for new trial to be started (ignored if existing

--- a/syne_tune/optimizer/schedulers/fifo.py
+++ b/syne_tune/optimizer/schedulers/fifo.py
@@ -123,10 +123,10 @@ class FIFOScheduler(ResourceLevelsScheduler):
         are passed to `searcher_factory` along with `search_options` and
         extra information. Defaults to "random" (i.e., random search)
     :type searcher: str or
-        :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher`
+        :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher`
     :param search_options: If searcher is `str`, these arguments are
         passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`
     :type search_options: dict, optional
     :param metric: Name of metric to optimize, key in results obtained via
         `on_trial_result`
@@ -160,7 +160,7 @@ class FIFOScheduler(ResourceLevelsScheduler):
         schedulers which make use of intermediate reports via
         `on_trial_result`. If this is not given, we try to infer its value
         from `config_space` (see
-        :class:`syne_tune.optimizer.schedulers.ResourceLevelsScheduler`).
+        :class:`~syne_tune.optimizer.schedulers.ResourceLevelsScheduler`).
         checking `config_space["epochs"]`, `config_space["max_t"]`, and
         `config_space["max_epochs"]`. If `max_resource_attr` is given, we use
         the value `config_space[max_resource_attr]`. But if `max_t` is given
@@ -172,9 +172,9 @@ class FIFOScheduler(ResourceLevelsScheduler):
         which is started with the first call to :meth:`_suggest`. Can also be set
         after construction, with :meth:`set_time_keeper`.
         Note: If you use
-        :class:`syne_tune.backend.simulator_backend.SimulatorBackend`, you need
+        :class:`~syne_tune.backend.simulator_backend.SimulatorBackend`, you need
         to pass its `time_keeper` here.
-    :type time_keeper: :class:`syne_tune.backend.time_keeper.TimeKeeper`,
+    :type time_keeper: :class:`~syne_tune.backend.time_keeper.TimeKeeper`,
         optional
     """
 

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -229,7 +229,7 @@ class HyperbandScheduler(FIFOScheduler):
     evaluations in one go.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.FIFOScheduler`:
+    :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`:
 
     :param resource_attr: Name of resource attribute in results obtained
         via `on_trial_result`, defaults to "epoch"
@@ -253,22 +253,22 @@ class HyperbandScheduler(FIFOScheduler):
     :type brackets: int, optional
     :param type: Type of Hyperband scheduler. Defaults to "stopping".
         Supported values (see also subclasses of
-        :class:`syne_tune.optimizer.schedulers.hyperband_stopping.RungSystem`):
+        :class:`~syne_tune.optimizer.schedulers.hyperband_stopping.RungSystem`):
 
         * stopping: A config eval is executed by a single task. The task is
           stopped at a milestone if its metric is worse than a fraction
           of those who reached the milestone earlier, otherwise it
           continues. See
-          :class:`syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`.
+          :class:`~syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`.
         * promotion: A config eval may be associated with multiple tasks
           over its lifetime. It is never terminated, but may be paused.
           Whenever a task becomes available, it may promote a config to
           the next milestone, if better than a fraction of others who
           reached the milestone. If no config can be promoted, a new one
           is chosen. See
-          :class:`syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`.
+          :class:`~syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`.
         * cost_promotion: This is a cost-aware variant of 'promotion', see
-          :class:`syne_tune.optimizer.schedulers.hyperband_cost_promotion.CostPromotionRungSystem`
+          :class:`~syne_tune.optimizer.schedulers.hyperband_cost_promotion.CostPromotionRungSystem`
           for details. In this case, costs must be reported under the name
           `rung_system_kwargs["cost_attr"]` in results.
         * pasha: Similar to promotion type Hyperband, but it progressively
@@ -279,11 +279,11 @@ class HyperbandScheduler(FIFOScheduler):
           `rung_system_kwargs["num_threshold_candidates"]` of
           `points_to_evaluate` will enforce stricter rules on which task is
           continued. See
-          :class:`syne_tune.optimizer.schedulers.hyperband_rush.RUSHStoppingRungSystem`
+          :class:`~`syne_tune.optimizer.schedulers.hyperband_rush.RUSHStoppingRungSystem`
           and
-          :class:`syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
+          :class:`~`syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
         * rush_promotion: Same as `rush_stopping` but for promotion, see
-          :class:`syne_tune.optimizer.schedulers.hyperband_rush.RUSHPromotionRungSystem`
+          :class:`~syne_tune.optimizer.schedulers.hyperband_rush.RUSHPromotionRungSystem`
 
     :type type: str, optional
     :param cost_attr: Required if the scheduler itself uses a cost metric
@@ -354,7 +354,7 @@ class HyperbandScheduler(FIFOScheduler):
           "rush_stopping"]`. The first `num_threshold_candidates` in
           `points_to_evaluate` enforce stricter requirements to the
           continuation of training tasks. See
-          :class:`syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
+          :class:`~syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
 
     :type rung_system_kwargs: dict, optional
     """
@@ -490,11 +490,11 @@ class HyperbandScheduler(FIFOScheduler):
         `kwargs` being used here:
 
         * elapsed_time: Time from start of experiment, set in
-          :meth:`syne_tune.optimizer.schedulers.FIFOScheduler._suggest`
+          :meth:`~syne_tune.optimizer.schedulers.FIFOScheduler._suggest`
         * bracket: Bracket in which new trial is started, set in
-          :meth:`syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`
+          :meth:`~syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`
         * milestone: First milestone the new trial will reach, set in
-          :meth:`syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`
+          :meth:`~syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`
 
         :param config: New config suggested for `trial_id`
         :param trial_id: Input to `_suggest`
@@ -894,9 +894,9 @@ def hyperband_rung_levels(
     """Creates `rung_levels` from `grace_period`, `reduction_factor`
 
     :param rung_levels: If given, this is returned
-    :param grace_period: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
-    :param reduction_factor: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
-    :param max_t: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param grace_period: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param reduction_factor: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
+    :param max_t: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     :return: List of rung levels
     """
     if rung_levels is not None:
@@ -949,8 +949,8 @@ class HyperbandBracketManager:
     on `scheduler_type` manifest themselves mostly at the level of the rung
     level system itself.
 
-    :param scheduler_type: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
-    :param resource_attr: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :param scheduler_type: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :param resource_attr: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
     :param metric: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
     :param mode: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
     :param max_t: See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.

--- a/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
+++ b/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
@@ -23,7 +23,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
     Cost-aware extension of promotion-based asynchronous Hyperband (ASHA).
 
     This code is equivalent with base
-    :class:`syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`,
+    :class:`~syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`,
     except the "promotable" condition in :meth:`_find_promotable_trial` is
     replaced.
 
@@ -52,7 +52,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
 
     Note that costs :math:`c(\mathbf{x}, r)` reported via `cost_attr` need to
     be total costs of a trial. If the trial is paused and resumed, partial costs
-    have to be added up. See :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`
+    have to be added up. See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     for how this works.
     """
 

--- a/syne_tune/optimizer/schedulers/hyperband_promotion.py
+++ b/syne_tune/optimizer/schedulers/hyperband_promotion.py
@@ -33,7 +33,7 @@ class PromotionRungSystem(RungSystem):
 
     The rule to decide whether a paused trial is promoted (or remains
     paused) is the same as in
-    :class:`syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`,
+    :class:`~syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`,
     except that *continues* becomes *gets promoted*. If several paused trials
     in a rung can be promoted, the one with the best metric value is chosen.
 
@@ -140,7 +140,7 @@ class PromotionRungSystem(RungSystem):
     def on_task_schedule(self) -> dict:
         """
         Used to implement
-        :meth:`syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`.
+        :meth:`~syne_tune.optimizer.schedulers.HyperbandScheduler._promote_trial`.
         Searches through rungs to find a trial which can be promoted. If one is
         found, we return the `trial_id` and other info (current milestone,
         milestone to be promoted to). We also mark the trial as being promoted

--- a/syne_tune/optimizer/schedulers/hyperband_rush.py
+++ b/syne_tune/optimizer/schedulers/hyperband_rush.py
@@ -30,7 +30,7 @@ class RUSHDecider:
         | AutoML workshop @ ICML 2021.
 
     For a more detailed description, refer to
-    :class:`syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`.
 
     :param num_threshold_candidates: Number of threshold candidates
     :param mode: "min" or "max"
@@ -87,7 +87,7 @@ class RUSHStoppingRungSystem(StoppingRungSystem):
     Implementation for RUSH algorithm, stopping variant.
 
     Additional arguments on top of base class
-    :class:`syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`:
+    :class:`~syne_tune.optimizer.schedulers.hyperband_stopping.StoppingRungSystem`:
 
     :param num_threshold_candidates: Number of threshold candidates
     """
@@ -125,7 +125,7 @@ class RUSHPromotionRungSystem(PromotionRungSystem):
     Implementation for RUSH algorithm, promotion variant.
 
     Additional arguments on top of base class
-    :class:`syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`:
+    :class:`~syne_tune.optimizer.schedulers.hyperband_promotion.PromotionRungSystem`:
 
     :param num_threshold_candidates: Number of threshold candidates
     """

--- a/syne_tune/optimizer/schedulers/pbt.py
+++ b/syne_tune/optimizer/schedulers/pbt.py
@@ -98,11 +98,11 @@ class PopulationBasedTraining(FIFOScheduler):
     decrement (multiply by 0.8) the value (probability 0.5 each). For categorical
     hyperparameters, the value is always resampled uniformly.
 
-    Note: While this is implemented as child of :class:`syne_tune.optimizer.schedulers.FIFOScheduler`, we
+    Note: While this is implemented as child of :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`, we
     require `searcher="random"` (default), since the current code only supports
     a random searcher.
 
-    Additional arguments on top of parent class :class:`syne_tune.optimizer.schedulers.FIFOScheduler`.
+    Additional arguments on top of parent class :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
 
     :param resource_attr: Name of resource attribute in results obtained
         via `on_trial_result`, defaults to "time_total_s"

--- a/syne_tune/optimizer/schedulers/ray_scheduler.py
+++ b/syne_tune/optimizer/schedulers/ray_scheduler.py
@@ -32,7 +32,7 @@ class RayTuneScheduler(TrialScheduler):
     configurations to evaluate can be passed in `points_to_evaluate`. If
     `ray_searcher` is given, this argument is ignored (needs to be passed
     to `ray_searcher` at construction). Note: Use
-    :func:`syne_tune.optimizer.schedulers.searchers.impute_points_to_evaluate`
+    :func:`~syne_tune.optimizer.schedulers.searchers.impute_points_to_evaluate`
     in order to preprocess `points_to_evaluate` specified by the user or
     the benchmark.
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost/sklearn_cost_model.py
@@ -248,7 +248,7 @@ class ScikitLearnCostModel(NonLinearCostModel):
 class UnivariateSplineCostModel(NonLinearCostModel):
     """
     Here, `c1(x)` is given by a univariate spline
-    (:class:`scipy.optimize.UnivariateSpline`), where a single scalar is
+    (:class:`~`scipy.optimize.UnivariateSpline`), where a single scalar is
     extracted from x.
 
     In the second part of the dataset (`pos >= num_data0`), duplicate entries with

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -42,11 +42,11 @@ class Bore(SearcherWithRandomSeed):
         | https://arxiv.org/abs/2102.09009
 
     Note: Bore only works in the non-parallel non-multi-fidelity setting. Make
-    sure that you use it with :class:`syne_tune.optimizer.schedulers.FIFOScheduler`
-    and set `n_workers=1` in :class:`syne_tune.Tuner`.
+    sure that you use it with :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
+    and set `n_workers=1` in :class:`~syne_tune.Tuner`.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param mode: Can be "min" (default) or "max".
     :param gamma: Defines the percentile, i.e how many percent of configurations

--- a/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
@@ -39,7 +39,7 @@ class MultiFidelityBore(Bore):
         | Proceedings of the 35th International Conference on Machine Learning
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.bore.Bore`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.bore.Bore`:
 
     :param resource_attr: Name of resource attribute. Defaults to "epoch"
     """

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -51,7 +51,7 @@ class BotorchSearcher(SearcherWithRandomSeed):
     supports pending evaluations.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param mode: "min" (default) or "max"
     :param num_init_random: Number of initial random draws, after this

--- a/syne_tune/optimizer/schedulers/searchers/bracket_distribution.py
+++ b/syne_tune/optimizer/schedulers/searchers/bracket_distribution.py
@@ -18,7 +18,7 @@ from syne_tune.optimizer.scheduler import TrialScheduler
 class BracketDistribution:
     """
     Configures asynchronous multi-fidelity schedulers such as
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` with
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` with
     distribution over brackets. This distribution can be fixed up front, or
     change adaptively during the course of an experiment. It has an effect
     only if the scheduler is run with more than one bracket.

--- a/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
@@ -35,10 +35,10 @@ logger = logging.getLogger(__name__)
 class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
     """
     Gaussian process-based constrained hyperparameter optimization (to be used
-    with :class:`syne_tune.optimizer.schedulers.FIFOScheduler`).
+    with :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`).
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.cost_aware.cost_aware_gp_fifo_searcher.MultiModelGPFIFOSearcher`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.cost_aware.cost_aware_gp_fifo_searcher.MultiModelGPFIFOSearcher`:
 
     :param constraint_attr: Name of constraint metric in `report` passed to
         :meth:`_update`.

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_fifo_searcher.py
@@ -36,9 +36,9 @@ logger = logging.getLogger(__name__)
 class MultiModelGPFIFOSearcher(GPFIFOSearcher):
     """
     Superclass for multi-model extensions of
-    :class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`. We first
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`. We first
     call
-    :meth:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`
+    :meth:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`
     passing factory and `skip_optimization` predicate for the `INTERNAL_METRIC_NAME`
     model, then replace the state transformer by a multi-model one.
     """
@@ -61,7 +61,7 @@ class MultiModelGPFIFOSearcher(GPFIFOSearcher):
 class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
     """
     Gaussian process-based cost-aware hyperparameter optimization (to be used
-    with :class:`syne_tune.optimizer.schedulers.FIFOScheduler`). The searcher
+    with :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`). The searcher
     requires a cost metric, which is given by `cost_attr`.
 
     Implements two different variants. If `resource_attr` is given, cost values
@@ -77,7 +77,7 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
     as well.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`:
 
     :param cost_attr: Mandatory. Name of cost attribute in data obtained
         from reporter (e.g., elapsed training time). Depending on whether
@@ -95,7 +95,7 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
         :math:`c(x, r)`. Ignored if `resource_attr` is not given, since
         :math:`c(x)` is represented by a default GP surrogate model.
     :type cost_model:
-        :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`, optional
+        :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`, optional
     """
 
     def __init__(

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_multifidelity_searcher.py
@@ -41,9 +41,9 @@ logger = logging.getLogger(__name__)
 class MultiModelGPMultiFidelitySearcher(GPMultiFidelitySearcher):
     """
     Superclass for multi-model extensions of
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`.
     We first call
-    :meth:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`
+    :meth:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`
     passing factory and `skip_optimization` predicate for the `INTERNAL_METRIC_NAME`
     model, then replace the state transformer by a multi-model one.
     """
@@ -67,19 +67,19 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
     """
     Gaussian process-based cost-aware multi-fidelity hyperparameter
     optimization (to be used with
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`). The searcher
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`). The searcher
     requires a cost metric, which is given by `cost_attr`.
 
     The acquisition function used here is the same as in
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`,
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`,
     but expected improvement (EI) is replaced by EIpu (see
-    :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl.EIpuAcquisitionFunction`).
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc_impl.EIpuAcquisitionFunction`).
 
     Cost values are read from each report and cost is modeled as :math:`c(x, r)`,
     the cost model being given by `kwargs["cost_model"]`.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`:
 
     :param cost_attr: Mandatory. Name of cost attribute in data obtained
         from reporter (e.g., elapsed training time). Depending on whether
@@ -92,7 +92,7 @@ class CostAwareGPMultiFidelitySearcher(MultiModelGPMultiFidelitySearcher):
     :type resource_attr: str
     :param cost_model: Model for :math:`c(x, r)`
     :type cost_model:
-        :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`, optional
+        :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`, optional
     """
 
     def __init__(

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -461,12 +461,12 @@ class GPFIFOSearcher(ModelBasedSearcher):
     """Gaussian process Bayesian optimization for FIFO scheduler
 
     This searcher must be used with
-    :class:`syne_tune.optimizer.schedulers.FIFOScheduler`. It provides
+    :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. It provides
     Bayesian optimization, based on a Gaussian process surrogate model.
 
     It is *not* recommended creating :class:`GPFIFOSearcher` searcher objects
     directly, but rather to create
-    :class:`syne_tune.optimizer.schedulers.FIFOScheduler` objects with
+    :class:`~syne_tune.optimizer.schedulers.FIFOScheduler` objects with
     `searcher="bayesopt"`, and passing arguments here in `search_options`.
     This will use the appropriate functions from
     :mod:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory` to
@@ -507,11 +507,11 @@ class GPFIFOSearcher(ModelBasedSearcher):
     Note that the full logic of construction based on arguments is given in
     :mod:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory`. In
     particular, see
-    :func:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory.gp_fifo_searcher_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.gp_searcher_factory.gp_fifo_searcher_defaults`
     for default values.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param clone_from_state: Internal argument, do not use
     :type clone_from_state: bool
@@ -529,7 +529,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
     :param num_init_random: Number of initial :meth:`get_config` calls for which
         randomly sampled configs are returned. Afterwards, the model-based
         searcher is used. Defaults to
-        :const:`syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.defaults.DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS`
+        :const:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.defaults.DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS`
     :type num_init_random: int, optional
     :param num_init_candidates: Number of initial candidates sampled at
         random in order to seed the model-based search in `get_config`.
@@ -551,7 +551,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
           used for local optimization afterwards
 
         Defaults to
-        :const:`syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.defaults.DEFAULT_INITIAL_SCORING`
+        :const:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.defaults.DEFAULT_INITIAL_SCORING`
     :type initial_scoring: str, optional
     :param skip_local_optimization: If `True`, the local gradient-based
         optimization of the acquisition function is skipped, and the
@@ -603,7 +603,7 @@ class GPFIFOSearcher(ModelBasedSearcher):
         range are all task IDs. Also, `transfer_learning_active_task` must
         denote the active task, and `transfer_learning_active_config_space`
         is used as `active_config_space` argument in
-        :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
+        :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
         This allows us to use a narrower search space for the active task than
         for the union of all tasks (`config_space` must be that), which is
         needed if some configurations of non-active tasks lie outside of the

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -43,20 +43,20 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
     Gaussian process Bayesian optimization for asynchronous Hyperband scheduler.
 
     This searcher must be used with
-    :class:`syne_tune,optimizer.schedulers.HyperbandScheduler`. It provides a
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`. It provides a
     novel combination of Bayesian optimization, based on a Gaussian process
     surrogate model, with Hyperband scheduling. In particular, observations
     across resource levels are modelled jointly.
 
     It is *not* recommended to create :class:`GPMultiFidelitySearcher` searcher
     objects directly, but rather to create
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` objects with
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` objects with
     `searcher="bayesopt"`, and passing arguments here in `search_options`.
     This will use the appropriate functions from
     :mod:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory` to
     create components in a consistent way.
 
-    Most of :class:`syne_tune,optimizer.schedulers.searchers.GPFIFOSearcher`
+    Most of :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`
     comments apply here as well. In multi-fidelity HPO, we optimize a function
     :math:`f(\mathbf{x}, r)`, :math:`\mathbf{x}` the configuration, :math:`r`
     the resource (or time) attribute. The latter must be a positive integer.
@@ -66,7 +66,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
     If `model == "gp_multitask"` (default), we model the function
     :math:`f(\mathbf{x}, r)` jointly over all resource levels :math:`r` at
     which it is observed (but see `searcher_data` in
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`). The kernel
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`). The kernel
     and mean function of our surrogate model are over :math:`(\mathbf{x}, r)`.
     The surrogate model is selected by `gp_resource_kernel`. More details about
     the supported kernels is in:
@@ -84,7 +84,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
     :math:`\mathbf{x}` would reach when started.
 
     Additional arguments on top of parent class
-    :class:`syne_tune,optimizer.schedulers.searchers.GPFIFOSearcher`.
+    :class:`~syne_tune,optimizer.schedulers.searchers.GPFIFOSearcher`.
 
     :param model: Selects surrogate model (learning curve model) to be used.
         Choices are:
@@ -105,7 +105,7 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         is normalized to mean 0, variance 1. The reference above provides details
         on the models supported here. For the exponential decay kernel, the
         base kernel over :math:`\mathbf{x}` is Matern 5/2 ARD. See
-        :const:`syne_tune.optimizer.schedulers.searchers.bayesopt.models.kernel_factory.SUPPORTED_RESOURCE_MODELS`
+        :const:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.kernel_factory.SUPPORTED_RESOURCE_MODELS`
         for supported choices. Defaults to "exp-decay-sum"
     :type gp_resource_kernel: str, optional
     :param resource_acq: Only relevant for `model in

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -463,9 +463,9 @@ def _create_common_objects(model=None, is_hypertune=False, **kwargs):
 def gp_fifo_searcher_factory(**kwargs) -> dict:
     """
     Returns `kwargs` for
-    :meth:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`,
+    :meth:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.FIFOScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`).
 
     Extensions of `kwargs` by the scheduler:
 
@@ -478,7 +478,7 @@ def gp_fifo_searcher_factory(**kwargs) -> dict:
     * `max_epochs`: Maximum resource value
 
     :param kwargs: `search_options` coming from scheduler
-    :return: `kwargs` for :meth:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`
+    :return: `kwargs` for :meth:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher._create_internal`
     """
     assert (
         kwargs["scheduler"] == "fifo"
@@ -494,12 +494,12 @@ def gp_fifo_searcher_factory(**kwargs) -> dict:
 def gp_multifidelity_searcher_factory(**kwargs) -> dict:
     """
     Returns `kwargs` for
-    :meth:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`,
+    :meth:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.HyperbandScheduler`).
 
     :param kwargs: `search_options` coming from scheduler
-    :return: `kwargs` for :meth:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`
+    :return: `kwargs` for :meth:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher._create_internal`
     """
     supp_schedulers = {
         "hyperband_stopping",
@@ -531,12 +531,12 @@ def gp_multifidelity_searcher_factory(**kwargs) -> dict:
 def hypertune_searcher_factory(**kwargs) -> dict:
     """
     Returns `kwargs` for
-    :meth:`syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher._create_internal`,
+    :meth:`~syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.HyperbandScheduler`).
 
     :param kwargs: `search_options` coming from scheduler
-    :return: `kwargs` for :meth:`syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher._create_internal`
+    :return: `kwargs` for :meth:`~syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher._create_internal`
     """
     if kwargs.get("model") is None:
         kwargs["model"] = "gp_independent"
@@ -552,9 +552,9 @@ def hypertune_searcher_factory(**kwargs) -> dict:
 def constrained_gp_fifo_searcher_factory(**kwargs) -> dict:
     """
     Returns `kwargs` for
-    :meth:`syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher._create_internal`,
+    :meth:`~syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.FIFOScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`).
 
     :param kwargs: `search_options` coming from scheduler
     :return: `kwargs` for :meth:`syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher._create_internal`
@@ -605,7 +605,7 @@ def cost_aware_coarse_gp_fifo_searcher_factory(**kwargs) -> dict:
     Returns `kwargs` for
     :meth:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPFIFOSearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.FIFOScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`).
 
     This is for the coarse-grained variant, where costs :math:`c(x)` are obtained
     together with metric values and are given a GP surrogate model.
@@ -661,11 +661,11 @@ def cost_aware_fine_gp_fifo_searcher_factory(**kwargs) -> dict:
     Returns `kwargs` for
     :meth:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPFIFOSearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.FIFOScheduler`).
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`).
 
     This is for the fine-grained variant, where costs :math:`c(x, r)` are
     obtained with each report and are represented by a
-    :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`
+    :class:`~`syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model.CostModel`
     surrogate model.
 
     :param kwargs: `search_options` coming from scheduler
@@ -725,7 +725,7 @@ def cost_aware_gp_multifidelity_searcher_factory(**kwargs) -> dict:
     Returns `kwargs` for
     :meth:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPMultiFidelitySearcher._create_internal`,
     based on `kwargs` equal to `search_options` passed to and extended by
-    scheduler (see :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`).
+    scheduler (see :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`).
 
     :param kwargs: `search_options` coming from scheduler
     :return: `kwargs` for :meth:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPMultiFidelitySearcher._create_internal`
@@ -872,9 +872,9 @@ def _common_defaults(
 def gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
     to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 
@@ -885,9 +885,9 @@ def gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
 def gp_multifidelity_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
     to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 
@@ -898,9 +898,9 @@ def gp_multifidelity_searcher_defaults() -> (Set[str], dict, dict):
 def hypertune_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
     to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.hypertune.HyperTuneSearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 
@@ -911,8 +911,8 @@ def hypertune_searcher_defaults() -> (Set[str], dict, dict):
 def constrained_gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults` to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher`.
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults` to be applied to `search_options` for
+    :class:`~syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 
@@ -923,9 +923,9 @@ def constrained_gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
 def cost_aware_gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
     to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPFIFOSearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPFIFOSearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 
@@ -936,9 +936,9 @@ def cost_aware_gp_fifo_searcher_defaults() -> (Set[str], dict, dict):
 def cost_aware_gp_multifidelity_searcher_defaults() -> (Set[str], dict, dict):
     """
     Returns `mandatory`, `default_options`, `config_space` for
-    :func:`syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
+    :func:`~syne_tune.optimizer.schedulers.searchers.utils.default_arguments.check_and_merge_defaults`
     to be applied to `search_options` for
-    :class:`syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPMultiFidelitySearcher`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.cost_aware.CostAwareGPMultiFidelitySearcher`.
 
     :return: `(mandatory, default_options, config_space)`
 

--- a/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_searcher.py
@@ -29,9 +29,9 @@ logger = logging.getLogger(__name__)
 class HyperTuneSearcher(GPMultiFidelitySearcher):
     """
     Implements Hyper-Tune as extension of
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`,
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`,
     see
-    :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune.gp_model.HyperTuneIndependentGPModel`
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune.gp_model.HyperTuneIndependentGPModel`
     for references. Two modifications:
 
     * New brackets are sampled from a model-based distribution :math:`[w_k]`
@@ -40,7 +40,7 @@ class HyperTuneSearcher(GPMultiFidelitySearcher):
 
     It is *not* recommended to create :class:`HyperTuneSearcher` searcher
     objects directly, but rather to create
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler` objects with
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` objects with
     `searcher="hypertune"`, and passing arguments here in `search_options`.
     This will use the appropriate functions from
     :mod:`syne_tune.optimizer.schedulers.searchers.gp_searcher_factory` to
@@ -51,7 +51,7 @@ class HyperTuneSearcher(GPMultiFidelitySearcher):
     `expdecay_normalize_inputs`.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPMultiFidelitySearcher`:
 
     :param model: Selects surrogate model (learning curve model) to be used.
         Choices are:

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -50,7 +50,7 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
         | https://arxiv.org/abs/1807.01774
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param mode: Mode to use for the metric given, can be "min" or "max". Is
         obtained from scheduler in :meth:`configure_scheduler`. Defaults to "min"

--- a/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
@@ -34,7 +34,7 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
         | Proceedings of the 35th International Conference on Machine Learning
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`:
 
     :param resource_attr: Name of resource attribute. Defaults to
         `scheduler.resource_attr` in :meth:`configure_scheduler`

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -42,7 +42,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
     https://colab.research.google.com/github/google-research/google-research/blob/master/evolution/regularized_evolution_algorithm/regularized_evolution.ipynb
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param mode: Mode to use for the metric given, can be "min" or "max",
         defaults to "min"

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -54,13 +54,13 @@ def _impute_default_config(
     """Imputes missing values in `default_config` by mid-point rule
 
     For numerical types, the mid-point in the range is chosen (in normal
-    or log). For :class:`syne_tune.config_space.Categorical`, we pick the first
+    or log). For :class:`~`syne_tune.config_space.Categorical`, we pick the first
     entry of `categories`.
 
     :param default_config: Configuration to be imputed
     :param config_space: Configuration space
     :return: Imputed configuration. If `default_config` has entries with
-        values not being :class:`syne_tune.config_space.Domain`, they are not
+        values not being :class:`~`syne_tune.config_space.Domain`, they are not
         included
     """
     new_config = dict()
@@ -135,7 +135,7 @@ def impute_points_to_evaluate(
 ) -> List[dict]:
     """
     Transforms `points_to_evaluate` argument to
-    :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher`. Each
+    :class:`~`syne_tune.optimizer.schedulers.searchers.BaseSearcher`. Each
     config in the list can be partially specified, or even be an empty dict.
     For each hyperparameter not specified, the default value is determined
     using a midpoint heuristic. Also, duplicate entries are filtered out.
@@ -144,7 +144,7 @@ def impute_points_to_evaluate(
     configurations are specified.
 
     :param points_to_evaluate: Argument to
-        :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher`
+        :class:`~`syne_tune.optimizer.schedulers.searchers.BaseSearcher`
     :param config_space: Configuration space
     :return: List of fully specified initial configs
     """
@@ -166,11 +166,11 @@ def impute_points_to_evaluate(
 class BaseSearcher:
     """
     Base class of searchers, which are components of schedulers responsible for
-    implementing :meth:`get_config`.
+    implementing :meth:`~get_config`.
 
     :param config_space: Configuration space
-    :param metric: Name of metric passed to :meth:`update`. Can be obtained from
-        scheduler in :meth:`configure_scheduler`
+    :param metric: Name of metric passed to :meth:`~update`. Can be obtained from
+        scheduler in :meth:`~configure_scheduler`
     :param points_to_evaluate: List of configurations to be evaluated
         initially (in that order). Each config in the list can be partially
         specified, or even be an empty dict. For each hyperparameter not
@@ -200,7 +200,7 @@ class BaseSearcher:
         This method has to be called before the searcher can be used.
 
         :param scheduler: Scheduler the searcher is used with.
-        :type scheduler: :class:`syne_tune.optimizer.schedulers.TrialScheduler`
+        :type scheduler: :class:`~`syne_tune.optimizer.schedulers.TrialScheduler`
         """
         from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 
@@ -244,9 +244,9 @@ class BaseSearcher:
         It can be overwritten by searchers which also react to intermediate
         results.
 
-        :param trial_id: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
-        :param config: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
-        :param result: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param trial_id: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param config: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param result: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
         :param update: Should surrogate model be updated?
         """
         if update:
@@ -255,9 +255,9 @@ class BaseSearcher:
     def _update(self, trial_id: str, config: dict, result: dict):
         """Update surrogate model with result
 
-        :param trial_id: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
-        :param config: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
-        :param result: See :meth:`syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param trial_id: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param config: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
+        :param result: See :meth:`~syne_tune.optimizer.schedulers.TrialScheduler.on_trial_result`
         """
         raise NotImplementedError
 
@@ -360,8 +360,8 @@ class BaseSearcher:
     def debug_log(self) -> Optional[DebugLogPrinter]:
         """
         Some subclasses support writing a debug log, using
-        :class:`syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log.DebugLogPrinter`.
-        See :class:`syne_tune.optimizer.schedulers.searchers.RandomSearcher`
+        :class:`~`syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log.DebugLogPrinter`.
+        See :class:`~`syne_tune.optimizer.schedulers.searchers.RandomSearcher`
         for an example.
 
         :return: `debug_log` object` or None (not supported)
@@ -395,7 +395,7 @@ class SearcherWithRandomSeed(BaseSearcher):
     Additional arguments on top of parent class :class:`BaseSearcher`.
 
     :param random_seed_generator: If given, random seed is drawn from there
-    :type random_seed_generator: :class:`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`, optional
+    :type random_seed_generator: :class:`~`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`, optional
     :param random_seed: Used if `random_seed_generator` is not given.
     :type random_seed: int, optional
     """

--- a/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_callback.py
@@ -61,7 +61,7 @@ def _extended_result(searcher, result):
 
 class StoreResultsAndModelParamsCallback(StoreResultsCallback):
     """
-    Extends :class:`syne_tune.tuner_callback.StoreResultsCallback` by also
+    Extends :class:`~syne_tune.tuner_callback.StoreResultsCallback` by also
     storing the current surrogate model parameters in :meth:`on_trial_result`.
     This works for schedulers with model-based searchers. For other schedulers,
     this callback behaves the same as the superclass.
@@ -86,7 +86,7 @@ class StoreResultsAndModelParamsCallback(StoreResultsCallback):
 class SimulatorAndModelParamsCallback(SimulatorCallback):
     """
     Extends
-    :class:`syne_tune.backend.simulator_backend.simulator_callback.SimulatorCallback`
+    :class:`~syne_tune.backend.simulator_backend.simulator_callback.SimulatorCallback`
     by also storing the current surrogate model parameters in
     :meth:`on_trial_result`. This works for schedulers with model-based searchers.
     For other schedulers, this callback behaves the same as the superclass.

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -42,13 +42,13 @@ def searcher_factory(searcher_name: str, **kwargs) -> BaseSearcher:
 
     This function creates searcher objects from string argument name and
     additional kwargs. It is typically called in the constructor of a
-    scheduler (see :class:`syne_tune.optimizer.schedulers.FIFOScheduler`),
+    scheduler (see :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`),
     which provides most of the required `kwargs`.
 
     :param searcher_name: Value of `searcher` argument to scheduler (see
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`)
+        :class:`~`syne_tune.optimizer.schedulers.FIFOScheduler`)
     :param kwargs: Argument to
-        :class:`syne_tune.optimizer.schedulers.searchers.BaseSearcher` constructor
+        :class:`~`syne_tune.optimizer.schedulers.searchers.BaseSearcher` constructor
     :return: New searcher object
     """
     supported_schedulers = None

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_factory.py
@@ -33,10 +33,10 @@ def make_hyperparameter_ranges(
     """Default method to create :class:`HyperparameterRanges` from `config_space`
 
     :param config_space: Configuration space
-    :param name_last_pos: See :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
-    :param value_for_last_pos: See :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
-    :param active_config_space: See :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
-    :param prefix_keys: See :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
+    :param name_last_pos: See :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
+    :param value_for_last_pos: See :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
+    :param active_config_space: See :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
+    :param prefix_keys: See :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional
     :return: New object
     """
     hp_ranges = HyperparameterRangesImpl(

--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
@@ -252,7 +252,7 @@ class HyperparameterRangeInteger(HyperparameterRange):
 class HyperparameterRangeFiniteRange(HyperparameterRange):
     """
     Finite range numerical hyperparameter, see
-    :class:`syne_tune.config_space.FiniteRange`. Internally, we use an `int`
+    :class:`~syne_tune.config_space.FiniteRange`. Internally, we use an `int`
     with linear scaling.
 
     Note: Different to :class:`HyperparameterRangeContinuous`, we require that
@@ -513,7 +513,7 @@ class HyperparameterRangeCategoricalBinary(HyperparameterRangeCategorical):
 class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
     """
     Ordinal hyperparameter, equal distance encoding. See also
-    :class:`syne_tune.config_space.Ordinal`.
+    :class:`~syne_tune.config_space.Ordinal`.
 
     :param name: Name of hyperparameter
     :param choices: Values parameter can take
@@ -550,7 +550,7 @@ class HyperparameterRangeOrdinalEqual(HyperparameterRangeCategorical):
 class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
     """
     Ordinal hyperparameter, nearest neighbour encoding. See also
-    :class:`syne_tune.config_space.OrdinalNearestNeighbor`.
+    :class:`~syne_tune.config_space.OrdinalNearestNeighbor`.
 
     :param name: Name of hyperparameter
     :param choices: Values parameter can take (numerical values, strictly
@@ -601,7 +601,7 @@ class HyperparameterRangeOrdinalNearestNeighbor(HyperparameterRangeCategorical):
 class HyperparameterRangesImpl(HyperparameterRanges):
     """
     Basic implementation of
-    :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
+    :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`.
 
     :param config_space: Configuration space
     :param name_last_pos: See :class:`syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`, optional

--- a/syne_tune/optimizer/schedulers/synchronous/dehb.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb.py
@@ -148,7 +148,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
     :param config_space: Configuration space for trial evaluation function
     :param rungs_first_bracket: Determines rung level systems for each
         bracket, see
-        :class:`syne_tune.optimizer.schedulers.synchronous.dehb_bracket_manager.DifferentialEvolutionHyperbandBracketManager`
+        :class:`~syne_tune.optimizer.schedulers.synchronous.dehb_bracket_manager.DifferentialEvolutionHyperbandBracketManager`
     :param num_brackets_per_iteration: Number of brackets per iteration. The
         algorithm cycles through these brackets in one iteration. If not
         given, the maximum number is used (i.e., `len(rungs_first_bracket)`)
@@ -156,7 +156,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         :meth:`on_trial_result`
     :type metric: str
     :param searcher: Selects searcher. Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`..
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`..
         If `searcher == "random_encoded"` (default), the encoded configs are
         sampled directly, each entry independently from U([0, 1]).
         This distribution has higher entropy than for "random" if
@@ -164,7 +164,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         `points_to_evaluate` is still used in this case.
     :type searcher: str, optional
     :param search_options: Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
     :type search_options: dict, optional
     :param mode: Mode to use for the metric given, can be "min" (default) or
         "max"
@@ -179,7 +179,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
     :type points_to_evaluate: `List[dict]`, optional
     :param random_seed: Master random seed. Generators used in the scheduler
         or searcher are seeded using
-        :class:`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
+        :class:`~syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_attr: Key name in config for fixed attribute

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -73,7 +73,7 @@ _CONSTRAINTS = {
 class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
     """
     Synchronous Hyperband. Compared to
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`, this is also
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`, this is also
     scheduling jobs asynchronously, but decision-making is synchronized,
     in that trials are only promoted to the next milestone once the rung they
     are currently paused at, is completely occupied.
@@ -86,16 +86,16 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
 
     :param config_space: Configuration space for trial evaluation function
     :param bracket_rungs: Determines rung level systems for each bracket, see
-        :class:`syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager.SynchronousHyperbandBracketManager`
+        :class:`~syne_tune.optimizer.schedulers.synchronous.hyperband_bracket_manager.SynchronousHyperbandBracketManager`
     :param metric: Name of metric to optimize, key in result's obtained via
         :meth:`on_trial_result`
     :type metric: str
     :param searcher: Selects searcher. Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
         Defaults to "random"
     :type searcher: str, optional
     :param search_options: Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
     :type search_options: dict, optional
     :param mode: Mode to use for the metric given, can be "min" (default) or
         "max"
@@ -110,7 +110,7 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
     :type points_to_evaluate: `List[dict]`, optional
     :param random_seed: Master random seed. Generators used in the scheduler
         or searcher are seeded using
-        :class:`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
+        :class:`~syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_attr: Key name in config for fixed attribute

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -64,11 +64,11 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
         maximum number of brackets per iteration. Pass 1 for successive halving.
     :type brackets: int, optional
     :param searcher: Selects searcher. Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
         Defaults to "random"
     :type searcher: str, optional
     :param search_options: Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
     :type search_options: dict, optional
     :param mode: Mode to use for the metric given, can be "min" (default) or
         "max"
@@ -83,13 +83,13 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
     :type points_to_evaluate: `List[dict]`, optional
     :param random_seed: Master random seed. Generators used in the scheduler
         or searcher are seeded using
-        :class:`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
+        :class:`~syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_level: Largest rung level, corresponds to `max_t` in
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
         `grace_period`. If this is not given, it is inferred like in
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`.
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
     :type max_resource_level: int, optional
     :param max_resource_attr: Key name in config for fixed attribute
         containing the maximum resource. If given, trials need not be
@@ -163,7 +163,7 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
         :meth:`on_trial_result`
     :type metric: str
     :param searcher: Selects searcher. Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`..
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`..
         If `searcher == "random_encoded"` (default), the encoded configs are
         sampled directly, each entry independently from U([0, 1]).
         This distribution has higher entropy than for "random" if
@@ -171,7 +171,7 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
         `points_to_evaluate` is still used in this case.
     :type searcher: str, optional
     :param search_options: Passed to
-        :func:`syne_tune.optimizer.schedulers.searchers.searcher_factory`.
+        :func:`~syne_tune.optimizer.schedulers.searchers.searcher_factory`.
     :type search_options: dict, optional
     :param mode: Mode to use for the metric given, can be "min" (default) or
         "max"
@@ -186,13 +186,13 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
     :type points_to_evaluate: `List[dict]`, optional
     :param random_seed: Master random seed. Generators used in the scheduler
         or searcher are seeded using
-        :class:`syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
+        :class:`~syne_tune.optimizer.schedulers.random_seeds.RandomSeedGenerator`.
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_level: Largest rung level, corresponds to `max_t` in
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
         `grace_period`. If this is not given, it is inferred like in
-        :class:`syne_tune.optimizer.schedulers.FIFOScheduler`.
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
     :type max_resource_level: int, optional
     :param max_resource_attr: Key name in config for fixed attribute
         containing the maximum resource. If given, trials need not be

--- a/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/quantile_based/quantile_based_searcher.py
@@ -123,7 +123,7 @@ class QuantileBasedSurrogateSearcher(SearcherWithRandomSeed):
     from and the best configurations are returned as next candidate to evaluate.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param mode: Whether to minimize or maximize, default to "min".
     :param transfer_learning_evaluations: Dictionary from task name to offline

--- a/syne_tune/optimizer/schedulers/transfer_learning/rush.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/rush.py
@@ -36,7 +36,7 @@ class RUSHScheduler(TransferLearningMixin, HyperbandScheduler):
         | AutoML workshop @ ICML 2021.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     :param transfer_learning_evaluations: Dictionary from task name to offline
         evaluations.

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -32,14 +32,14 @@ class ZeroShotTransfer(TransferLearningMixin, SearcherWithRandomSeed):
     A zero-shot transfer hyperparameter optimization method which jointly selects
     configurations that minimize the average rank obtained on historic metadata
     (`transfer_learning_evaluations`). This is a searcher which can be used
-    with :class:`syne_tune.optimizer.schedulers.FIFOScheduler`. Reference:
+    with :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Reference:
 
         | Sequential Model-Free Hyperparameter Tuning.
         | Martin Wistuba, Nicolas Schilling, Lars Schmidt-Thieme.
         | IEEE International Conference on Data Mining (ICDM) 2015.
 
     Additional arguments on top of parent class
-    :class:`syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
+    :class:`~syne_tune.optimizer.schedulers.searchers.SearcherWithRandomSeed`:
 
     :param transfer_learning_evaluations: Dictionary from task name to
         offline evaluations.

--- a/syne_tune/remote/remote_launcher.py
+++ b/syne_tune/remote/remote_launcher.py
@@ -41,8 +41,8 @@ class RemoteLauncher:
     will spawn one Sagemaker job per trial.
 
     :param tuner: Tuner that should be run remotely on a `instance_type`
-        instance. Note that :class:`syne_tune.StoppingCriterion` should be used
-        for the :class:`syne_tune.Tuner` rather than a lambda function to ensure
+        instance. Note that :class:`~`syne_tune.StoppingCriterion` should be used
+        for the :class:`~`syne_tune.Tuner` rather than a lambda function to ensure
         serialization.
     :param role: SageMaker role to be used to launch the remote tuning instance.
     :param instance_type: Instance where the tuning is going to happen.
@@ -59,7 +59,7 @@ class RemoteLauncher:
     :param s3_path: S3 base path used for checkpointing, outputs of tuning
         will be stored under `{s3_path}/{tuner_name}`. The logs of the local
         backend are only stored if `store_logs_localbackend` is True.
-        Defaults to :func:`syne_tune.util.s3_experiment_path`
+        Defaults to :func:`~syne_tune.util.s3_experiment_path`
     :param no_tuner_logging: If `True`, the logging level for `syne_tune.tuner`
         is set to `logging.ERROR`. Defaults to `False`
     """

--- a/syne_tune/report.py
+++ b/syne_tune/report.py
@@ -54,10 +54,10 @@ class Reporter:
 
     :param add_time: If True (default), the time (in secs) since creation of the
         :class:`Reporter` object is reported automatically as
-        :const:`syne_tune.constants.ST_WORKER_TIME`
+        :const:`~syne_tune.constants.ST_WORKER_TIME`
     :param add_cost: If True (default), estimated dollar cost since creation of
         :class:`Reporter` object is reported automatically as
-        :const:`syne_tune.constants.ST_WORKER_COST`. This is available for
+        :const:`~syne_tune.constants.ST_WORKER_COST`. This is available for
         SageMaker back-end only. Requires `add_time=True`.
     """
 
@@ -93,7 +93,7 @@ class Reporter:
     def __call__(self, **kwargs) -> None:
         """Report metric values from training function back to Syne Tune
 
-        A time stamp :const:`syne_tune.constants.ST_WORKER_TIMESTAMP` is added.
+        A time stamp :const:`~syne_tune.constants.ST_WORKER_TIMESTAMP` is added.
         See :attr:`add_time`, :attr:`add_cost` comments for other automatically
         added metrics.
 

--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -28,21 +28,21 @@ logger = logging.getLogger(__name__)
 
 class TunerCallback:
     """
-    Allows user of :class:`syne_tune.Tuner` to monitor progress, store
+    Allows user of :class:`~syne_tune.Tuner` to monitor progress, store
     additional results, etc.
     """
 
     def on_tuning_start(self, tuner):
         """Called at start of tuning loop
 
-        :param tuner: :class:`syne_tune.Tuner` object
+        :param tuner: :class:`~syne_tune.Tuner` object
         """
         pass
 
     def on_tuning_end(self):
         """Called once the tuning loop terminates
 
-        This is called before :class:`syne_tune.Tuner` object is serialized
+        This is called before :class:`~syne_tune.Tuner` object is serialized
         (optionally), and also before running jobs are stopped.
         """
         pass
@@ -110,12 +110,12 @@ class TunerCallback:
 
 class StoreResultsCallback(TunerCallback):
     """
-    Default implementation of :class:`TunerCallback` which records all
+    Default implementation of :class:`~TunerCallback` which records all
     reported results, and allows to store them as CSV file.
 
     :param add_wallclock_time: If True, wallclock time since call of
         `on_tuning_start` is stored as
-        :const:`syne_tune.constants.ST_TUNER_TIME`.
+        :const:`~syne_tune.constants.ST_TUNER_TIME`.
     """
 
     def __init__(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes all long links to short ones, by using ~ prefix (hint by Martin W)

Looks huge, but it is really just that ...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
