### PR TITLE
pytest: Add pytest-xdist

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,4 +33,4 @@ jobs:
         python -m pip install .[extra] --upgrade pip
     - name: Test with pytest
       run: |
-        pytest
+        pytest -n 2 --dist loadgroup

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 timeout = 1
+addopts = -n 4 --dist loadgroup

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-timeout
+pytest-xdist
 # 22.1.0 fails with sphinx:
 # https://github.com/psf/black/issues/2964
 black==22.3.0

--- a/tst/schedulers/bayesopt/gpautograd/test_gp.py
+++ b/tst/schedulers/bayesopt/gpautograd/test_gp.py
@@ -45,6 +45,7 @@ def test_likelihood_encoding():
     assert isinstance(likelihood.encoding_noise, PositiveScalarEncoding)
 
 
+@pytest.mark.xdist_group("parallel")
 def test_gp_regression_no_noise():
     def f(x):
         return anp.sin(x) / x
@@ -91,6 +92,7 @@ def test_gp_regression_no_noise():
     # plt.show()
 
 
+@pytest.mark.xdist_group("parallel")
 def test_gp_regression_with_noise():
     def f(x):
         return anp.sin(x) / x

--- a/tst/schedulers/bayesopt/test_gaussproc.py
+++ b/tst/schedulers/bayesopt/test_gaussproc.py
@@ -98,6 +98,7 @@ def _make_model_mcmc(
     return model, gpmodel
 
 
+@pytest.mark.xdist_group("parallel")
 def test_gp_fit(tuning_job_state):
     _set_seeds(0)
     hp_ranges = tuning_job_state.hp_ranges
@@ -128,6 +129,7 @@ def test_gp_fit(tuning_job_state):
 
 
 @pytest.mark.timeout(10)
+@pytest.mark.xdist_group("parallel")
 def test_gp_mcmc_fit(tuning_job_state):
     hp_ranges = make_hyperparameter_ranges({"x": uniform(-4.0, 4.0)})
 
@@ -184,6 +186,7 @@ def _compute_acq_with_gradient_many(acq_func, X_test):
 
 
 @pytest.mark.timeout(10)
+@pytest.mark.xdist_group("parallel")
 def test_gp_fantasizing():
     """
     Compare whether acquisition function evaluations (values, gradients) with
@@ -298,6 +301,7 @@ def default_models() -> List[GaussProcSurrogateModel]:
 
 
 @pytest.mark.timeout(10)
+@pytest.mark.xdist_group("parallel")
 def test_current_best():
     for model in default_models():
         current_best = model.current_best()[0].item()

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -196,6 +196,7 @@ def test_integer_to_ndarray_and_back(lower, upper, domain):
 # it generates random candidates and checks the distribution is correct
 # and also that they can be transformed to internal representation and back while still obtaining
 # the same value
+@pytest.mark.timeout(2)
 def test_distribution_of_random_candidates():
     random_state = np.random.RandomState(0)
     hp_ranges = make_hyperparameter_ranges(


### PR DESCRIPTION
# feat/parallelize-tests

## Why

With `pytest-xdist` we can parallelize the test suite. This results in a quick win for a faster feedback loop.

### Numbers

Below are the results of the test suite on my machine (an i9-13900k):

| command | run # | real | user | sys |
| --- | --- | --- | --- | --- |
| pytest | 1 | 0m35.141s | 1m12.942s | 2m6.306s |
| pytest | 2 | 0m37.991s | 2m18.906s | 2m49.160s |
| pytest | 3 | 0m36.207s | 1m36.687s | 2m39.535s |
| pytest -n 1 --dist loadgroup | 1 | 0m35.896s | 1m25.656s | 2m17.317s |
| pytest -n 1 --dist loadgroup | 2 | 0m38.354s | 2m2.959s | 3m7.145s |
| pytest -n 1 --dist loadgroup | 3 | 0m38.792s | 2m14.633s | 3m8.681s |
| pytest -n 2 --dist loadgroup | 1 | 0m25.270s | 2m24.090s | 3m14.851s |
| pytest -n 2 --dist loadgroup | 2 | 0m28.600s | 3m51.649s | 4m6.193s |
| pytest -n 2 --dist loadgroup | 3 | 0m28.093s | 3m43.806s | 3m49.875s |
| pytest -n 3 --dist loadgroup | 1 | 0m22.370s | 2m59.735s | 3m32.893s |
| pytest -n 3 --dist loadgroup | 2 | 0m19.252s | 1m55.877s | 2m37.809s |
| pytest -n 3 --dist loadgroup | 3 | 0m22.168s | 2m56.645s | 3m25.640s |
| pytest -n 4 --dist loadgroup | 1 | 0m20.715s | 2m50.816s | 3m20.745s |
| pytest -n 4 --dist loadgroup | 2 | 0m20.518s | 2m48.112s | 3m36.456s |
| pytest -n 4 --dist loadgroup | 3 | 0m20.832s | 3m2.586s | 3m28.027s |

The average of each run's real times are:

| command | real |
| --- | --- |
| pytest | 0m36.446s |
| pytest -n 1 --dist loadgroup | 0m37.681s |
| pytest -n 2 --dist loadgroup | 0m27.321s |
| pytest -n 3 --dist loadgroup | 0m21.263s |
| pytest -n 4 --dist loadgroup | 0m20.688s |

Going beyond four processes doesn't seem to yield any further improvements (likely because some portions of the test suite involve parallelized operations).

## How

I added `pytest-xdist` to the `dev` extra requirements. I also updated the `pytest.ini` file with `addopts` to configure the test suite to run with four processes and run tests with the same group on the same worker (to avoid resource contention). The `test_cholesky_factorization` test was refactored into two smaller tests which both increase their timeout with respect to input size. Additionally, tests which involved parallelized operations were added to an `xdist_group` named `parallel` to ensure they are run on the same worker (to avoid resource contention).

While the standard GitHub runners only have two cores (the `unit-tests.yml` workflow has been edited accordingly), local development can benefit from this.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
