### PR TITLE
Example usage of the ask-tell interface in syne-tune

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -318,3 +318,30 @@ complete HPO solution. If you already have a system in place for job
 scheduling and managing the state of the tuning problem, you may want to
 call the scheduler on its own. This example demonstrates how to do this
 for Gaussian process based Bayesian optimization.
+
+
+Ask Tell interface
+=================================
+
+.. literalinclude:: ../../examples/launch_ask_tell_scheduler.py
+   :caption: examples/launch_ask_tell_scheduler.py
+   :lines: 13-
+
+This is an example on how to use syne-tune in the ask-tell mode.
+In this setup the tuning loop and experiments are disentangled. The AskTell Scheduler suggests new configurations
+and the users themselves perform experiments to test the performance of each configuration.
+Once done, user feeds the result into the Scheduler which uses the data to suggest better configurations.
+
+
+In some cases, experiments needed for function evaluations can be very complex and require extra orchestration
+(example vary from setting up jobs on non-aws clusters to runnig physical lab experiments) in which case this
+interface provides all the necessary flexibility
+
+Ask Tell interface for Hyperband
+=================================
+
+.. literalinclude:: ../../examples/launch_ask_tell_scheduler_hyperband.py
+   :caption: examples/launch_ask_tell_scheduler_hyperband.py
+   :lines: 13-
+
+This is an extension of launch_ask_tell_scheduler.py to run multi-fidelity methods such as Hyperband

--- a/examples/launch_ask_tell_scheduler.py
+++ b/examples/launch_ask_tell_scheduler.py
@@ -132,7 +132,9 @@ def plot_objective():
 
 def tune_with_random_search() -> TrialResult:
     metric, mode, config_space, max_iterations = get_objective()
-    scheduler = AskTellScheduler(base_scheduler=RandomSearch(config_space, metric=metric, mode=mode))
+    scheduler = AskTellScheduler(
+        base_scheduler=RandomSearch(config_space, metric=metric, mode=mode)
+    )
     for iter in range(max_iterations):
         trial_suggestion = scheduler.ask()
         test_result = target_function(**trial_suggestion.config)
@@ -142,7 +144,9 @@ def tune_with_random_search() -> TrialResult:
 
 def save_restart_with_gp() -> TrialResult:
     metric, mode, config_space, max_iterations = get_objective()
-    scheduler = AskTellScheduler(base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode))
+    scheduler = AskTellScheduler(
+        base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode)
+    )
     for iter in range(int(max_iterations / 2)):
         trial_suggestion = scheduler.ask()
         test_result = target_function(**trial_suggestion.config)
@@ -166,7 +170,9 @@ def save_restart_with_gp() -> TrialResult:
 
 def tune_with_gp() -> TrialResult:
     metric, mode, config_space, max_iterations = get_objective()
-    scheduler = AskTellScheduler(base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode))
+    scheduler = AskTellScheduler(
+        base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode)
+    )
     for iter in range(max_iterations):
         trial_suggestion = scheduler.ask()
         test_result = target_function(**trial_suggestion.config)

--- a/examples/launch_ask_tell_scheduler.py
+++ b/examples/launch_ask_tell_scheduler.py
@@ -1,0 +1,185 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import datetime
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import dill
+import numpy as np
+
+from syne_tune.backend.trial_status import Trial, Status, TrialResult
+from syne_tune.config_space import randint, uniform
+from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization, ASHA
+from syne_tune.optimizer.scheduler import TrialScheduler, SchedulerDecision
+
+
+class AskTellScheduler:
+    bscheduler: TrialScheduler
+    trial_counter: int
+    completed_experiments: dict[int, TrialResult]
+
+    def __init__(self, base_scheduler: TrialScheduler):
+        self.bscheduler = base_scheduler
+        self.trial_counter = 0
+        self.completed_experiments = {}
+
+    def ask(self) -> Trial:
+        """
+        Ask the scheduler for new trial to run
+        :return: Trial to run
+        """
+        trial_suggestion = self.bscheduler.suggest(self.trial_counter)
+        trial = Trial(
+            trial_id=self.trial_counter, config=trial_suggestion.config, creation_time=datetime.datetime.now()
+        )
+        self.trial_counter += 1
+        return trial
+
+    def tell(self, trial: Trial, experiment_result: dict[str, float]):
+        """
+        Feed experiment results back to the Scheduler
+
+        :param trial: Trial that was run
+        :param experiment_result: {metric: value} dictionary with experiment results
+        """
+        trial_result = trial.add_results(
+            metrics=experiment_result, status=Status.completed, training_end_time=datetime.datetime.now()
+        )
+        self.bscheduler.on_trial_complete(trial=trial, result=experiment_result)
+        self.completed_experiments[trial_result.trial_id] = trial_result
+
+    def best_trial(self, metris: str) -> TrialResult:
+        """
+        Return the best trial according to the provided metric
+        """
+        if self.bscheduler.mode == "max":
+            sign = 1.0
+        else:
+            sign = -1.0
+
+        return max(
+            [value for key, value in self.completed_experiments.items()], key=lambda trial: sign * trial.metrics[metris]
+        )
+
+    def save(self, output_path: Optional[Union[str, Path]] = None) -> Path:
+        """
+        Save the scheduler to a given path
+        :param output_path: Complete output path for the scheduler,
+            defaults to ask_tell_scheduler-after-trial={self.trial_counter}.dill
+        :return: output path
+        """
+        if output_path is None:
+            output_path = f"ask_tell_scheduler-after-trial={self.trial_counter}.dill"
+
+        with open(output_path, "wb") as f:
+            dill.dump(self, f)
+        return output_path
+
+    @staticmethod
+    def from_file(output_path: Union[str, Path]) -> "AskTellScheduler":
+        """
+        Load the scheduler from path
+        :param output_path: Complete output path for the scheduler
+        """
+        with open(output_path, "rb") as f:
+            scheduler = dill.load(f)
+        return scheduler
+
+
+def target_function(x, noise: bool = True):
+    fx = x * x + np.sin(x)
+    if noise:
+        sigma = np.cos(x) ** 2 + 0.01
+        noise = 0.1 * np.random.normal(loc=x, scale=sigma)
+        fx = fx + noise
+
+    return fx
+
+
+def get_objective():
+    metric = "mean_loss"
+    mode = "min"
+    max_iterations = 100
+    config_space = {
+        "x": uniform(-1, 1),
+    }
+    return metric, mode, config_space, max_iterations
+
+
+def inspect_objective():
+    """
+    In this function, we will inspect the objective by plotting the target function
+    :return:
+    """
+    import matplotlib.pyplot as plt
+
+    metric, mode, config_space, max_iterations = get_objective()
+
+    plt.set_cmap("viridis")
+    x = np.linspace(config_space["x"].lower, config_space["x"].upper, 400)
+    fx = target_function(x, noise=False)
+    noise = 0.1 * np.cos(x) ** 2 + 0.01
+
+    plt.plot(x, fx, "r--", label="True value")
+    plt.fill_between(x, fx + noise, fx - noise, alpha=0.2, fc="r")
+    plt.legend()
+    plt.grid()
+    plt.show()
+
+
+def tune_with_random_search() -> TrialResult:
+    metric, mode, config_space, max_iterations = get_objective()
+    scheduler = AskTellScheduler(base_scheduler=RandomSearch(config_space, metric=metric, mode=mode))
+    for iter in range(max_iterations):
+        trial_suggestion = scheduler.ask()
+        test_result = target_function(**trial_suggestion.config)
+        scheduler.tell(trial_suggestion, {metric: test_result})
+    return scheduler.best_trial(metric)
+
+
+def save_restart_with_gp() -> TrialResult:
+    metric, mode, config_space, max_iterations = get_objective()
+    scheduler = AskTellScheduler(base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode))
+    for iter in range(int(max_iterations / 2)):
+        trial_suggestion = scheduler.ask()
+        test_result = target_function(**trial_suggestion.config)
+        scheduler.tell(trial_suggestion, {metric: test_result})
+
+    scheduler.save("scheduler-checkpoint.dill")
+    # --- Break the experimental loop and return to the tuning later
+    scheduler = AskTellScheduler.from_file("scheduler-checkpoint.dill")
+
+    for iter in range(int(max_iterations / 2)):
+        trial_suggestion = scheduler.ask()
+        test_result = target_function(**trial_suggestion.config)
+        scheduler.tell(trial_suggestion, {metric: test_result})
+    return scheduler.best_trial(metric)
+
+
+def tune_with_gp() -> TrialResult:
+    metric, mode, config_space, max_iterations = get_objective()
+    scheduler = AskTellScheduler(base_scheduler=BayesianOptimization(config_space, metric=metric, mode=mode))
+    for iter in range(max_iterations):
+        trial_suggestion = scheduler.ask()
+        test_result = target_function(**trial_suggestion.config)
+        scheduler.tell(trial_suggestion, {metric: test_result})
+    return scheduler.best_trial(metric)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.WARN)
+    # inspect_objective()
+    print("Random:", tune_with_random_search())
+    print("GP with restart:", save_restart_with_gp())
+    print("GP:", tune_with_gp())

--- a/examples/launch_ask_tell_scheduler.py
+++ b/examples/launch_ask_tell_scheduler.py
@@ -23,16 +23,14 @@ interface provides all the necessary flexibility
 """
 import datetime
 import logging
-from pathlib import Path
-from typing import Optional, Union
 
 import dill
 import numpy as np
 
 from syne_tune.backend.trial_status import Trial, Status, TrialResult
-from syne_tune.config_space import randint, uniform
-from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization, ASHA
-from syne_tune.optimizer.scheduler import TrialScheduler, SchedulerDecision
+from syne_tune.config_space import uniform
+from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization
+from syne_tune.optimizer.scheduler import TrialScheduler
 
 
 class AskTellScheduler:

--- a/examples/launch_ask_tell_scheduler_hyperband.py
+++ b/examples/launch_ask_tell_scheduler_hyperband.py
@@ -65,7 +65,9 @@ def run_hyperband_step(
 ) -> Tuple[float, float]:
     for step in range(1, max_steps):
         test_result = target_function(**trial_suggestion.config, step=step)
-        decision = scheduler.bscheduler.on_trial_result(trial_suggestion, {metric: test_result, "epoch": step})
+        decision = scheduler.bscheduler.on_trial_result(
+            trial_suggestion, {metric: test_result, "epoch": step}
+        )
         if decision == SchedulerDecision.STOP:
             break
     return step, test_result
@@ -86,7 +88,9 @@ def tune_with_hyperband() -> TrialResult:
     )
     for iter in range(max_iterations):
         trial_suggestion = scheduler.ask()
-        final_step, test_result = run_hyperband_step(scheduler, trial_suggestion, max_steps, metric)
+        final_step, test_result = run_hyperband_step(
+            scheduler, trial_suggestion, max_steps, metric
+        )
         scheduler.tell(trial_suggestion, {metric: test_result, "epoch": final_step})
     return scheduler.best_trial(metric)
 

--- a/examples/launch_ask_tell_schedululer_hyperband.py
+++ b/examples/launch_ask_tell_schedululer_hyperband.py
@@ -1,0 +1,84 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import datetime
+import logging
+from pathlib import Path
+from typing import Optional, Union, Tuple
+
+import dill
+import numpy as np
+
+from examples.launch_ask_tell_scheduler import AskTellScheduler
+from syne_tune.backend.trial_status import Trial, Status, TrialResult
+from syne_tune.config_space import randint, uniform
+from syne_tune.optimizer.baselines import RandomSearch, BayesianOptimization, ASHA
+from syne_tune.optimizer.scheduler import TrialScheduler, SchedulerDecision
+
+
+def target_function(x, step: int = None, noise: bool = True):
+    fx = x * x + np.sin(x)
+    if noise:
+        sigma = np.cos(x) ** 2 + 0.01
+        noise = 0.1 * np.random.normal(loc=x, scale=sigma)
+        fx = fx + noise
+
+    if step is not None:
+        fx += step * 0.01
+
+    return fx
+
+
+def get_objective():
+    metric = "mean_loss"
+    mode = "min"
+    max_iterations = 100
+    config_space = {
+        "x": uniform(-1, 1),
+    }
+    return metric, mode, config_space, max_iterations
+
+
+def tune_with_hyperband() -> TrialResult:
+    metric, mode, config_space, max_iterations = get_objective()
+    max_steps = 100
+
+    scheduler = AskTellScheduler(
+        base_scheduler=ASHA(
+            config_space,
+            metric=metric,
+            resource_attr="epoch",
+            max_t=max_steps,
+            mode=mode,
+        )
+    )
+    for iter in range(max_iterations):
+        trial_suggestion = scheduler.ask()
+        final_step, test_result = run_hyperband_step(scheduler, trial_suggestion, max_steps, metric)
+        scheduler.tell(trial_suggestion, {metric: test_result, "epoch": final_step})
+    return scheduler.best_trial(metric)
+
+
+def run_hyperband_step(
+    scheduler: AskTellScheduler, trial_suggestion: Trial, max_steps: int, metric: str
+) -> Tuple[float, float]:
+    for step in range(1, max_steps):
+        test_result = target_function(**trial_suggestion.config, step=step)
+        decision = scheduler.bscheduler.on_trial_result(trial_suggestion, {metric: test_result, "epoch": step})
+        if decision == SchedulerDecision.STOP:
+            break
+    return step, test_result
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.WARN)
+    print("Hyperband:", tune_with_hyperband())


### PR DESCRIPTION
*Description of changes:*
What: Setup an ask-tell interface like in scikit-optimize ([library](https://github.com/scikit-optimize/scikit-optimize), [issue that asks for it](https://github.com/scikit-optimize/scikit-optimize/issues/68) in scikit-opt) to enable users with very specific requirements to plug into the HPO engines implemented in syne-tune. This work would include providing an example that shows how to set up this mode of operation by calling a trial scheduler suggest and communicating results with on_trial_results.

Why: In order to use syne-tune at the moment, user needs to wrap their function evaluator into a script that can be executed by syne-tune. In some cases, experiments needed for function evaluations can be more complex and require extra orchestration (example vary from setting up jobs on non-aws clusters to runnig physical lab experiments)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
