### PR TITLE
Refactoring of model-based searchers and schedulers, includes fixes of HyperTune and SyncMOBSTER

### DIFF
--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -53,7 +53,6 @@ def get_transfer_learning_evaluations(
     test_task: str,
     datasets: Optional[List[str]],
     n_evals: Optional[int] = None,
-    ignore_hash: bool = False,
 ) -> dict:
     """
     :param blackbox_name: name of blackbox
@@ -63,7 +62,7 @@ def get_transfer_learning_evaluations(
     :param n_evals: maximum number of evaluations to be returned
     :return:
     """
-    task_to_evaluations = load_blackbox(blackbox_name, ignore_hash=ignore_hash)
+    task_to_evaluations = load_blackbox(blackbox_name)
 
     # todo retrieve right metric
     metric_index = 0
@@ -160,12 +159,6 @@ def parse_args(
                 default="none",
                 help="Ordinal encoding for fcnet categorical HPs",
             ),
-            dict(
-                name="ignore_blackbox_hash",
-                type=int,
-                default=0,
-                help="Ignore mechanism to check whether blackbox files are up to date?",
-            ),
         ]
     )
     if nested_dict:
@@ -179,7 +172,6 @@ def parse_args(
     args, method_names, seeds = _parse_args(methods, extra_args)
     args.verbose = bool(args.verbose)
     args.support_checkpointing = bool(args.support_checkpointing)
-    args.ignore_blackbox_hash = bool(args.ignore_blackbox_hash)
     if args.benchmark is not None:
         benchmark_names = [args.benchmark]
     else:
@@ -255,7 +247,6 @@ def main(
             surrogate=benchmark.surrogate,
             surrogate_kwargs=benchmark.surrogate_kwargs,
             add_surrogate_kwargs=benchmark.add_surrogate_kwargs,
-            ignore_hash=args.ignore_blackbox_hash,
         )
 
         resource_attr = next(iter(backend.blackbox.fidelity_space.keys()))
@@ -279,7 +270,6 @@ def main(
                     blackbox_name=benchmark.blackbox_name,
                     test_task=benchmark.dataset_name,
                     datasets=benchmark.datasets,
-                    ignore_hash=args.ignore_blackbox_hash,
                 ),
             )
         scheduler = methods[method](

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -53,6 +53,7 @@ def get_transfer_learning_evaluations(
     test_task: str,
     datasets: Optional[List[str]],
     n_evals: Optional[int] = None,
+    ignore_hash: bool = False,
 ) -> dict:
     """
     :param blackbox_name: name of blackbox
@@ -62,7 +63,7 @@ def get_transfer_learning_evaluations(
     :param n_evals: maximum number of evaluations to be returned
     :return:
     """
-    task_to_evaluations = load_blackbox(blackbox_name)
+    task_to_evaluations = load_blackbox(blackbox_name, ignore_hash=ignore_hash)
 
     # todo retrieve right metric
     metric_index = 0
@@ -159,6 +160,12 @@ def parse_args(
                 default="none",
                 help="Ordinal encoding for fcnet categorical HPs",
             ),
+            dict(
+                name="ignore_blackbox_hash",
+                type=int,
+                default=0,
+                help="Ignore mechanism to check whether blackbox files are up to date?",
+            ),
         ]
     )
     if nested_dict:
@@ -172,6 +179,7 @@ def parse_args(
     args, method_names, seeds = _parse_args(methods, extra_args)
     args.verbose = bool(args.verbose)
     args.support_checkpointing = bool(args.support_checkpointing)
+    args.ignore_blackbox_hash = bool(args.ignore_blackbox_hash)
     if args.benchmark is not None:
         benchmark_names = [args.benchmark]
     else:
@@ -247,6 +255,7 @@ def main(
             surrogate=benchmark.surrogate,
             surrogate_kwargs=benchmark.surrogate_kwargs,
             add_surrogate_kwargs=benchmark.add_surrogate_kwargs,
+            ignore_hash=args.ignore_blackbox_hash,
         )
 
         resource_attr = next(iter(backend.blackbox.fidelity_space.keys()))
@@ -270,6 +279,7 @@ def main(
                     blackbox_name=benchmark.blackbox_name,
                     test_task=benchmark.dataset_name,
                     datasets=benchmark.datasets,
+                    ignore_hash=args.ignore_blackbox_hash,
                 ),
             )
         scheduler = methods[method](

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -146,7 +146,6 @@ def launch_remote(
         )
         hyperparameters["support_checkpointing"] = int(args.support_checkpointing)
         hyperparameters["verbose"] = int(args.verbose)
-        hyperparameters["ignore_blackbox_hash"] = int(args.ignore_blackbox_hash)
         if benchmark_key is not None:
             hyperparameters["benchmark_key"] = benchmark_key
         sm_args["hyperparameters"] = hyperparameters

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -146,6 +146,7 @@ def launch_remote(
         )
         hyperparameters["support_checkpointing"] = int(args.support_checkpointing)
         hyperparameters["verbose"] = int(args.verbose)
+        hyperparameters["ignore_blackbox_hash"] = int(args.ignore_blackbox_hash)
         if benchmark_key is not None:
             hyperparameters["benchmark_key"] = benchmark_key
         sm_args["hyperparameters"] = hyperparameters

--- a/benchmarking/nursery/benchmark_yahpo/baselines.py
+++ b/benchmarking/nursery/benchmark_yahpo/baselines.py
@@ -17,6 +17,7 @@ from syne_tune.optimizer.baselines import (
     RandomSearch,
     BayesianOptimization,
     ASHA,
+    MOBSTER,
 )
 
 
@@ -24,6 +25,7 @@ class Methods:
     RS = "RS"
     BO = "BO"
     ASHA = "ASHA"
+    MOBSTER = "MOBSTER"
 
 
 methods = {
@@ -44,6 +46,20 @@ methods = {
         random_seed=method_arguments.random_seed,
     ),
     Methods.ASHA: lambda method_arguments: ASHA(
+        config_space=method_arguments.config_space,
+        search_options=search_options(method_arguments),
+        mode=method_arguments.mode,
+        metric=method_arguments.metric,
+        max_resource_attr=method_arguments.max_resource_attr,
+        resource_attr=method_arguments.resource_attr,
+        random_seed=method_arguments.random_seed,
+        **(
+            method_arguments.scheduler_kwargs
+            if method_arguments.scheduler_kwargs is not None
+            else dict()
+        ),
+    ),
+    Methods.MOBSTER: lambda method_arguments: MOBSTER(
         config_space=method_arguments.config_space,
         search_options=search_options(method_arguments),
         mode=method_arguments.mode,

--- a/benchmarking/nursery/benchmark_yahpo/benchmark_definitions.py
+++ b/benchmarking/nursery/benchmark_yahpo/benchmark_definitions.py
@@ -13,6 +13,7 @@
 from benchmarking.commons.benchmark_definitions import (
     yahpo_iaml_benchmark_definitions,
     yahpo_rbv2_benchmark_definitions,
+    yahpo_nb301_benchmark_definitions,
 )
 from benchmarking.commons.benchmark_definitions.yahpo import (
     yahpo_rbv2_metrics,
@@ -47,4 +48,6 @@ for method in yahpo_rbv2_methods:
         }
 
 
-benchmark_definitions = benchmark_definitions_iaml
+# benchmark_definitions = benchmark_definitions_iaml
+# benchmark_definitions = benchmark_definitions_rbv2
+benchmark_definitions = yahpo_nb301_benchmark_definitions

--- a/benchmarking/nursery/benchmark_yahpo/launch_remote.py
+++ b/benchmarking/nursery/benchmark_yahpo/launch_remote.py
@@ -26,8 +26,7 @@ from benchmarking.nursery.benchmark_yahpo.hpo_main import (
 if __name__ == "__main__":
 
     def _is_expensive_method(method: str) -> bool:
-        # return True
-        return method == "BO"
+        return method in {"BO", "MOBSTER"}
 
     entry_point = Path(__file__).parent / "hpo_main.py"
     launch_remote(

--- a/docs/source/tutorials/developer/extend_sync_hb.rst
+++ b/docs/source/tutorials/developer/extend_sync_hb.rst
@@ -75,7 +75,15 @@ first bracket which is not yet complete, is the *primary bracket*.
 
 Given these classes,
 :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
-is straightforward. It is a pause-and-resume scheduler.
+is straightforward. It is a pause-and-resume scheduler, and it implements the API
+:class:`~syne_tune.optimizer.schedulers.multi_fidelity.MultiFidelitySchedulerMixin`,
+so that any searchers supporting multi-fidelity schedulers can be used. More
+precisely, ``SynchronousHyperbandScheduler`` inherits from
+:class:`~syne_tune.optimizer.schedulers.synchronous.hyperband.SynchronousHyperbandCommon`,
+which derives from
+:class:`~syne_tune.optimizer.schedulers.scheduler_searcher.TrialSchedulerWithSearcher` and
+:class:`~syne_tune.optimizer.schedulers.multi_fidelity.MultiFidelitySchedulerMixin`
+and collects some code used during construction.
 
 * ``_suggest`` polls ``self.bracket_manager.next_job()``. If the ``SlotInRung``
   returned has ``trial_id`` assigned, it corresponds to a trial to be
@@ -197,7 +205,10 @@ is very similar to ``SynchronousHyperbandBracketManager``. Differences include:
   cross-over and selection.
 
 :class:`~syne_tune.optimizer.schedulers.synchronous.DifferentialEvolutionHyperbandScheduler`
-implements the DEHB scheduler.
+implements the DEHB scheduler. Just like ``SynchronousHyperbandScheduler``, it
+inherits from
+:class:`~syne_tune.optimizer.schedulers.synchronous.hyperband.SynchronousHyperbandCommon`,
+which contains common code used by both of them.
 
 * On top of ``SynchronousHyperbandScheduler``, it also maps ``trial_id`` to
   encoded configuration in ``self._trial_info``, and ``self._global_parent_pool``

--- a/docs/source/tutorials/developer/new_searcher.rst
+++ b/docs/source/tutorials/developer/new_searcher.rst
@@ -74,6 +74,8 @@ some best practices for linking a new searcher into the factory:
   being specified by the user. You will always have the fields contributed by
   the generic schedulers, and for all others, your code should ideally come with
   sensible defaults.
+* Make sure to implement the ``configure_scheduler`` method of your new searcher,
+  restricting usage to supported scheduler types.
 
 Contribute your Extension
 -------------------------

--- a/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
+++ b/syne_tune/blackbox_repository/conversion_scripts/scripts/yahpo_import.py
@@ -50,6 +50,8 @@ from yahpo_gym.benchmark_set import BenchmarkSet
 from yahpo_gym.configuration import list_scenarios
 from yahpo_gym import local_config
 
+logger = logging.getLogger(__name__)
+
 
 def download(target_path: Path, version: str):
     import urllib
@@ -58,12 +60,12 @@ def download(target_path: Path, version: str):
 
     target_file = target_path / f"yahpo_data-{version}"
     if not target_file.exists():
-        logging.info(f"File {target_file} not found redownloading it.")
+        logger.info(f"File {target_file} not found redownloading it.")
         urllib.request.urlretrieve(root + f"v{version}.zip", str(target_path) + ".zip")
         with zipfile.ZipFile(str(target_path) + ".zip", "r") as zip_ref:
             zip_ref.extractall(target_path)
     else:
-        logging.info(f"File {target_file} found, skipping download.")
+        logger.info(f"File {target_file} found, skipping download.")
 
 
 def _check_whether_iaml(benchmark: BenchmarkSet) -> bool:

--- a/syne_tune/blackbox_repository/simulated_tabular_backend.py
+++ b/syne_tune/blackbox_repository/simulated_tabular_backend.py
@@ -279,9 +279,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         space of the original blackbox is used. However, its numerical parameters
         have finite domains (categorical or ordinal), which is usually not what
         we want for a surrogate.
-    :param ignore_hash: If `True`, the hashing mechanism to check whether the
-        blackbox files match a pre-computed hash, is ignored. This is not
-        recommended. Defaults to `False`.
     :param simulatorbackend_kwargs: Additional arguments to parent
         :class:`~syne_tune.backend.simulator_backend.SimulatorBackend`
     """
@@ -298,7 +295,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         surrogate_kwargs: Optional[dict] = None,
         add_surrogate_kwargs: Optional[dict] = None,
         config_space_surrogate: Optional[dict] = None,
-        ignore_hash: bool = False,
         **simulatorbackend_kwargs,
     ):
         assert (
@@ -330,7 +326,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             }
         else:
             self._config_space_surrogate = None
-        self._ignore_hash = ignore_hash
 
     @property
     def blackbox(self) -> Blackbox:
@@ -340,7 +335,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             self._blackbox = load_blackbox(
                 self.blackbox_name,
                 yahpo_kwargs=self._surrogate_kwargs,
-                ignore_hash=self._ignore_hash,
             )
             if self.dataset is None:
                 assert not isinstance(self._blackbox, dict), (
@@ -375,7 +369,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
             "dataset": self.dataset,
             "surrogate": self._surrogate,
             "surrogate_kwargs": self._surrogate_kwargs,
-            "ignore_hash": self._ignore_hash,
         }
         if self._config_space_surrogate is not None:
             state["config_space_surrogate"] = config_space_to_json_dict(
@@ -395,7 +388,6 @@ class BlackboxRepositoryBackend(_BlackboxSimulatorBackend):
         self.dataset = state["dataset"]
         self._surrogate = state["surrogate"]
         self._surrogate_kwargs = state["surrogate_kwargs"]
-        self._ignore_hash = state["ignore_hash"]
         self._blackbox = None
         if "config_space_surrogate" in state:
             self._config_space_surrogate = config_space_from_json_dict(

--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -204,12 +204,7 @@ class HyperTune(HyperbandScheduler):
             f", must be in {supp}"
         )
         search_options[k] = model
-        k = "hypertune_distribution_num_samples"
-        num_samples = search_options.get(k, 50)
-        search_options[k] = num_samples
         kwargs["search_options"] = search_options
-        num_brackets = kwargs.get("brackets", 4)
-        kwargs["brackets"] = num_brackets
         super(HyperTune, self).__init__(
             config_space=config_space,
             metric=metric,
@@ -346,7 +341,8 @@ class SyncMOBSTER(SynchronousGeometricHyperbandScheduler):
     the asynchronous case.
 
     One of ``max_resource_level``, ``max_resource_attr`` needs to be in ``kwargs``.
-    The latter is more useful, see also :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
+    The latter is more useful, see also
+    :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
 
     The default surrogate model (``search_options["model"]`` in ``kwargs``) is
     ``"gp_independent"``, different to :class:`MOBSTER`.

--- a/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
+++ b/syne_tune/optimizer/schedulers/hyperband_cost_promotion.py
@@ -70,9 +70,9 @@ class CostPromotionRungSystem(PromotionRungSystem):
             rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
         )
         self._cost_attr = cost_attr
-        # Note: The data entry in _rungs is now a dict mapping trial_id to
-        # (metric_value, cost_value, was_promoted), where metric_value is
-        # m(x, r), cost value is c(x, r).
+        # Note: The data entry in ``_rungs`` is now a dict mapping trial_id to
+        # ``(metric_value, cost_value, was_promoted)``, where metric_value is
+        # :math:`m(x, r)`, cost value is :math:`c(x, r)`.
 
     def _find_promotable_trial(
         self, recorded: dict, prom_quant: float, resource: int
@@ -85,7 +85,7 @@ class CostPromotionRungSystem(PromotionRungSystem):
         :param recorded: Dict to scan
         :param prom_quant: Quantile for promotion
         :param resource: Amount of resources spent on the rung.
-        :return: trial_id if found, otherwise None
+        :return: ``trial_id`` if found, otherwise ``None``
         """
         ret_id = None
         if len(recorded) > 1:

--- a/syne_tune/optimizer/schedulers/hyperband_pasha.py
+++ b/syne_tune/optimizer/schedulers/hyperband_pasha.py
@@ -40,18 +40,20 @@ class PASHARungSystem(PromotionRungSystem):
             rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
         )
         self.ranking_criterion = ranking_criterion
-        # define the index of the current top rung, starting from 1 for the lowest rung
-        #
-        self.current_rung_idx = 2
-        self.rung_levels = rung_levels
+        # define the index of the current top rung, starting from 1 for the
+        # lowest rung
+        assert self.num_rungs >= 1, "rung_levels must not be empty"
+        self.rung_levels = rung_levels.copy()
 
         # initialize current maximum resources
+        self.current_rung_idx = min(len(rung_levels) - 1, 2)
         self.current_max_t = rung_levels[self.current_rung_idx - 1]
 
         self.epsilon = epsilon
         self.epsilon_scaling = epsilon_scaling
 
-    # overriding the method in HB promotion to accommodate the increasing max resources level
+    # overriding the method in HB promotion to accommodate the increasing max
+    # resources level
     def _effective_max_t(self):
         return self.current_max_t
 

--- a/syne_tune/optimizer/schedulers/hyperband_rush.py
+++ b/syne_tune/optimizer/schedulers/hyperband_rush.py
@@ -99,9 +99,12 @@ class RUSHStoppingRungSystem(StoppingRungSystem):
         metric: str,
         mode: str,
         resource_attr: str,
+        max_t: int,
         num_threshold_candidates: int,
     ):
-        super().__init__(rung_levels, promote_quantiles, metric, mode, resource_attr)
+        super().__init__(
+            rung_levels, promote_quantiles, metric, mode, resource_attr, max_t
+        )
         self._decider = RUSHDecider(num_threshold_candidates, mode)
 
     def _task_continues(

--- a/syne_tune/optimizer/schedulers/hyperband_stopping.py
+++ b/syne_tune/optimizer/schedulers/hyperband_stopping.py
@@ -42,19 +42,21 @@ def quantile_cutoff(values, prom_quant, mode):
 
 class RungSystem:
     """
-    Terminology: trials emit results at certain resource levels (e.g.,
-    epoch numbers). Some resource levels are rung levels, this is where
-    scheduling decisions (stop, continue or pause, resume) are taken.
+    Terminology: Trials emit results at certain resource levels (e.g., epoch
+    numbers). Some resource levels are rung levels, this is where scheduling
+    decisions (stop, continue or pause, resume) are taken. For a running trial,
+    the next rung level (or ``max_t``) it will reach is called its next
+    milestone.
 
-    For a running trial, the next rung level it will reach is called
-    its next milestone.
+    Note that ``rung_levels``, ``promote_quantiles`` can be empty. All
+    entries of ``rung_levels`` are smaller than ``max_t``.
 
     :param rung_levels: List of rung levels (positive int, increasing)
-    :param promote_quantiles: List of promotion quantiles at each rung
-        level
+    :param promote_quantiles: List of promotion quantiles at each rung level
     :param metric: Name of metric to optimize
     :param mode: "min" or "max"
     :param resource_attr: Name of resource attribute
+    :param max_t: Largest resource level
     """
 
     def __init__(
@@ -64,11 +66,15 @@ class RungSystem:
         metric: str,
         mode: str,
         resource_attr: str,
+        max_t: int,
     ):
-        assert len(rung_levels) == len(promote_quantiles)
+        self.num_rungs = len(rung_levels)
+        assert len(promote_quantiles) == self.num_rungs
+        assert self.num_rungs == 0 or rung_levels[-1] < max_t
         self._metric = metric
         self._mode = mode
         self._resource_attr = resource_attr
+        self._max_t = max_t
         # The data entry in ``_rungs`` is a dict with key trial_id. The
         # value type depends on the subclass, but it contains the
         # metric value
@@ -130,7 +136,11 @@ class RungSystem:
             considered milestones for this task
         :return: First milestone to be considered
         """
-        return self._rungs[-(skip_rungs + 1)].level
+        return (
+            self._rungs[-(skip_rungs + 1)].level
+            if skip_rungs < self.num_rungs
+            else self._max_t
+        )
 
     def _milestone_rungs(self, skip_rungs: int) -> List[RungEntry]:
         if skip_rungs > 0:
@@ -142,7 +152,8 @@ class RungSystem:
         """
         :param skip_rungs: This number of the smallest rung levels are not
             considered milestones for this task
-        :return: All milestones to be considered
+        :return: All milestones to be considered, in decreasing order; does
+            not include ``max_t``
         """
         milestone_rungs = self._milestone_rungs(skip_rungs)
         return [x.level for x in milestone_rungs]
@@ -216,39 +227,44 @@ class StoppingRungSystem(RungSystem):
     def on_task_report(self, trial_id: str, result: dict, skip_rungs: int) -> dict:
         resource = result[self._resource_attr]
         metric_value = result[self._metric]
-        task_continues = True
-        milestone_reached = False
-        next_milestone = None
-        milestone_rungs = self._milestone_rungs(skip_rungs)
-        for rung in milestone_rungs:
-            milestone = rung.level
-            prom_quant = rung.prom_quant
-            recorded = rung.data
-            if not (resource < milestone or trial_id in recorded):
-                # Note: It is important for model-based searchers that
-                # milestones are reached exactly, not jumped over. In
-                # particular, if a future milestone is reported via
-                # register_pending, its reward value has to be passed
-                # later on via update.
-                if resource > milestone:
-                    logger.warning(
-                        f"resource = {resource} > {milestone} = milestone. "
-                        "Make sure to report time attributes covering all milestones.\n"
-                        f"Continueing, but milestone {milestone} has been skipped."
-                    )
-                else:
-                    milestone_reached = True
-                    # Enter new metric value before checking condition
-                    recorded[trial_id] = metric_value
-                    task_continues = self._task_continues(
-                        metric_value=metric_value,
-                        recorded=recorded,
-                        prom_quant=prom_quant,
-                        trial_id=trial_id,
-                        resource=resource,
-                    )
-                break
-            next_milestone = milestone
+        if resource == self._max_t:
+            task_continues = False
+            milestone_reached = True
+            next_milestone = None
+        else:
+            task_continues = True
+            milestone_reached = False
+            next_milestone = self._max_t
+            milestone_rungs = self._milestone_rungs(skip_rungs)
+            for rung in milestone_rungs:
+                milestone = rung.level
+                prom_quant = rung.prom_quant
+                recorded = rung.data
+                if not (resource < milestone or trial_id in recorded):
+                    # Note: It is important for model-based searchers that
+                    # milestones are reached exactly, not jumped over. In
+                    # particular, if a future milestone is reported via
+                    # register_pending, its reward value has to be passed
+                    # later on via update.
+                    if resource > milestone:
+                        logger.warning(
+                            f"resource = {resource} > {milestone} = milestone. "
+                            "Make sure to report time attributes covering all milestones.\n"
+                            f"Continueing, but milestone {milestone} has been skipped."
+                        )
+                    else:
+                        milestone_reached = True
+                        # Enter new metric value before checking condition
+                        recorded[trial_id] = metric_value
+                        task_continues = self._task_continues(
+                            metric_value=metric_value,
+                            recorded=recorded,
+                            prom_quant=prom_quant,
+                            trial_id=trial_id,
+                            resource=resource,
+                        )
+                    break
+                next_milestone = milestone
         return {
             "task_continues": task_continues,
             "milestone_reached": milestone_reached,

--- a/syne_tune/optimizer/schedulers/multi_fidelity.py
+++ b/syne_tune/optimizer/schedulers/multi_fidelity.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import List
+
+
+class MultiFidelitySchedulerMixin:
+    """
+    Declares properties which are required for multi-fidelity schedulers.
+    """
+
+    @property
+    def resource_attr(self) -> str:
+        """
+        :return: Name of resource attribute in reported results
+        """
+        raise NotImplementedError
+
+    @property
+    def max_resource_level(self) -> int:
+        """
+        :return: Maximum resource level
+        """
+        raise NotImplementedError
+
+    @property
+    def rung_levels(self) -> List[int]:
+        """
+        :return: Rung levels (positive int; increasing), may or may not
+            include ``max_resource_level``
+        """
+        raise NotImplementedError
+
+    @property
+    def searcher_data(self) -> str:
+        """
+        :return: Relevant only if a model-based searcher is used.
+            Example: For NN tuning and ``resource_attr == "epoch"``, we receive
+            a result for each epoch, but not all epoch values are also rung
+            levels. ``searcher_data`` determines which of these results are
+            passed to the searcher. As a rule, the more data the searcher
+            receives, the better its fit, but also the more expensive
+            :meth:`get_config` may become. Choices:
+
+            * "rungs": Only results at rung levels. Cheapest
+            * "all": All results. Most expensive
+            * "rungs_and_last": Results at rung levels plus last recent one.
+              Not available for all multi-fidelity schedulers
+        """
+        raise NotImplementedError
+
+    @property
+    def num_brackets(self) -> int:
+        """
+        :return: Number of brackets (i.e., rung level systems). If the scheduler
+            does not use brackets, it has to return 1
+        """
+        raise NotImplementedError

--- a/syne_tune/optimizer/schedulers/scheduler_searcher.py
+++ b/syne_tune/optimizer/schedulers/scheduler_searcher.py
@@ -1,0 +1,119 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import Optional
+import logging
+import numpy as np
+
+from syne_tune.optimizer.schedulers.searchers import BaseSearcher
+from syne_tune.optimizer.scheduler import TrialSuggestion, TrialScheduler
+from syne_tune.optimizer.schedulers.random_seeds import RandomSeedGenerator
+from syne_tune.backend.trial_status import Trial
+
+logger = logging.getLogger(__name__)
+
+
+class TrialSchedulerWithSearcher(TrialScheduler):
+    """
+    Base class for trial schedulers which have a
+    :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher` member
+    ``searcher``. This searcher has a method
+    :meth:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher.configure_scheduler`
+    which has to be called before the searcher is first used.
+
+    We also collect common code here:
+
+    * Determine ``max_resource_level`` if not explicitly given
+    * Master seed, :attr:`random_seed_generator`
+    """
+
+    def __init__(self, config_space: dict, **kwargs):
+        super().__init__(config_space)
+        self._searcher_initialized = False
+        # Generator for random seeds
+        random_seed = kwargs.get("random_seed")
+        if random_seed is None:
+            random_seed = np.random.randint(0, 2**32)
+        logger.info(f"Master random_seed = {random_seed}")
+        self.random_seed_generator = RandomSeedGenerator(random_seed)
+
+    @property
+    def searcher(self) -> Optional[BaseSearcher]:
+        raise NotImplementedError
+
+    def _initialize_searcher(self):
+        """Callback to initialize searcher based on scheduler, if not done already"""
+        if not self._searcher_initialized:
+            if self.searcher is not None:
+                self.searcher.configure_scheduler(self)
+            self._searcher_initialized = True
+
+    def suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        self._initialize_searcher()
+        return super().suggest(trial_id)
+
+    def on_trial_error(self, trial: Trial):
+        self._initialize_searcher()
+        if self.searcher is not None:
+            trial_id = str(trial.trial_id)
+            self.searcher.evaluation_failed(trial_id)
+            if self.searcher.debug_log is not None:
+                logger.info(f"trial_id {trial_id}: Evaluation failed!")
+
+    def on_trial_complete(self, trial: Trial, result: dict):
+        self._initialize_searcher()
+        if self.searcher is not None:
+            config = self._preprocess_config(trial.config)
+            self.searcher.on_trial_result(
+                str(trial.trial_id), config, result=result, update=True
+            )
+
+    def _infer_max_resource_level_getval(self, name):
+        if name in self.config_space and name not in self._hyperparameter_keys:
+            return self.config_space[name]
+        else:
+            return None
+
+    def _infer_max_resource_level(
+        self, max_resource_level: Optional[int], max_resource_attr: Optional[str]
+    ):
+        """Infer ``max_resource_level`` if not explicitly given.
+
+        :param max_resource_level: Value explicitly provided, or None
+        :param max_resource_attr: Name of max resource attribute in
+            ``self.config_space`` (optional)
+        :return: Inferred value for ``max_resource_level``
+        """
+        inferred_max_t = None
+        names = ("epochs", "max_t", "max_epochs")
+        if max_resource_attr is not None:
+            names = (max_resource_attr,) + names
+        for name in names:
+            inferred_max_t = self._infer_max_resource_level_getval(name)
+            if inferred_max_t is not None:
+                break
+        if max_resource_level is not None:
+            if inferred_max_t is not None and max_resource_level != inferred_max_t:
+                logger.warning(
+                    f"max_resource_level = {max_resource_level} is different "
+                    f"from the value {inferred_max_t} inferred from "
+                    "config_space"
+                )
+        else:
+            # It is OK if max_resource_level cannot be inferred
+            if inferred_max_t is not None:
+                logger.info(
+                    f"max_resource_level = {inferred_max_t}, as inferred "
+                    "from config_space"
+                )
+            max_resource_level = inferred_max_t
+        return max_resource_level

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
@@ -433,22 +433,25 @@ class GaussProcModelFactory(TransformerModelFactory):
         )
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
+        from syne_tune.optimizer.schedulers.multi_fidelity import (
+            MultiFidelitySchedulerMixin,
+        )
 
         if isinstance(
             self._gpmodel, (IndependentGPPerResourceModel, HyperTuneJointGPModel)
         ):
-            assert isinstance(scheduler, HyperbandScheduler), (
+            assert isinstance(scheduler, MultiFidelitySchedulerMixin), (
                 "gpmodel of type IndependentGPPerResourceModel requires "
-                + "HyperbandScheduler scheduler"
+                "MultiFidelitySchedulerMixin scheduler"
             )
             # Likelihood of internal model still has to be created (depends on
-            # rung levels of scheduler). Note that ``max_t`` must be included
-            max_t = scheduler.max_t
-            if scheduler.rung_levels[-1] == max_t:
+            # rung levels of scheduler). Note that ``max_resource_level`` must be
+            # included
+            max_resource_level = scheduler.max_resource_level
+            if scheduler.rung_levels[-1] == max_resource_level:
                 rung_levels = scheduler.rung_levels
             else:
-                rung_levels = scheduler.rung_levels + [max_t]
+                rung_levels = scheduler.rung_levels + [max_resource_level]
             self._gpmodel.create_likelihood(rung_levels)
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gpiss_model.py
@@ -310,6 +310,20 @@ class GaussProcAdditiveModelFactory(TransformerModelFactory):
             **extra_kwargs,
         )
 
+    def configure_scheduler(self, scheduler):
+        from syne_tune.optimizer.schedulers.multi_fidelity import (
+            MultiFidelitySchedulerMixin,
+        )
+
+        assert isinstance(
+            scheduler, MultiFidelitySchedulerMixin
+        ), "GaussProcAdditiveModelFactory requires MultiFidelitySchedulerMixin scheduler"
+        assert scheduler.searcher_data == "all", (
+            "For an additive Gaussian learning curve model (model='gp_issm' or "
+            "model='gp_expdecay' in search_options), you need to set "
+            "searcher_data='all' when creating the multi-fidelity scheduler"
+        )
+
     def _draw_fantasy_values(self, state: TuningJobState) -> TuningJobState:
         """
         Note: Fantasized target values are not de-normalized, because they

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm.py
@@ -75,7 +75,7 @@ class BayesianOptimizationAlgorithm(NextCandidatesAlgorithm):
         Note: Model updates (by the state transformer) for batch candidates beyond
         the first do not involve fitting hyperparameters, so they are usually
         cheap.
-    :param exclusion_candidates: set of candidates that should not be returned,
+    :param exclusion_candidates: Set of candidates that should not be returned,
         because they are already labeled, currently pending, or have failed
     :param num_requested_candidates: number of candidates to return
     :param greedy_batch_selection: If True and ``num_requested_candidates > 1``, we

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/common.py
@@ -113,6 +113,16 @@ class ExclusionList:
             self.excl_set
         ) >= self.configspace_size
 
+    def get_state(self) -> dict:
+        return {
+            "excl_set": list(self.excl_set),
+            "keys": self.keys,
+        }
+
+    def clone_from_state(self, state: dict):
+        self.keys = state["keys"]
+        self.excl_set = set(state["excl_set"])
+
 
 class CandidateGenerator:
     """

--- a/syne_tune/optimizer/schedulers/searchers/bore/bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/bore.py
@@ -144,12 +144,13 @@ class Bore(SearcherWithRandomSeed):
         self.targets = []
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
+        from syne_tune.optimizer.schedulers.scheduler_searcher import (
+            TrialSchedulerWithSearcher,
+        )
 
         assert isinstance(
-            scheduler, FIFOScheduler
-        ), "This searcher requires FIFOScheduler scheduler"
-
+            scheduler, TrialSchedulerWithSearcher
+        ), "This searcher requires TrialSchedulerWithSearcher scheduler"
         super().configure_scheduler(scheduler)
 
     def _loss(self, x):

--- a/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
+++ b/syne_tune/optimizer/schedulers/searchers/bore/multi_fidelity_bore.py
@@ -82,18 +82,15 @@ class MultiFidelityBore(Bore):
         self.resource_levels = []
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-        from syne_tune.optimizer.schedulers.synchronous.hyperband import (
-            SynchronousHyperbandScheduler,
+        from syne_tune.optimizer.schedulers.multi_fidelity import (
+            MultiFidelitySchedulerMixin,
         )
 
         super().configure_scheduler(scheduler)
         assert isinstance(
-            scheduler, (HyperbandScheduler, SynchronousHyperbandScheduler)
-        ), (
-            "This searcher requires HyperbandScheduler or "
-            + "SynchronousHyperbandScheduler scheduler"
-        )
+            scheduler, MultiFidelitySchedulerMixin
+        ), "This searcher requires MultiFidelitySchedulerMixin scheduler"
+        self.resource_attr = scheduler.resource_attr
 
     def _train_model(self, train_data, train_targets):
         # find the highest resource level we have at least one data points of the positive class

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -683,11 +683,13 @@ class GPFIFOSearcher(ModelBasedSearcher):
         self._create_internal(**kwargs_int)
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
+        from syne_tune.optimizer.schedulers.scheduler_searcher import (
+            TrialSchedulerWithSearcher,
+        )
 
         assert isinstance(
-            scheduler, FIFOScheduler
-        ), "This searcher requires FIFOScheduler scheduler"
+            scheduler, TrialSchedulerWithSearcher
+        ), "This searcher requires TrialSchedulerWithSearcher scheduler"
         super().configure_scheduler(scheduler)
         # Allow model factory to depend on ``scheduler`` as well
         model_factory = self.state_transformer.model_factory

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -432,15 +432,6 @@ def _create_common_objects(model=None, is_hypertune=False, **kwargs):
                 **_kwargs,
             )
         )
-    elif model == "gp_independent":
-        result.update(
-            _create_gp_independent_model(
-                hp_ranges=hp_ranges,
-                active_metric=INTERNAL_METRIC_NAME,
-                random_seed=random_seed,
-                **_kwargs,
-            )
-        )
     else:
         result.update(
             _create_gp_additive_model(

--- a/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
@@ -74,17 +74,14 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
         self.resource_levels = []
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
-        from syne_tune.optimizer.schedulers.synchronous.hyperband import (
-            SynchronousHyperbandScheduler,
+        from syne_tune.optimizer.schedulers.multi_fidelity import (
+            MultiFidelitySchedulerMixin,
         )
 
+        super().configure_scheduler(scheduler)
         assert isinstance(
-            scheduler, (HyperbandScheduler, SynchronousHyperbandScheduler)
-        ), (
-            "This searcher requires HyperbandScheduler or "
-            + "SynchronousHyperbandScheduler scheduler"
-        )
+            scheduler, MultiFidelitySchedulerMixin
+        ), "This searcher requires MultiFidelitySchedulerMixin scheduler"
         self.resource_attr = scheduler.resource_attr
 
     def _train_kde(self, train_data, train_targets):

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -138,11 +138,13 @@ class RegularizedEvolution(SearcherWithRandomSeed):
             self.population.popleft()
 
     def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
+        from syne_tune.optimizer.schedulers.scheduler_searcher import (
+            TrialSchedulerWithSearcher,
+        )
 
         assert isinstance(
-            scheduler, FIFOScheduler
-        ), "This searcher requires FIFOScheduler scheduler"
+            scheduler, TrialSchedulerWithSearcher
+        ), "This searcher requires TrialSchedulerWithSearcher scheduler"
         super().configure_scheduler(scheduler)
 
     def clone_from_state(self, state: dict):

--- a/syne_tune/optimizer/schedulers/synchronous/dehb.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb.py
@@ -21,8 +21,10 @@ from syne_tune.optimizer.schedulers.synchronous.dehb_bracket_manager import (
 from syne_tune.optimizer.schedulers.synchronous.hyperband_bracket import (
     SlotInRung,
 )
+from syne_tune.optimizer.schedulers.synchronous.hyperband import (
+    SynchronousHyperbandCommon,
+)
 from syne_tune.optimizer.scheduler import TrialSuggestion, SchedulerDecision
-from syne_tune.optimizer.schedulers.fifo import ResourceLevelsScheduler
 from syne_tune.backend.trial_status import Trial
 from syne_tune.config_space import cast_config_values
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
@@ -34,12 +36,9 @@ from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
     Float,
     Boolean,
 )
-from syne_tune.optimizer.schedulers.random_seeds import RandomSeedGenerator
 from syne_tune.optimizer.schedulers.searchers.searcher import (
-    BaseSearcher,
     impute_points_to_evaluate,
 )
-from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_factory
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
     make_hyperparameter_ranges,
 )
@@ -49,8 +48,6 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
     DebugLogPrinter,
 )
-
-__all__ = ["DifferentialEvolutionHyperbandScheduler"]
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +60,12 @@ _ARGUMENT_KEYS = {
     "points_to_evaluate",
     "random_seed",
     "max_resource_attr",
+    "max_resource_level",
     "resource_attr",
     "mutation_factor",
     "crossover_probability",
     "support_pause_resume",
+    "searcher_data",
 }
 
 _DEFAULT_OPTIONS = {
@@ -76,6 +75,7 @@ _DEFAULT_OPTIONS = {
     "mutation_factor": 0.5,
     "crossover_probability": 0.5,
     "support_pause_resume": True,
+    "searcher_data": "rungs",
 }
 
 _CONSTRAINTS = {
@@ -83,10 +83,12 @@ _CONSTRAINTS = {
     "mode": Categorical(choices=("min", "max")),
     "random_seed": Integer(0, 2**32 - 1),
     "max_resource_attr": String(),
+    "max_resource_level": Integer(1, None),
     "resource_attr": String(),
     "mutation_factor": Float(lower=0, upper=1),
     "crossover_probability": Float(lower=0, upper=1),
     "support_pause_resume": Boolean(),
+    "searcher_data": Categorical(("rungs", "all")),
 }
 
 
@@ -125,7 +127,7 @@ class ExtendedSlotInRung:
         )
 
 
-class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
+class DifferentialEvolutionHyperbandScheduler(SynchronousHyperbandCommon):
     """
     Differential Evolution Hyperband, as proposed in
 
@@ -186,6 +188,12 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         containing the maximum resource. If given, trials need not be
         stopped, which can run more efficiently.
     :type max_resource_attr: str, optional
+    :param max_resource_level: Largest rung level, corresponds to ``max_t`` in
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive
+        int larger than ``grace_period``. If this is not given, it is inferred
+        like in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. In
+        particular, it is not needed if ``max_resource_attr`` is given.
+    :type max_resource_level: int, optional
     :param resource_attr: Name of resource attribute in results obtained via
         :meth:`on_trial_result`. The type of resource must be int. Default to
         "epoch"
@@ -203,6 +211,19 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         Note: The resumed trial still gets assigned a new ``trial_id``, but it
         starts from the earlier checkpoint.
     :type support_pause_resume: bool, optional
+    :param searcher_data: Relevant only if a model-based searcher is used.
+        Example: For NN tuning and ``resource_attr == "epoch"``, we receive a
+        result for each epoch, but not all epoch values are also rung levels.
+        searcher_data determines which of these results are passed to the
+        searcher. As a rule, the more data the searcher receives, the better
+        its fit, but also the more expensive get_config may become. Choices:
+
+        * "rungs" (default): Only results at rung levels. Cheapest
+        * "all": All results. Most expensive
+
+        Note: For a Gaussian additive learning curve surrogate model, this
+        has to be set to "all".
+    :type searcher_data: str, optional
     """
 
     MAX_RETRIES = 50
@@ -214,7 +235,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         num_brackets_per_iteration: Optional[int] = None,
         **kwargs,
     ):
-        super().__init__(config_space)
+        super().__init__(config_space, **kwargs)
         self._create_internal(rungs_first_bracket, num_brackets_per_iteration, **kwargs)
 
     def _create_internal(
@@ -234,38 +255,14 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
             _CONSTRAINTS,
             dict_name="scheduler_options",
         )
-        self.metric = kwargs.get("metric")
-        assert self.metric is not None, (
-            "Argument 'metric' is mandatory. Pass the name of the metric "
-            + "reported by your training script, which you'd like to "
-            + "optimize, and use 'mode' to specify whether it should "
-            + "be minimized or maximized"
-        )
-        self.mode = kwargs["mode"]
-        self.max_resource_attr = kwargs.get("max_resource_attr")
-        self._resource_attr = kwargs["resource_attr"]
         self.mutation_factor = kwargs["mutation_factor"]
         self.crossover_probability = kwargs["crossover_probability"]
         self._support_pause_resume = kwargs["support_pause_resume"]
-        # Generator for random seeds
-        random_seed = kwargs.get("random_seed")
-        if random_seed is None:
-            random_seed = np.random.randint(0, 2**32)
-        logger.info(f"Master random_seed = {random_seed}")
-        self.random_seed_generator = RandomSeedGenerator(random_seed)
-        # Generate searcher
-        searcher = kwargs["searcher"]
-        assert isinstance(
-            searcher, str
-        ), f"searcher must be of type string, but has type {type(searcher)}"
-        search_options = kwargs.get("search_options")
-        if search_options is None:
-            search_options = dict()
-        else:
-            search_options = search_options.copy()
+        search_options = self._create_internal_common(
+            skip_searchers={"random_encoded"}, **kwargs
+        )
         self._debug_log = None
-        if searcher == "random_encoded":
-            self.searcher = None
+        if self._searcher is None:
             if search_options.get("debug_log", True):
                 self._debug_log = DebugLogPrinter()
             points_to_evaluate = kwargs.get("points_to_evaluate")
@@ -273,29 +270,7 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
                 points_to_evaluate, self.config_space
             )
         else:
-            search_options.update(
-                {
-                    "config_space": self.config_space.copy(),
-                    "metric": self.metric,
-                    "points_to_evaluate": kwargs.get("points_to_evaluate"),
-                    "mode": kwargs["mode"],
-                    "random_seed_generator": self.random_seed_generator,
-                    "resource_attr": self._resource_attr,
-                    "scheduler": "hyperband_synchronous",
-                }
-            )
-            if searcher == "bayesopt":
-                # We need ``max_epochs`` in this case
-                max_epochs = self._infer_max_resource_level(
-                    max_resource_level=None, max_resource_attr=self.max_resource_attr
-                )
-                assert max_epochs is not None, (
-                    "If searcher='bayesopt', need to know the maximum resource "
-                    + "level. Please provide max_resource_attr argument."
-                )
-                search_options["max_epochs"] = max_epochs
-            self.searcher: BaseSearcher = searcher_factory(searcher, **search_options)
-            self._debug_log = self.searcher.debug_log
+            self._debug_log = self._searcher.debug_log
             self._points_to_evaluate = None
         # Bracket manager
         self.bracket_manager = DifferentialEvolutionHyperbandBracketManager(
@@ -310,9 +285,9 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         self.random_state = np.random.RandomState(self.random_seed_generator())
         # How often is selection skipped because target still pending?
         self.num_selection_skipped = 0
-        # Maps trial_id to ext_slot, as returned by ``bracket_manager.next_job``,
+        # Maps ``trial_id`` to ``ext_slot``, as returned by ``bracket_manager.next_job``,
         # and required by ``bracket_manager.on_result``. Entries are removed once
-        # passed to ``on_result``. Here, ext_slot is of type ``ExtendedSlotInRung``.
+        # passed to ``on_result``. Here, ``ext_slot`` is of type ``ExtendedSlotInRung``.
         self._trial_to_pending_slot = dict()
         # Maps trial_id to trial information (in particular, the encoded
         # config)
@@ -321,6 +296,15 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         # metric values are available). This global "parent pool" is used
         # during mutations if the normal parent pool is too small
         self._global_parent_pool = {level: [] for _, level in rungs_first_bracket}
+        self._rung_levels = [level for _, level in rungs_first_bracket]
+
+    @property
+    def rung_levels(self) -> List[int]:
+        return self._rung_levels
+
+    @property
+    def num_brackets(self) -> int:
+        return len(self.bracket_manager.bracket_rungs)
 
     def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
         if self._excl_list.config_space_exhausted():
@@ -382,10 +366,10 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
                     )
             else:
                 # Draw encoded config at random
-                restore_searcher = self.searcher
-                self.searcher = None
+                restore_searcher = self._searcher
+                self._searcher = None
                 encoded_config = self._encoded_config_from_searcher(trial_id)
-                self.searcher = restore_searcher
+                self._searcher = restore_searcher
             if encoded_config is None:
                 break  # Searcher failed to return config
             if promoted_from_trial_id is not None:
@@ -568,15 +552,19 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
                     trial_decision = SchedulerDecision.PAUSE
                 else:
                     trial_decision = SchedulerDecision.STOP
-                if self.searcher is not None:
+                prev_level = self.bracket_manager.level_to_prev_level(
+                    ext_slot.bracket_id, milestone
+                )
+                if resource > prev_level and self.searcher is not None:
                     config = self._hp_ranges.from_ndarray(
                         self._trial_info[trial_id].encoded_config
                     )
+                    update = self.searcher_data == "all" or resource == milestone
                     self.searcher.on_trial_result(
                         trial_id=str(trial_id),
                         config=config,
                         result=result,
-                        update=True,
+                        update=update,
                     )
         else:
             trial_decision = SchedulerDecision.STOP
@@ -736,9 +724,8 @@ class DifferentialEvolutionHyperbandScheduler(ResourceLevelsScheduler):
         and will most likely not be promoted.
 
         """
+        super().on_trial_error(trial)
         trial_id = trial.trial_id
-        if self.searcher is not None:
-            self.searcher.evaluation_failed(str(trial_id))
         if trial_id in self._trial_to_pending_slot:
             ext_slot = self._trial_to_pending_slot[trial_id]
             self._report_as_failed(ext_slot)

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Optional, List
+from typing import Optional, List, Set
 import logging
 import numpy as np
 
@@ -22,7 +22,8 @@ from syne_tune.optimizer.schedulers.synchronous.hyperband_rung_system import (
     RungSystemsPerBracket,
 )
 from syne_tune.optimizer.scheduler import TrialSuggestion, SchedulerDecision
-from syne_tune.optimizer.schedulers.fifo import ResourceLevelsScheduler
+from syne_tune.optimizer.schedulers.scheduler_searcher import TrialSchedulerWithSearcher
+from syne_tune.optimizer.schedulers.multi_fidelity import MultiFidelitySchedulerMixin
 from syne_tune.backend.trial_status import Trial
 from syne_tune.config_space import cast_config_values
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
@@ -32,11 +33,8 @@ from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
     assert_no_invalid_options,
     Integer,
 )
-from syne_tune.optimizer.schedulers.random_seeds import RandomSeedGenerator
 from syne_tune.optimizer.schedulers.searchers.searcher import BaseSearcher
 from syne_tune.optimizer.schedulers.searchers.searcher_factory import searcher_factory
-
-__all__ = ["SynchronousHyperbandScheduler"]
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +47,7 @@ _ARGUMENT_KEYS = {
     "points_to_evaluate",
     "random_seed",
     "max_resource_attr",
+    "max_resource_level",
     "resource_attr",
     "searcher_data",
 }
@@ -65,12 +64,91 @@ _CONSTRAINTS = {
     "mode": Categorical(choices=("min", "max")),
     "random_seed": Integer(0, 2**32 - 1),
     "max_resource_attr": String(),
+    "max_resource_level": Integer(1, None),
     "resource_attr": String(),
     "searcher_data": Categorical(("rungs", "all")),
 }
 
 
-class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
+class SynchronousHyperbandCommon(
+    TrialSchedulerWithSearcher, MultiFidelitySchedulerMixin
+):
+    """
+    Common code for :meth:`_create_internal` in
+    :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
+    and
+    :class:`~syne_tune.optimizer.schedulers.synchronous.DifferentialEvolutionHyperbandScheduler`
+    """
+
+    def _create_internal_common(
+        self, skip_searchers: Optional[Set[str]] = None, **kwargs
+    ) -> dict:
+        self.metric = kwargs.get("metric")
+        assert self.metric is not None, (
+            "Argument 'metric' is mandatory. Pass the name of the metric "
+            + "reported by your training script, which you'd like to "
+            + "optimize, and use 'mode' to specify whether it should "
+            + "be minimized or maximized"
+        )
+        self.mode = kwargs["mode"]
+        self.max_resource_attr = kwargs.get("max_resource_attr")
+        self._resource_attr = kwargs["resource_attr"]
+        self._max_resource_level = self._infer_max_resource_level(
+            max_resource_level=kwargs.get("max_resource_level"),
+            max_resource_attr=self.max_resource_attr,
+        )
+        assert self._max_resource_level is not None, (
+            "Maximum resource level has to be specified, please provide "
+            "max_resource_attr or max_resource_level argument."
+        )
+        self._searcher_data = kwargs["searcher_data"]
+        # Generate searcher
+        searcher = kwargs["searcher"]
+        assert isinstance(
+            searcher, str
+        ), f"searcher must be of type string, but has type {type(searcher)}"
+        search_options = kwargs.get("search_options")
+        if search_options is None:
+            search_options = dict()
+        else:
+            search_options = search_options.copy()
+        if skip_searchers is None or searcher not in skip_searchers:
+            search_options.update(
+                {
+                    "config_space": self.config_space.copy(),
+                    "metric": self.metric,
+                    "points_to_evaluate": kwargs.get("points_to_evaluate"),
+                    "mode": kwargs["mode"],
+                    "random_seed_generator": self.random_seed_generator,
+                    "resource_attr": self._resource_attr,
+                    "scheduler": "hyperband_synchronous",
+                }
+            )
+            if searcher == "bayesopt":
+                search_options["max_epochs"] = self._max_resource_level
+            self._searcher: BaseSearcher = searcher_factory(searcher, **search_options)
+        else:
+            self._searcher = None
+        return search_options
+
+    @property
+    def searcher(self) -> Optional[BaseSearcher]:
+        return self._searcher
+
+    @property
+    def resource_attr(self) -> str:
+        return self._resource_attr
+
+    @property
+    def max_resource_level(self) -> int:
+        return self._max_resource_level
+
+    @property
+    def searcher_data(self) -> str:
+        return self._searcher_data
+
+
+class SynchronousHyperbandScheduler(SynchronousHyperbandCommon):
     """
     Synchronous Hyperband. Compared to
     :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`, this is also
@@ -117,6 +195,12 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
         containing the maximum resource. If given, trials need not be
         stopped, which can run more efficiently.
     :type max_resource_attr: str, optional
+    :param max_resource_level: Largest rung level, corresponds to ``max_t`` in
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive
+        int larger than ``grace_period``. If this is not given, it is inferred
+        like in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. In
+        particular, it is not needed if ``max_resource_attr`` is given.
+    :type max_resource_level: int, optional
     :param resource_attr: Name of resource attribute in results obtained via
         ``:meth:`on_trial_result`. The type of resource must be int. Default to
         "epoch"
@@ -139,8 +223,7 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
     def __init__(
         self, config_space: dict, bracket_rungs: RungSystemsPerBracket, **kwargs
     ):
-        """ """
-        super().__init__(config_space)
+        super().__init__(config_space, **kwargs)
         self._create_internal(bracket_rungs, **kwargs)
 
     def _create_internal(self, bracket_rungs: RungSystemsPerBracket, **kwargs):
@@ -151,59 +234,12 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
         kwargs = check_and_merge_defaults(
             kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS, dict_name="scheduler_options"
         )
-        self.metric = kwargs.get("metric")
-        assert self.metric is not None, (
-            "Argument 'metric' is mandatory. Pass the name of the metric "
-            + "reported by your training script, which you'd like to "
-            + "optimize, and use 'mode' to specify whether it should "
-            + "be minimized or maximized"
-        )
-        self.mode = kwargs["mode"]
-        self.max_resource_attr = kwargs.get("max_resource_attr")
-        self._resource_attr = kwargs["resource_attr"]
-        # Generator for random seeds
-        random_seed = kwargs.get("random_seed")
-        if random_seed is None:
-            random_seed = np.random.randint(0, 2**32)
-        logger.info(f"Master random_seed = {random_seed}")
-        self.random_seed_generator = RandomSeedGenerator(random_seed)
-        # Generate searcher
-        searcher = kwargs["searcher"]
-        assert isinstance(
-            searcher, str
-        ), f"searcher must be of type string, but has type {type(searcher)}"
-        search_options = kwargs.get("search_options")
-        if search_options is None:
-            search_options = dict()
-        else:
-            search_options = search_options.copy()
-        search_options.update(
-            {
-                "config_space": self.config_space.copy(),
-                "metric": self.metric,
-                "points_to_evaluate": kwargs.get("points_to_evaluate"),
-                "mode": kwargs["mode"],
-                "random_seed_generator": self.random_seed_generator,
-                "resource_attr": self._resource_attr,
-                "scheduler": "hyperband_synchronous",
-            }
-        )
-        if searcher == "bayesopt":
-            # We need ``max_epochs`` in this case
-            max_epochs = self._infer_max_resource_level(
-                max_resource_level=None, max_resource_attr=self.max_resource_attr
-            )
-            assert max_epochs is not None, (
-                "If searcher='bayesopt', need to know the maximum resource "
-                + "level. Please provide max_resource_attr argument."
-            )
-            search_options["max_epochs"] = max_epochs
-        self.searcher: BaseSearcher = searcher_factory(searcher, **search_options)
+        self._create_internal_common(**kwargs)
         # Bracket manager
         self.bracket_manager = SynchronousHyperbandBracketManager(
-            bracket_rungs, mode=self.mode
+            bracket_rungs,
+            mode=self.mode,
         )
-        self.searcher_data = kwargs["searcher_data"]
         # Maps trial_id to tuples (bracket_id, slot_in_rung), as returned
         # by ``bracket_manager.next_job``, and required by
         # ``bracket_manager.on_result``. Entries are removed once passed to
@@ -212,10 +248,15 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
         self._trial_to_pending_slot = dict()
         # Maps trial_id (active) to config
         self._trial_to_config = dict()
+        self._rung_levels = [level for _, level in bracket_rungs[0]]
 
     @property
-    def resource_attr(self) -> str:
-        return self._resource_attr
+    def rung_levels(self) -> List[int]:
+        return self._rung_levels
+
+    @property
+    def num_brackets(self) -> int:
+        return len(self.bracket_manager.bracket_rungs)
 
     def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
         do_debug_log = self.searcher.debug_log is not None
@@ -304,7 +345,6 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
             )
             resource = int(result[self._resource_attr])
             milestone = slot_in_rung.level
-            prev_level = self.bracket_manager.level_to_prev_level(bracket_id, milestone)
             trial_decision = SchedulerDecision.CONTINUE
             if resource >= milestone:
                 assert resource == milestone, (
@@ -319,6 +359,7 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
                 del self._trial_to_pending_slot[trial_id]
                 # Trial should be paused
                 trial_decision = SchedulerDecision.PAUSE
+            prev_level = self.bracket_manager.level_to_prev_level(bracket_id, milestone)
             if resource > prev_level:
                 # If the training script does not implement checkpointing, each
                 # trial starts from scratch. In this case, the condition
@@ -347,8 +388,8 @@ class SynchronousHyperbandScheduler(ResourceLevelsScheduler):
         and will most likely not be promoted.
 
         """
+        super().on_trial_error(trial)
         trial_id = trial.trial_id
-        self.searcher.evaluation_failed(str(trial_id))
         if trial_id in self._trial_to_pending_slot:
             bracket_id, slot_in_rung = self._trial_to_pending_slot[trial_id]
             self._report_as_failed(bracket_id, slot_in_rung)

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from syne_tune.optimizer.scheduler import TrialScheduler
+from syne_tune.optimizer.schedulers.scheduler_searcher import TrialSchedulerWithSearcher
 from syne_tune.optimizer.schedulers.synchronous.hyperband import (
     SynchronousHyperbandScheduler,
 )
@@ -28,7 +28,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
 )
 
 
-_ARGUMENT_KEYS = {"grace_period", "max_resource_level", "reduction_factor", "brackets"}
+_ARGUMENT_KEYS = {"grace_period", "reduction_factor", "brackets"}
 
 _DEFAULT_OPTIONS = {
     "grace_period": 1,
@@ -37,7 +37,6 @@ _DEFAULT_OPTIONS = {
 
 _CONSTRAINTS = {
     "grace_period": Integer(1, None),
-    "max_resource_level": Integer(1, None),
     "reduction_factor": Float(2, None),
     "brackets": Integer(1, None),
 }
@@ -87,9 +86,10 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_level: Largest rung level, corresponds to ``max_t`` in
-        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
-        ``grace_period``. If this is not given, it is inferred like in
-        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive
+        int larger than ``grace_period``. If this is not given, it is inferred
+        like in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. In
+        particular, it is not needed if ``max_resource_attr`` is given.
     :type max_resource_level: int, optional
     :param max_resource_attr: Key name in config for fixed attribute
         containing the maximum resource. If given, trials need not be
@@ -115,14 +115,13 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
     """
 
     def __init__(self, config_space: dict, **kwargs):
-        TrialScheduler.__init__(self, config_space)
+        TrialSchedulerWithSearcher.__init__(self, config_space, **kwargs)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(
             kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS, dict_name="scheduler_options"
         )
         self.grace_period = kwargs["grace_period"]
         self.reduction_factor = kwargs["reduction_factor"]
-        num_brackets = kwargs.get("brackets")
         max_resource_level = self._infer_max_resource_level(
             kwargs.get("max_resource_level"), kwargs.get("max_resource_attr")
         )
@@ -131,12 +130,11 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
             + "explicit argument 'max_resource_level', or as entry in "
             + "'config_space', with name 'max_resource_attr'"
         )
-        self.max_resource_level = max_resource_level
         bracket_rungs = SynchronousHyperbandRungSystem.geometric(
             min_resource=self.grace_period,
             max_resource=max_resource_level,
             reduction_factor=self.reduction_factor,
-            num_brackets=num_brackets,
+            num_brackets=kwargs.get("brackets"),
         )
         self._create_internal(bracket_rungs, **filter_by_key(kwargs, _ARGUMENT_KEYS))
 
@@ -190,9 +188,10 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
         If not given, the master random seed is drawn at random here.
     :type random_seed: int, optional
     :param max_resource_level: Largest rung level, corresponds to ``max_t`` in
-        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive int larger than
-        ``grace_period``. If this is not given, it is inferred like in
-        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. Must be positive
+        int larger than ``grace_period``. If this is not given, it is inferred
+        like in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. In
+        particular, it is not needed if ``max_resource_attr`` is given.
     :type max_resource_level: int, optional
     :param max_resource_attr: Key name in config for fixed attribute
         containing the maximum resource. If given, trials need not be
@@ -218,7 +217,7 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
     """
 
     def __init__(self, config_space: dict, **kwargs):
-        TrialScheduler.__init__(self, config_space)
+        TrialSchedulerWithSearcher.__init__(self, config_space, **kwargs)
         # Additional parameters to determine rung systems
         kwargs = check_and_merge_defaults(
             kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS, dict_name="scheduler_options"
@@ -236,7 +235,6 @@ class GeometricDifferentialEvolutionHyperbandScheduler(
             + f"max_resource_attr = {kwargs.get('max_resource_attr')}\n"
             + f"config_space = {config_space}"
         )
-        self.max_resource_level = max_resource_level
         bracket_rungs = SynchronousHyperbandRungSystem.geometric(
             min_resource=self.grace_period,
             max_resource=max_resource_level,

--- a/syne_tune/tuning_status.py
+++ b/syne_tune/tuning_status.py
@@ -80,7 +80,6 @@ class TuningStatus:
 
     # TODO: ``metric_names`` not used for anything. Remove?
     def __init__(self, metric_names: List[str]):
-        """ """
         self.metric_names = metric_names
         self.start_time = time.perf_counter()
 

--- a/tst/schedulers/test_hyperband.py
+++ b/tst/schedulers/test_hyperband.py
@@ -86,7 +86,7 @@ def test_register_pending():
         new_searcher = MyRandomSearcher(
             old_searcher.config_space, metric=old_searcher._metric
         )
-        scheduler.searcher = new_searcher
+        scheduler._searcher = new_searcher
 
         # Start 4 trials (0, 1, 2, 3)
         trials = dict()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Major refactoring/simplification of model-based searchers and schedulers, along with bug fixes for HyperTune and SyncMOBSTER. In detail:

- Allow to ignore BB hash checking as an option
- nursery/benchmark_yahpo: Also allow for MOBSTER
- Extend developer tutorial corresponding to refactoring
- Replacing logging by logger in some code
- Remove defaults in baselines.HyperTune
- Refactoring: Collect common code in TrialSchedulerWithSearcher, which extends ResourceLevelsScheduler, and makes sure self.searcher.configure_scheduler is called
- Refactoring: MultiFidelitySchedulerMixin as API for multi-fidelity schedulers, allows for configure_scheduler implementations of searchers
- Special case "hypertune" searcher in HyperbandScheduler: Number of brackets is needed for construction
- HyperbandScheduker: rung_levels does not include max_resource_level
- Simplify RungSystem subclasses: Always pass max_t, not contained in rung_levels
- Rewrite configure_scheduler methods to use TrialSchedulerWithSearcher, MultiFidelitySchedulerMixin instead of specific classes
- SynchronousHyperbandCommon: Common code for constructing SynchronousHyperbandScheduler, DifferentialEvolutionHyperbandScheduler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
