### PR TITLE
Fix issue with Hyper-Tune (related to number of brackets), by cleanin…

### DIFF
--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -204,12 +204,7 @@ class HyperTune(HyperbandScheduler):
             f", must be in {supp}"
         )
         search_options[k] = model
-        k = "hypertune_distribution_num_samples"
-        num_samples = search_options.get(k, 50)
-        search_options[k] = num_samples
         kwargs["search_options"] = search_options
-        num_brackets = kwargs.get("brackets", 4)
-        kwargs["brackets"] = num_brackets
         super(HyperTune, self).__init__(
             config_space=config_space,
             metric=metric,

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -171,7 +171,7 @@ class HyperbandScheduler(FIFOScheduler):
     Rung levels are values of the resource attribute at which stop/go decisions
     are made for jobs, comparing their metric against others at the same level.
     These rung levels (positive, strictly increasing) can be specified via
-    ``rung_levels``, the largest must be ``<= max_resource_level``.
+    ``rung_levels``, the largest must be ``<= max_t``.
     If ``rung_levels`` is not given, they are specified by ``grace_period``
     and ``reduction_factor``. If :math:`r_{min}` is ``grace_period``,
     :math:`\eta` is ``reduction_factor``, then rung levels are
@@ -247,7 +247,7 @@ class HyperbandScheduler(FIFOScheduler):
         is set based on the ratio of successive rung levels.
     :type rung_levels: ``List[int]``, optional
     :param brackets: Number of brackets to be used in Hyperband. Each
-        bracket has a different grace period, all share ``max_resource_level``
+        bracket has a different grace period, all share ``max_t``
         and ``reduction_factor``. If ``brackets == 1`` (default), we run
         asynchronous successive halving.
     :type brackets: int, optional
@@ -372,18 +372,28 @@ class HyperbandScheduler(FIFOScheduler):
         self._resource_attr = kwargs["resource_attr"]
         self._rung_system_kwargs = kwargs["rung_system_kwargs"]
         self._cost_attr = kwargs.get("cost_attr")
-        self._num_brackets = kwargs["brackets"]
         assert not (
             scheduler_type == "cost_promotion" and self._cost_attr is None
         ), "cost_attr must be given if type='cost_promotion'"
         # Default: May be modified by searcher (via ``configure_scheduler``)
         self.bracket_distribution = DefaultHyperbandBracketDistribution()
+        # See :meth:`_extend_search_options` for why this is needed:
+        if kwargs.get("searcher") == "hypertune":
+            self._num_brackets_info = {
+                "num_brackets": kwargs["brackets"],
+                "rung_levels": kwargs.get("rung_levels"),
+                "grace_period": kwargs["grace_period"],
+                "reduction_factor": kwargs["reduction_factor"],
+            }
+        else:
+            self._num_brackets_info = None
+
         # Superclass constructor
         super().__init__(config_space, **filter_by_key(kwargs, _ARGUMENT_KEYS))
         assert self.max_t is not None, (
             "Either max_t must be specified, or it has to be specified as "
-            + "config_space['epochs'], config_space['max_t'], "
-            + "config_space['max_epochs']"
+            + "config_space[max_resource_attr], config_space['epochs'], "
+            + "config_space['max_t'], config_space['max_epochs']"
         )
 
         # If rung_levels is given, grace_period and reduction_factor are ignored
@@ -409,14 +419,14 @@ class HyperbandScheduler(FIFOScheduler):
         rung_system_per_bracket = kwargs["rung_system_per_bracket"]
 
         self.terminator = HyperbandBracketManager(
-            scheduler_type,
-            self._resource_attr,
-            self.metric,
-            self.mode,
-            self.max_t,
-            rung_levels,
-            self._num_brackets,
-            rung_system_per_bracket,
+            scheduler_type=scheduler_type,
+            resource_attr=self._resource_attr,
+            metric=self.metric,
+            mode=self.mode,
+            max_t=self.max_t,
+            rung_levels=rung_levels,
+            brackets=kwargs["brackets"],
+            rung_system_per_bracket=rung_system_per_bracket,
             cost_attr=self._total_cost_attr(),
             random_seed=self.random_seed_generator(),
             rung_system_kwargs=self._rung_system_kwargs,
@@ -445,7 +455,20 @@ class HyperbandScheduler(FIFOScheduler):
 
     @property
     def rung_levels(self) -> List[int]:
+        """
+        Note that all entries of ``rung_levels`` are smaller than ``max_t`` (or
+        ``config_space[max_resource_attr]``): rung levels are resource levels where
+        stop/go decisions are made. In particular, if ``rung_levels`` is passed at
+        construction with ``rung_levels[-1] == max_t``, this last entry is stripped
+        off.
+
+        :return: Rung levels (strictly increasing, positive ints)
+        """
         return self.terminator.rung_levels
+
+    @property
+    def num_brackets(self) -> int:
+        return self.terminator.num_brackets
 
     @property
     def resource_attr(self) -> str:
@@ -457,7 +480,7 @@ class HyperbandScheduler(FIFOScheduler):
             self.bracket_distribution.configure(self)
 
     def _extend_search_options(self, search_options: dict) -> dict:
-        # Note: Needs self.scheduler_type to be set
+        # Note: Needs ``self.scheduler_type`` to be set
         scheduler = "hyperband_{}".format(self.scheduler_type)
         result = dict(
             search_options, scheduler=scheduler, resource_attr=self._resource_attr
@@ -467,8 +490,23 @@ class HyperbandScheduler(FIFOScheduler):
         cost_attr = self._total_cost_attr()
         if cost_attr is not None:
             result["cost_attr"] = cost_attr
-        if "hypertune_distribution_num_samples" in result:
-            result["hypertune_distribution_num_brackets"] = self._num_brackets
+        if self._num_brackets_info is not None:
+            # At this point, the correct number of brackets needs to be
+            # determined. This could be smaller than the ``brackets`` argument
+            # passed at construction, since the number of brackets is limited
+            # by the number of rung levels, which in turn requires ``max_t``
+            # to have been determined. This is why we need some extra effort
+            # here
+            rung_levels = hyperband_rung_levels(
+                self._num_brackets_info["rung_levels"],
+                grace_period=self._num_brackets_info["grace_period"],
+                reduction_factor=self._num_brackets_info["reduction_factor"],
+                max_t=self.max_t,
+            )
+            num_brackets = min(
+                self._num_brackets_info["num_brackets"], len(rung_levels) + 1
+            )
+            result["hypertune_distribution_num_brackets"] = num_brackets
         return result
 
     def _total_cost_attr(self) -> Optional[str]:
@@ -828,6 +866,7 @@ class HyperbandScheduler(FIFOScheduler):
                         do_update = False  # Do not update again
                     else:
                         record.largest_update_resource = resource
+                act_str = None
                 if not task_continues:
                     if (not self.does_pause_resume()) or resource >= self.max_t:
                         trial_decision = SchedulerDecision.STOP
@@ -893,7 +932,10 @@ def hyperband_rung_levels(
 ) -> List[int]:
     """Creates ``rung_levels`` from ``grace_period``, ``reduction_factor``
 
-    :param rung_levels: If given, this is returned
+    Note: If ``rung_levels`` is given and ``rung_levels[-1] == max_t``, we strip
+    off this final entry, so that all rung levels are ``< max_t``.
+
+    :param rung_levels: If given, this is returned (but see above)
     :param grace_period: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     :param reduction_factor: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
     :param max_t: See :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`
@@ -926,10 +968,8 @@ def hyperband_rung_levels(
         max_rungs = int(np.log(max_t / min_t) / np.log(rf) + 1)
         rung_levels = [int(round(min_t * np.power(rf, k))) for k in range(max_rungs)]
         assert rung_levels[-1] <= max_t  # Sanity check
-        assert len(rung_levels) >= 2, (
-            f"grace_period = {grace_period}, reduction_factor = "
-            + f"{reduction_factor}, max_t = {max_t} leads to single rung level only"
-        )
+    if rung_levels[-1] == max_t:
+        rung_levels = rung_levels[:-1]
     return rung_levels
 
 
@@ -978,6 +1018,9 @@ class HyperbandBracketManager:
         rung_system_kwargs: dict,
         scheduler: HyperbandScheduler,
     ):
+        assert (
+            rung_levels[-1] < max_t
+        ), f"rung_levels = {rung_levels} must not contain max_t = {max_t}"
         self._scheduler_type = scheduler_type
         self._resource_attr = resource_attr
         self._max_t = max_t
@@ -986,17 +1029,21 @@ class HyperbandBracketManager:
         self._scheduler = scheduler
         # Maps trial_id -> bracket_id
         self._task_info = dict()
-        max_num_brackets = len(rung_levels)
+        max_num_brackets = len(rung_levels) + 1
         self.num_brackets = min(brackets, max_num_brackets)
         num_systems = self.num_brackets if rung_system_per_bracket else 1
         rung_levels_plus_maxt = rung_levels[1:] + [max_t]
         # Promotion quantiles: q_j = r_j / r_{j+1}
         promote_quantiles = [x / y for x, y in zip(rung_levels, rung_levels_plus_maxt)]
-        kwargs = dict(metric=metric, mode=mode, resource_attr=resource_attr)
+        kwargs = dict(
+            metric=metric,
+            mode=mode,
+            resource_attr=resource_attr,
+            max_t=max_t,
+        )
         if scheduler_type == "stopping":
             rs_type = StoppingRungSystem
         elif scheduler_type == "pasha":
-            kwargs["max_t"] = max_t
             kwargs["ranking_criterion"] = rung_system_kwargs["ranking_criterion"]
             kwargs["epsilon"] = rung_system_kwargs["epsilon"]
             kwargs["epsilon_scaling"] = rung_system_kwargs["epsilon_scaling"]
@@ -1005,18 +1052,16 @@ class HyperbandBracketManager:
             kwargs["num_threshold_candidates"] = rung_system_kwargs.get(
                 "num_threshold_candidates", 0
             )
-            if scheduler_type == "rush_stopping":
-                rs_type = RUSHStoppingRungSystem
-            else:
-                kwargs["max_t"] = max_t
-                rs_type = RUSHPromotionRungSystem
+            rs_type = (
+                RUSHStoppingRungSystem
+                if scheduler_type == "rush_stopping"
+                else RUSHPromotionRungSystem
+            )
+        elif scheduler_type == "promotion":
+            rs_type = PromotionRungSystem
         else:
-            kwargs["max_t"] = max_t
-            if scheduler_type == "promotion":
-                rs_type = PromotionRungSystem
-            else:
-                kwargs["cost_attr"] = cost_attr
-                rs_type = CostPromotionRungSystem
+            kwargs["cost_attr"] = cost_attr
+            rs_type = CostPromotionRungSystem
         self._rung_systems = [
             rs_type(
                 rung_levels=rung_levels[s:],
@@ -1057,7 +1102,7 @@ class HyperbandBracketManager:
         Since the bracket has already been sampled, not much is done here.
         We return the list of milestones for this bracket in reverse
         (decreasing) order. The first entry is ``max_t``, even if it is
-        not a milestone in the bracket. This list contains the resource
+        not a rung level in the bracket. This list contains the resource
         levels the task would reach if it ran to ``max_t`` without being stopped.
 
         :param trial_id: ID of trial

--- a/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
+++ b/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
@@ -70,9 +70,9 @@ class CostPromotionRungSystem(PromotionRungSystem):
             rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
         )
         self._cost_attr = cost_attr
-        # Note: The data entry in _rungs is now a dict mapping trial_id to
-        # (metric_value, cost_value, was_promoted), where metric_value is
-        # m(x, r), cost value is c(x, r).
+        # Note: The data entry in ``_rungs`` is now a dict mapping trial_id to
+        # ``(metric_value, cost_value, was_promoted)``, where metric_value is
+        # :math:`m(x, r)`, cost value is :math:`c(x, r)`.
 
     def _find_promotable_trial(
         self, recorded: dict, prom_quant: float, resource: int
@@ -85,7 +85,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
         :param recorded: Dict to scan
         :param prom_quant: Quantile for promotion
         :param resource: Amount of resources spent on the rung.
-        :return: trial_id if found, otherwise None
+        :return: ``trial_id`` if found, otherwise ``None``
         """
         ret_id = None
         if len(recorded) > 1:

--- a/syne_tune/optimizer/schedulers/hyperband_pasha.py
+++ b/syne_tune/optimizer/schedulers/hyperband_pasha.py
@@ -40,18 +40,20 @@ class PASHARungSystem(PromotionRungSystem):
             rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
         )
         self.ranking_criterion = ranking_criterion
-        # define the index of the current top rung, starting from 1 for the lowest rung
-        #
-        self.current_rung_idx = 2
-        self.rung_levels = rung_levels
+        # define the index of the current top rung, starting from 1 for the
+        # lowest rung
+        assert self.num_rungs >= 1, "rung_levels must not be empty"
+        self.rung_levels = rung_levels.copy()
 
         # initialize current maximum resources
+        self.current_rung_idx = min(len(rung_levels) - 1, 2)
         self.current_max_t = rung_levels[self.current_rung_idx - 1]
 
         self.epsilon = epsilon
         self.epsilon_scaling = epsilon_scaling
 
-    # overriding the method in HB promotion to accommodate the increasing max resources level
+    # overriding the method in HB promotion to accommodate the increasing max
+    # resources level
     def _effective_max_t(self):
         return self.current_max_t
 

--- a/syne_tune/optimizer/schedulers/hyperband_rush.py
+++ b/syne_tune/optimizer/schedulers/hyperband_rush.py
@@ -99,9 +99,12 @@ class RUSHStoppingRungSystem(StoppingRungSystem):
         metric: str,
         mode: str,
         resource_attr: str,
+        max_t: int,
         num_threshold_candidates: int,
     ):
-        super().__init__(rung_levels, promote_quantiles, metric, mode, resource_attr)
+        super().__init__(
+            rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
+        )
         self._decider = RUSHDecider(num_threshold_candidates, mode)
 
     def _task_continues(

--- a/syne_tune/optimizer/schedulers/hyperband_stopping.py
+++ b/syne_tune/optimizer/schedulers/hyperband_stopping.py
@@ -42,19 +42,21 @@ def quantile_cutoff(values, prom_quant, mode):
 
 class RungSystem:
     """
-    Terminology: trials emit results at certain resource levels (e.g.,
-    epoch numbers). Some resource levels are rung levels, this is where
-    scheduling decisions (stop, continue or pause, resume) are taken.
+    Terminology: Trials emit results at certain resource levels (e.g., epoch
+    numbers). Some resource levels are rung levels, this is where scheduling
+    decisions (stop, continue or pause, resume) are taken. For a running trial,
+    the next rung level (or ``max_t``) it will reach is called its next
+    milestone.
 
-    For a running trial, the next rung level it will reach is called
-    its next milestone.
+    Note that ``rung_levels``, ``promote_quantiles`` can be empty. All
+    entries of ``rung_levels`` are smaller than ``max_t``.
 
     :param rung_levels: List of rung levels (positive int, increasing)
-    :param promote_quantiles: List of promotion quantiles at each rung
-        level
+    :param promote_quantiles: List of promotion quantiles at each rung level
     :param metric: Name of metric to optimize
     :param mode: "min" or "max"
     :param resource_attr: Name of resource attribute
+    :param max_t: Largest resource level
     """
 
     def __init__(
@@ -64,11 +66,15 @@ class RungSystem:
         metric: str,
         mode: str,
         resource_attr: str,
+        max_t: int,
     ):
-        assert len(rung_levels) == len(promote_quantiles)
+        self.num_rungs = len(rung_levels)
+        assert len(promote_quantiles) == self.num_rungs
+        assert self.num_rungs == 0 or rung_levels[-1] < max_t
         self._metric = metric
         self._mode = mode
         self._resource_attr = resource_attr
+        self._max_t = max_t
         # The data entry in ``_rungs`` is a dict with key trial_id. The
         # value type depends on the subclass, but it contains the
         # metric value
@@ -130,7 +136,11 @@ class RungSystem:
             considered milestones for this task
         :return: First milestone to be considered
         """
-        return self._rungs[-(skip_rungs + 1)].level
+        return (
+            self._rungs[-(skip_rungs + 1)].level
+            if skip_rungs < self.num_rungs
+            else self._max_t
+        )
 
     def _milestone_rungs(self, skip_rungs: int) -> List[RungEntry]:
         if skip_rungs > 0:
@@ -142,7 +152,8 @@ class RungSystem:
         """
         :param skip_rungs: This number of the smallest rung levels are not
             considered milestones for this task
-        :return: All milestones to be considered
+        :return: All milestones to be considered, in decreasing order; does
+            not include ``max_t``
         """
         milestone_rungs = self._milestone_rungs(skip_rungs)
         return [x.level for x in milestone_rungs]
@@ -216,39 +227,44 @@ class StoppingRungSystem(RungSystem):
     def on_task_report(self, trial_id: str, result: dict, skip_rungs: int) -> dict:
         resource = result[self._resource_attr]
         metric_value = result[self._metric]
-        task_continues = True
-        milestone_reached = False
-        next_milestone = None
-        milestone_rungs = self._milestone_rungs(skip_rungs)
-        for rung in milestone_rungs:
-            milestone = rung.level
-            prom_quant = rung.prom_quant
-            recorded = rung.data
-            if not (resource < milestone or trial_id in recorded):
-                # Note: It is important for model-based searchers that
-                # milestones are reached exactly, not jumped over. In
-                # particular, if a future milestone is reported via
-                # register_pending, its reward value has to be passed
-                # later on via update.
-                if resource > milestone:
-                    logger.warning(
-                        f"resource = {resource} > {milestone} = milestone. "
-                        "Make sure to report time attributes covering all milestones.\n"
-                        f"Continueing, but milestone {milestone} has been skipped."
-                    )
-                else:
-                    milestone_reached = True
-                    # Enter new metric value before checking condition
-                    recorded[trial_id] = metric_value
-                    task_continues = self._task_continues(
-                        metric_value=metric_value,
-                        recorded=recorded,
-                        prom_quant=prom_quant,
-                        trial_id=trial_id,
-                        resource=resource,
-                    )
-                break
-            next_milestone = milestone
+        if resource == self._max_t:
+            task_continues = False
+            milestone_reached = True
+            next_milestone = None
+        else:
+            task_continues = True
+            milestone_reached = False
+            next_milestone = self._max_t
+            milestone_rungs = self._milestone_rungs(skip_rungs)
+            for rung in milestone_rungs:
+                milestone = rung.level
+                prom_quant = rung.prom_quant
+                recorded = rung.data
+                if not (resource < milestone or trial_id in recorded):
+                    # Note: It is important for model-based searchers that
+                    # milestones are reached exactly, not jumped over. In
+                    # particular, if a future milestone is reported via
+                    # register_pending, its reward value has to be passed
+                    # later on via update.
+                    if resource > milestone:
+                        logger.warning(
+                            f"resource = {resource} > {milestone} = milestone. "
+                            "Make sure to report time attributes covering all milestones.\n"
+                            f"Continueing, but milestone {milestone} has been skipped."
+                        )
+                    else:
+                        milestone_reached = True
+                        # Enter new metric value before checking condition
+                        recorded[trial_id] = metric_value
+                        task_continues = self._task_continues(
+                            metric_value=metric_value,
+                            recorded=recorded,
+                            prom_quant=prom_quant,
+                            trial_id=trial_id,
+                            resource=resource,
+                        )
+                    break
+                next_milestone = milestone
         return {
             "task_continues": task_continues,
             "milestone_reached": milestone_reached,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
@@ -75,7 +75,7 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
         Note: Model updates (by the state transformer) for batch candidates beyond
         the first do not involve fitting hyperparameters, so they are usually
         cheap.
-    :param exclusion_candidates: set of candidates that should not be returned,
+    :param exclusion_candidates: Set of candidates that should not be returned,
         because they are already labeled, currently pending, or have failed
     :param num_requested_candidates: number of candidates to return
     :param greedy_batch_selection: If True and ``num_requested_candidates > 1``, we

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
@@ -113,6 +113,16 @@ class ExclusionList:
             self.excl_set
         ) >= self.configspace_size
 
+    def get_state(self) -> dict:
+        return {
+            "excl_set": list(self.excl_set),
+            "keys": self.keys,
+        }
+
+    def clone_from_state(self, state: dict):
+        self.keys = state["keys"]
+        self.excl_set = set(state["excl_set"])
+
 
 class CandidateGenerator:
     """


### PR DESCRIPTION
…g up HyperbandScheduler

*Issue #, if available:*

*Description of changes:*

Fixes issue with Hyper-Tune, where defaults were set in baselines, and the number of brackets passed to the searcher was not correct. I cleaned up `HyperbandScheduler` by making sure that `rung_levels` never contains the final `max_t`. This makes sense, since a rung is where stop/go decisions are made. In the old code, `rung_levels` sometimes ended in `max_t`, sometimes not, which leads to problems.

I found these issues by working on a new unit test, which will be part of a future PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
