### PR TITLE
Fixes to yahpo_nb301 benchmark and to benchmarking tools

### DIFF
--- a/benchmarking/commons/benchmark_definitions/yahpo.py
+++ b/benchmarking/commons/benchmark_definitions/yahpo.py
@@ -38,7 +38,7 @@ from benchmarking.commons.benchmark_definitions.lcbench import (
 
 def yahpo_nb301_benchmark(dataset_name):
     return SurrogateBenchmarkDefinition(
-        max_wallclock_time=1800,  # TODO
+        max_wallclock_time=6 * 3600,
         n_workers=4,
         elapsed_time_attr="runtime",
         metric="val_accuracy",

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -87,7 +87,7 @@ def launch_remote(
         )
         sm_args["environment"] = environment
         hyperparameters = get_hyperparameters(
-            seed, method, experiment_tag, args, benchmark, map_extra_args
+            seed, method, experiment_tag, args, map_extra_args
         )
         hyperparameters["max_failures"] = args.max_failures
         hyperparameters["warm_pool"] = int(args.warm_pool)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix yahpo-nb301 benchmark: Shorten very long attribute names by removing common prefix
- Fix benchmarking tooling: Remote launching did not parse CL arguments properly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
