### PR TITLE
Management of random seeds in benchmarking

### DIFF
--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -76,6 +76,11 @@ def parse_args(
         type=int,
         help="Maximum runtime for experiment (overwrites default of benchmark)",
     )
+    parser.add_argument(
+        "--random_seed",
+        type=int,
+        help="Master random seed (drawn at random if not given)",
+    )
     if extra_args is not None:
         extra_args = copy.deepcopy(extra_args)
         for kwargs in extra_args:
@@ -104,6 +109,7 @@ def get_metadata(
     method: str,
     experiment_tag: str,
     benchmark_name: str,
+    random_seed: int,
     benchmark: Optional[BenchmarkDefinition] = None,
     extra_args: Optional[dict] = None,
 ) -> Dict[str, Any]:
@@ -113,6 +119,7 @@ def get_metadata(
     :param method: Name of method
     :param experiment_tag: Tag of experiment
     :param benchmark_name: Name of benchmark
+    :param random_seed: Master random seed
     :param benchmark: Optional. Take ``n_workers``, ``max_wallclock_time``
         from there
     :param extra_args: ``metadata`` updated by these at the end. Optional
@@ -123,6 +130,7 @@ def get_metadata(
         "algorithm": method,
         "tag": experiment_tag,
         "benchmark": benchmark_name,
+        "random_seed": random_seed,
     }
     if benchmark is not None:
         metadata.update(

--- a/benchmarking/commons/utils.py
+++ b/benchmarking/commons/utils.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 from pathlib import Path
 from typing import Optional
+import numpy as np
 
 from syne_tune.util import s3_experiment_path
 
@@ -93,3 +94,17 @@ def find_or_create_requirements_txt(
     else:
         fname = files[0]
     return fname
+
+
+SEED_UPPER_LIMIT = 2**32
+
+
+def get_master_random_seed(random_seed: Optional[int]) -> int:
+    if random_seed is None:
+        random_seed = np.random.randint(0, SEED_UPPER_LIMIT)
+    print(f"Master random_seed = {random_seed}")
+    return random_seed
+
+
+def effective_random_seed(master_random_seed: int, seed: int) -> int:
+    return (master_random_seed + seed) % SEED_UPPER_LIMIT

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -104,7 +104,8 @@ This call runs a number of experiments sequentially on the local machine:
   Fortunately, these are cheap to obtain in the simulation context. Another
   parameter is ``start_seed`` (default: 0), giving seeds
   ``start_seed, ..., num_seeds - 1``. For example, ``--start_seed 5  --num_seeds 6``
-  runs for a single seed equal to 5.
+  runs for a single seed equal to 5. The dependence of random choices on the
+  seed is detailed `below <bm_local.html#random-seeds-and-paired-comparisons>`_.
 * ``max_wallclock_time``, ``n_workers``: These arguments overwrite the defaults
   specified in the benchmark definitions.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Experiments which compare methods against each other, should share the same "master random seed", to which the repetition seed (0, 1, ...) is added. The current code just uses the repetition seed.

This is a problem of low entropy. Also, we want to pull together "real benchmark" data into new surrogate blackboxes, so we need to use different random seeds.

On the other hand, when comparing methods against each other, the same random seed (per repetition) should be used, which reduces variance between them (this is called "paired comparison"). So, the same master random seed should be used across an experiment, at least for the same benchmark.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
