### PR TITLE
Different searchers suggest same initial random configs. New methods …

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ BOHB | Falkner, et al. (2018) | model-based | yes | yes | no
 MOBSTER | Klein, et al. (2020) | model-based | yes | yes | no 
 DEHB | Awad, et al. (2021) | evolutionary | no | yes | no 
 HyperTune | Li, et al. (2022) | model-based | yes | yes | no 
+ASHABORE | Tiao, et al. (2021) | model-based | yes | yes | no 
 PASHA | Bohdal, et al. (2022)| random or model-based | yes | yes | no 
 REA | Real, et al. (2019) | evolutionary | yes | no | no 
+KDE | Falkner, et al. (2018) | model-based | yes | no | no 
 PBT | Jaderberg, et al. (2017) | evolutionary | no | yes | no 
 ZeroShotTransfer | Wistuba, et al. (2015) | deterministic | yes | no | yes 
 ASHA-CTS | Salinas, et al. (2021)| random | yes | yes | yes 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -135,9 +135,13 @@ The following hyperparameter optimization (HPO) methods are available in Syne Tu
 +---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
 | `HyperTune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`_                 | `Li, et al. (2022) <https://arxiv.org/abs/2201.06834>`_                        | model-based   | yes           | yes             | no        |
 +---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.ASHABORE`                                      | `Tiao, et al. (2021) <https://proceedings.mlr.press/v139/tiao21a.html>`_       | model-based   | yes           | yes             | no        |
++---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
 | :class:`~syne_tune.optimizer.baselines.PASHA`                                         | `Bohdal, et al. (2022) <https://arxiv.org/abs/2207.06940>`_                    | random        | yes           | yes             | no        |
 +---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
 | :class:`~syne_tune.optimizer.baselines.REA`                                           | `Real, et al. (2019) <https://arxiv.org/abs/1802.01548>`_                      | evolutionary  | yes           | no              | no        |
++---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.KDE`                                           | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`_                   | model-based   | yes           | no              | no        |
 +---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
 | :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining`                      | `Jaderberg, et al. (2017) <https://arxiv.org/abs/1711.09846>`_                 | evolutionary  | no            | yes             | no        |
 +---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
@@ -150,7 +154,8 @@ The following hyperparameter optimization (HPO) methods are available in Syne Tu
 
 The searchers fall into four broad categories, **deterministic**, **random**, **evolutionary** and **model-based**. The random searchers sample candidate hyperparameter configurations uniformly at random, while the model-based searchers sample them non-uniformly at random, according to a model (e.g., Gaussian process, density ration estimator, etc.) and an acquisition function. The evolutionary searchers make use of an evolutionary algorithm.
 
-Syne Tune also supports `BoTorch <https://github.com/pytorch/botorch>`_ searchers.
+Syne Tune also supports `BoTorch <https://github.com/pytorch/botorch>`_ searchers,
+see :class:`~syne_tune.optimizer.baselines.BOTorch`.
 
 Supported multi-objective optimization methods
 ----------------------------------------------

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -45,12 +45,6 @@ from syne_tune.optimizer.schedulers.searchers.bracket_distribution import (
     DefaultHyperbandBracketDistribution,
 )
 
-__all__ = [
-    "HyperbandScheduler",
-    "HyperbandBracketManager",
-    "hyperband_rung_levels",
-]
-
 logger = logging.getLogger(__name__)
 
 
@@ -974,7 +968,10 @@ def hyperband_rung_levels(
         ), f"max_t ({max_t}) must be greater than grace_period ({grace_period})"
         rf = reduction_factor
         min_t = grace_period
-        max_rungs = int(np.log(max_t / min_t) / np.log(rf) + 1)
+        max_rungs = 0
+        while min_t * np.power(rf, max_rungs) < max_t:
+            max_rungs += 1
+        max_rungs += 1
         rung_levels = [int(round(min_t * np.power(rf, k))) for k in range(max_rungs)]
         assert rung_levels[-1] <= max_t  # Sanity check
     if rung_levels[-1] == max_t:

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -971,7 +971,6 @@ def hyperband_rung_levels(
         max_rungs = 0
         while min_t * np.power(rf, max_rungs) < max_t:
             max_rungs += 1
-        max_rungs += 1
         rung_levels = [int(round(min_t * np.power(rf, k))) for k in range(max_rungs)]
         assert rung_levels[-1] <= max_t  # Sanity check
     if rung_levels[-1] == max_t:

--- a/syne_tune/optimizer/schedulers/searchers/__init__.py
+++ b/syne_tune/optimizer/schedulers/searchers/__init__.py
@@ -17,10 +17,12 @@ from syne_tune.try_import import try_import_gpsearchers_message
 from syne_tune.optimizer.schedulers.searchers.searcher import (  # noqa: F401
     BaseSearcher,
     SearcherWithRandomSeed,
-    RandomSearcher,
-    GridSearcher,
     impute_points_to_evaluate,
     extract_random_seed,
+)
+from syne_tune.optimizer.schedulers.searchers.random_grid_searcher import (  # noqa: F401
+    RandomSearcher,
+    GridSearcher,
 )
 from syne_tune.optimizer.schedulers.searchers.searcher_factory import (  # noqa: F401
     searcher_factory,
@@ -29,10 +31,10 @@ from syne_tune.optimizer.schedulers.searchers.searcher_factory import (  # noqa:
 __all__ = [
     "BaseSearcher",
     "SearcherWithRandomSeed",
-    "RandomSearcher",
-    "GridSearcher",
     "impute_points_to_evaluate",
     "extract_random_seed",
+    "RandomSearcher",
+    "GridSearcher",
     "searcher_factory",
 ]
 

--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     print(try_import_botorch_message())
 
-import syne_tune.config_space as cs
 from syne_tune.optimizer.schedulers.searchers.searcher import (
     SearcherWithRandomSeed,
     sample_random_configuration,

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -18,8 +18,8 @@ import time
 
 from syne_tune.optimizer.schedulers.searchers.searcher import (
     SearcherWithRandomSeed,
-    RandomSearcher,
 )
+from syne_tune.optimizer.schedulers.searchers import RandomSearcher
 from syne_tune.optimizer.schedulers.searchers.gp_searcher_factory import (
     gp_fifo_searcher_factory,
     gp_fifo_searcher_defaults,

--- a/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_searcher_factory.py
@@ -28,7 +28,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.kernel_factory imp
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.config_ext import (
     ExtendedConfiguration,
 )
-from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges import (
+from syne_tune.optimizer.schedulers.searchers.utils import (
     HyperparameterRanges,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.constants import (

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -16,10 +16,19 @@ import numpy as np
 import statsmodels.api as sm
 import scipy.stats as sps
 
-from syne_tune.optimizer.schedulers.searchers import SearcherWithRandomSeed
+from syne_tune.optimizer.schedulers.searchers.searcher import (
+    SearcherWithRandomSeed,
+    sample_random_configuration,
+)
 import syne_tune.config_space as sp
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
     DebugLogPrinter,
+)
+from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
+    make_hyperparameter_ranges,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common import (
+    ExclusionList,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,7 +64,10 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
     :param mode: Mode to use for the metric given, can be "min" or "max". Is
         obtained from scheduler in :meth:`configure_scheduler`. Defaults to "min"
     :param num_min_data_points: Minimum number of data points that we use to fit
-        the KDEs. If set to ``None``, we set this to the number of hyperparameters.
+        the KDEs. As long as less observations have been received in
+        :meth:`update`, randomly drawn configurations are returned in
+        :meth:`get_config`.
+        If set to ``None``, we set this to the number of hyperparameters.
         Defaults to ``None``.
     :param top_n_percent: Determines how many datapoints we use to fit the first
         KDE model for modeling the well performing configurations.
@@ -142,8 +154,13 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
         self.num_min_data_points = (
             len(self.vartypes) if num_min_data_points is None else num_min_data_points
         )
-        assert self.num_min_data_points >= len(self.vartypes)
+        assert self.num_min_data_points >= len(
+            self.vartypes
+        ), f"num_min_data_points = {num_min_data_points}, must be >= {len(self.vartypes)}"
         self._resource_attr = kwargs.get("resource_attr")
+        # Used for sampling initial random configs, and to avoid duplicates
+        self._hp_ranges = make_hyperparameter_ranges(self.config_space)
+        self._excl_list = ExclusionList.empty_list(self._hp_ranges)
         # Debug log printing (switched on by default)
         debug_log = kwargs.get("debug_log", True)
         if isinstance(debug_log, bool):
@@ -253,6 +270,17 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
             msg = f"Update for trial_id {trial_id}: metric = {metric_val:.3f}"
             logger.info(msg)
 
+    def _get_random_config(
+        self, exclusion_list: Optional[ExclusionList] = None
+    ) -> dict:
+        if exclusion_list is None:
+            exclusion_list = self._excl_list
+        return sample_random_configuration(
+            hp_ranges=self._hp_ranges,
+            random_state=self.random_state,
+            exclusion_list=exclusion_list,
+        )
+
     def get_config(self, **kwargs) -> Optional[dict]:
         suggestion = self._next_initial_config()
         if suggestion is None:
@@ -261,17 +289,15 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
             if models is None or self.random_state.rand() < self.random_fraction:
                 # return random candidate because a) we don't have enough data points or
                 # b) we sample some fraction of all samples randomly
-                suggestion = {
-                    k: v.sample() if isinstance(v, sp.Domain) else v
-                    for k, v in self.config_space.items()
-                }
+                suggestion = self._get_random_config()
             else:
                 self.bad_kde = models[0]
                 self.good_kde = models[1]
                 l = self.good_kde.pdf
                 g = self.bad_kde.pdf
 
-                acquisition_function = lambda x: max(1e-32, g(x)) / max(l(x), 1e-32)
+                def acquisition_function(x):
+                    return max(1e-32, g(x)) / max(l(x), 1e-32)
 
                 current_best = None
                 val_current_best = None
@@ -322,12 +348,17 @@ class KernelDensityEstimator(SearcherWithRandomSeed):
                             "candidate has non finite acquisition function value"
                         )
 
-                    if val_current_best is None or val_current_best > val:
-                        current_best = candidate
+                    config = self._from_feature(candidate)
+                    if (
+                        val_current_best is None or val_current_best > val
+                    ) and not self._excl_list.contains(config):
+                        current_best = config
                         val_current_best = val
 
-                suggestion = self._from_feature(feature_vector=current_best)
+                suggestion = current_best
 
+        if suggestion is not None:
+            self._excl_list.add(suggestion)
         return suggestion
 
     def _train_kde(self, train_data, train_targets):

--- a/syne_tune/optimizer/schedulers/searchers/random_grid_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/random_grid_searcher.py
@@ -1,0 +1,358 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+from collections import OrderedDict
+from itertools import product
+from typing import Optional, List, Dict
+
+import numpy as np
+
+from syne_tune.config_space import (
+    Float,
+    Integer,
+    Categorical,
+    FiniteRange,
+    Domain,
+    config_space_size,
+)
+from syne_tune.optimizer.schedulers.searchers.searcher import (
+    SearcherWithRandomSeed,
+    sample_random_configuration,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common import (
+    ExclusionList,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
+    DebugLogPrinter,
+)
+from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
+
+logger = logging.getLogger(__name__)
+
+
+class RandomSearcher(SearcherWithRandomSeed):
+    """
+    Searcher which randomly samples configurations to try next.
+
+    Additional arguments on top of parent class :class:`SearcherWithRandomSeed`:
+
+    :param debug_log: If ``True``, debug log printing is activated.
+        Logs which configs are chosen when, and which metric values are
+        obtained. Defaults to ``False``
+    :type debug_log: bool, optional
+    :param resource_attr: Optional. Key in ``result`` passed to :meth:`_update`
+        for resource value (for multi-fidelity schedulers)
+    :type resource_attr: str, optional
+    """
+
+    def __init__(
+        self,
+        config_space: dict,
+        metric: str,
+        points_to_evaluate: Optional[List[dict]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs
+        )
+        self._hp_ranges = make_hyperparameter_ranges(config_space)
+        self._resource_attr = kwargs.get("resource_attr")
+        # Used to avoid returning the same config more than once:
+        self._excl_list = ExclusionList.empty_list(self._hp_ranges)
+        # Debug log printing (switched off by default)
+        debug_log = kwargs.get("debug_log", False)
+        if isinstance(debug_log, bool):
+            if debug_log:
+                self._debug_log = DebugLogPrinter()
+            else:
+                self._debug_log = None
+        else:
+            assert isinstance(debug_log, DebugLogPrinter)
+            self._debug_log = debug_log
+
+    def configure_scheduler(self, scheduler):
+        from syne_tune.optimizer.schedulers.multi_fidelity import (
+            MultiFidelitySchedulerMixin,
+        )
+
+        super().configure_scheduler(scheduler)
+        # If the scheduler is multi-fidelity, we want to know the resource
+        # attribute, this is used for ``debug_log``
+        if isinstance(scheduler, MultiFidelitySchedulerMixin):
+            self._resource_attr = scheduler.resource_attr
+
+    def get_config(self, **kwargs) -> Optional[dict]:
+        """Sample a new configuration at random
+
+        This is done without replacement, so previously returned configs are
+        not suggested again.
+
+        :param trial_id: Optional. Used for ``debug_log``
+        :return: New configuration, or None
+        """
+        new_config = self._next_initial_config()
+        if new_config is None:
+            new_config = sample_random_configuration(
+                hp_ranges=self._hp_ranges,
+                random_state=self.random_state,
+                exclusion_list=self._excl_list,
+            )
+        if new_config is not None:
+            self._excl_list.add(new_config)  # Should not be suggested again
+            if self._debug_log is not None:
+                trial_id = kwargs.get("trial_id")
+                self._debug_log.start_get_config("random", trial_id=trial_id)
+                self._debug_log.set_final_config(new_config)
+                # All get_config debug log info is only written here
+                self._debug_log.write_block()
+        else:
+            msg = (
+                "Failed to sample a configuration not already chosen "
+                + f"before. Exclusion list has size {len(self._excl_list)}."
+            )
+            cs_size = self._excl_list.configspace_size
+            if cs_size is not None:
+                msg += f" Configuration space has size {cs_size}."
+            logger.warning(msg)
+        return new_config
+
+    def _update(self, trial_id: str, config: dict, result: dict):
+        if self._debug_log is not None:
+            metric_val = result[self._metric]
+            if self._resource_attr is not None:
+                # For HyperbandScheduler, also add the resource attribute
+                resource = int(result[self._resource_attr])
+                trial_id = trial_id + f":{resource}"
+            msg = f"Update for trial_id {trial_id}: metric = {metric_val:.3f}"
+            logger.info(msg)
+
+    def clone_from_state(self, state: dict):
+        new_searcher = RandomSearcher(
+            self.config_space,
+            metric=self._metric,
+            points_to_evaluate=[],
+            debug_log=self._debug_log,
+        )
+        new_searcher._resource_attr = self._resource_attr
+        new_searcher._restore_from_state(state)
+        return new_searcher
+
+    @property
+    def debug_log(self):
+        return self._debug_log
+
+
+DEFAULT_NSAMPLE = 5
+
+
+class GridSearcher(SearcherWithRandomSeed):
+    """Searcher that samples configurations from an equally spaced grid over config_space.
+
+    It first evaluates configurations defined in points_to_evaluate and then
+    continues with the remaining points from the grid.
+
+    Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
+
+    :param num_samples: Dictionary, optional. Number of samples per
+        hyperparameter. This is required for hyperparameters of type float,
+        optional for integer hyperparameters, and will be ignored for
+        other types (categorical, scalar). If left unspecified, a default
+        value of :const:`DEFAULT_NSAMPLE` will be used for float parameters, and
+        the smallest of :const:`DEFAULT_NSAMPLE` and integer range will be used
+        for integer parameters.
+    :param shuffle_config: If ``True`` (default), the order of configurations
+        suggested after those specified in ``points_to_evaluate`` is
+        shuffled. Otherwise, the order will follow the Cartesian product
+        of the configurations.
+    """
+
+    def __init__(
+        self,
+        config_space: dict,
+        metric: str,
+        points_to_evaluate: Optional[List[dict]] = None,
+        num_samples: Optional[Dict[str, int]] = None,
+        shuffle_config: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs
+        )
+        self._validate_config_space(config_space, num_samples)
+        self._hp_ranges = make_hyperparameter_ranges(config_space)
+
+        if not isinstance(shuffle_config, bool):
+            shuffle_config = True
+        self._shuffle_config = shuffle_config
+        self._generate_all_candidates_on_grid()
+        self._next_index = 0
+
+    def _validate_config_space(self, config_space: dict, num_samples: dict):
+        """
+        Validates config_space from two aspects: first, that all hyperparameters
+        are of acceptable types (i.e. float, integer, categorical). Second, num_samples is specified
+        for float hyperparameters. Num_samples for categorical variables are ignored as all of their
+        values is used in GridSearch. Num_samples for integer variables is optional, if specified it
+        will be used and will be capped at their range length.
+        Args:
+            config_space: The configuration space that defines search space grid.
+            num_samples: Number of samples for each hyperparameters. Only required for float hyperparameters.
+        """
+        if num_samples is None:
+            num_samples = dict()
+        self.num_samples = num_samples
+        for hp, hp_range in config_space.items():
+            # num_sample is required for float hp. If not specified default DEFAULT_NSAMPLE is used.
+            if isinstance(hp_range, Float):
+                if hp not in self.num_samples:
+                    self.num_samples[hp] = DEFAULT_NSAMPLE
+                    logger.warning(
+                        "number of samples is required for {}. By default, {} is set as number of samples".format(
+                            hp, DEFAULT_NSAMPLE
+                        )
+                    )
+            # num_sample for integer hp must be capped at length of the range when specified. Otherwise,
+            # minimum of default value DEFAULT_NSAMPLE and the interger range is used.
+            if isinstance(hp_range, Integer):
+                if hp in self.num_samples:
+                    if self.num_samples[hp] > len(hp_range):
+                        self.num_samples[hp] = min(len(hp_range), DEFAULT_NSAMPLE)
+                        logger.info(
+                            'number of samples for "{}" is larger than its range. We set it to the minimum of the default number of samples (i.e. {}) and its range length (i.e. {}).'.format(
+                                hp, DEFAULT_NSAMPLE, len(hp_range)
+                            )
+                        )
+                else:
+                    self.num_samples[hp] = min(len(hp_range), DEFAULT_NSAMPLE)
+            # num_samples is ignored for categorical hps.
+            if isinstance(hp_range, Categorical) or isinstance(hp_range, FiniteRange):
+                if hp in self.num_samples:
+                    logger.info(
+                        'number of samples for categorical variable "{}" is ignored.'.format(
+                            hp
+                        )
+                    )
+
+    def _generate_all_candidates_on_grid(self):
+        """
+        Generates all configurations to be evaluated by placing a regular,
+        equally spaced grid over the configuration space.
+        """
+        hp_keys = []
+        hp_values = []
+        # adding categorical, finiteRange, scalar parameters
+        for hp, hp_range in reversed(list(self.config_space.items())):
+            if isinstance(hp_range, Float) or isinstance(hp_range, Integer):
+                continue
+            if isinstance(hp_range, Categorical):
+                hp_keys.append(hp)
+                values = list(OrderedDict.fromkeys(hp_range.categories))
+                hp_values.append(values)
+            elif isinstance(hp_range, FiniteRange):
+                hp_keys.append(hp)
+                hp_values.append(hp_range.values)
+            elif not isinstance(hp_range, Domain):
+                hp_keys.append(hp)
+                hp_values.append([hp_range])
+
+        # adding float, integer parameters
+        for hpr in self._hp_ranges._hp_ranges:
+            if hpr.name not in hp_keys:
+                _hpr_nsamples = self.num_samples[hpr.name]
+                _normalized_points = [
+                    (idx + 0.5) / _hpr_nsamples for idx in range(_hpr_nsamples)
+                ]
+                _hpr_points = [
+                    hpr.from_ndarray(np.array([point])) for point in _normalized_points
+                ]
+                _hpr_points = list(set(_hpr_points))
+                hp_keys.append(hpr.name)
+                hp_values.append(_hpr_points)
+
+        self.hp_keys = hp_keys
+        self.hp_values_combinations = list(product(*hp_values))
+
+        if self._shuffle_config:
+            self.random_state.shuffle(self.hp_values_combinations)
+
+    def get_config(self, **kwargs) -> Optional[dict]:
+        """Select the next configuration from the grid.
+
+        This is done without replacement, so previously returned configs are
+        not suggested again.
+
+        :return: A new configuration that is valid, or None if no new config
+            can be suggested. The returned configuration is a dictionary that
+            maps hyperparameters to its values.
+        """
+
+        new_config = self._next_initial_config()
+        if new_config is None:
+            values = self._next_candidate_on_grid()
+            if values is not None:
+                new_config = dict(zip(self.hp_keys, values))
+        if new_config is not None:
+            # Write debug log for the config
+            entries = ["{}: {}".format(k, v) for k, v in new_config.items()]
+            msg = "\n".join(entries)
+            trial_id = kwargs.get("trial_id")
+            if trial_id is not None:
+                msg = "get_config[grid] for trial_id {}\n".format(trial_id) + msg
+            else:
+                msg = "get_config[grid]: \n".format(trial_id) + msg
+            logger.debug(msg)
+        else:
+            msg = "All the configurations has already been evaluated."
+            cs_size = config_space_size(self.config_space)
+            if cs_size is not None:
+                msg += " Configuration space has size".format(cs_size)
+            logger.warning(msg)
+        return new_config
+
+    def _next_candidate_on_grid(self) -> Optional[tuple]:
+        """
+        :return: Next configuration from the set of grid candidates
+            or None if no candidate is left.
+        """
+
+        if self._next_index < len(self.hp_values_combinations):
+            candidate = self.hp_values_combinations[self._next_index]
+            self._next_index += 1
+            return candidate
+        else:
+            # No more candidates
+            return None
+
+    def get_state(self) -> dict:
+        state = dict(
+            super().get_state(),
+            _next_index=self._next_index,
+        )
+        return state
+
+    def clone_from_state(self, state: dict):
+        new_searcher = GridSearcher(
+            config_space=self.config_space,
+            num_samples=self.num_samples,
+            metric=self._metric,
+            shuffle_config=self._shuffle_config,
+        )
+        new_searcher._restore_from_state(state)
+        return new_searcher
+
+    def _restore_from_state(self, state: dict):
+        super()._restore_from_state(state)
+        self._next_index = state["_next_index"]
+
+    def _update(self, trial_id: str, config: dict, result: dict):
+        pass

--- a/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
+++ b/syne_tune/optimizer/schedulers/searchers/regularized_evolution.py
@@ -19,6 +19,10 @@ from dataclasses import dataclass
 
 from syne_tune.optimizer.schedulers.searchers import SearcherWithRandomSeed
 from syne_tune.config_space import Domain
+from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
+from syne_tune.optimizer.schedulers.searchers.searcher import (
+    sample_random_configuration,
+)
 
 
 @dataclass
@@ -69,6 +73,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
         self.sample_size = sample_size
         self.population = deque()
         self.num_sample_try = 1000  # number of times allowed to sample a mutation
+        self._hp_ranges = make_hyperparameter_ranges(self.config_space)
 
     def _mutate_config(self, config: dict) -> dict:
         child_config = copy.deepcopy(config)
@@ -101,10 +106,7 @@ class RegularizedEvolution(SearcherWithRandomSeed):
         return child_config
 
     def _sample_random_config(self) -> dict:
-        return {
-            k: v.sample(random_state=self.random_state) if isinstance(v, Domain) else v
-            for k, v in self.config_space.items()
-        }
+        return sample_random_configuration(self._hp_ranges, self.random_state)
 
     def get_config(self, **kwargs) -> Optional[dict]:
         initial_config = self._next_initial_config()

--- a/syne_tune/optimizer/schedulers/searchers/searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher.py
@@ -12,17 +12,12 @@
 # permissions and limitations under the License.
 import logging
 import numpy as np
-from typing import Optional, List, Tuple, Dict
-from collections import OrderedDict
+from typing import Optional, List, Tuple
 
 from syne_tune.config_space import (
     Domain,
-    config_space_size,
     is_log_space,
     Categorical,
-    Float,
-    Integer,
-    FiniteRange,
     Ordinal,
     OrdinalNearestNeighbor,
 )
@@ -33,19 +28,14 @@ from syne_tune.optimizer.schedulers.searchers.utils.common import (
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
     DebugLogPrinter,
 )
-
-from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
-    make_hyperparameter_ranges,
-)
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.common import (
     ExclusionList,
 )
-from itertools import product
+from syne_tune.optimizer.schedulers.searchers.utils import (
+    HyperparameterRanges,
+)
 
 logger = logging.getLogger(__name__)
-
-
-DEFAULT_NSAMPLE = 5
 
 
 def _impute_default_config(
@@ -388,6 +378,34 @@ def extract_random_seed(**kwargs) -> (int, dict):
     return random_seed, _kwargs
 
 
+MAX_RETRIES = 100
+
+
+def sample_random_configuration(
+    hp_ranges: HyperparameterRanges,
+    random_state: np.random.RandomState,
+    exclusion_list: Optional[ExclusionList] = None,
+) -> Optional[dict]:
+    """
+    Samples a configuration from ``config_space`` at random.
+
+    :param hp_ranges: Used for sampling configurations
+    :param random_state: PRN generator
+    :param exclusion_list: Configurations not to be returned
+    :return: New configuration, or ``None`` if configuration space has been
+        exhausted
+    """
+    new_config = None
+    no_exclusion = exclusion_list is None
+    if no_exclusion or not exclusion_list.config_space_exhausted():
+        for _ in range(MAX_RETRIES):
+            _config = hp_ranges.random_config(random_state)
+            if no_exclusion or not exclusion_list.contains(_config):
+                new_config = _config
+                break
+    return new_config
+
+
 class SearcherWithRandomSeed(BaseSearcher):
     """
     Base class of searchers which use random decisions. Creates the
@@ -432,322 +450,3 @@ class SearcherWithRandomSeed(BaseSearcher):
 
     def set_random_state(self, random_state: np.random.RandomState):
         self.random_state = random_state
-
-
-class RandomSearcher(SearcherWithRandomSeed):
-    """
-    Searcher which randomly samples configurations to try next.
-
-    Additional arguments on top of parent class :class:`SearcherWithRandomSeed`:
-
-    :param debug_log: If ``True``, debug log printing is activated.
-        Logs which configs are chosen when, and which metric values are
-        obtained. Defaults to ``False``
-    :type debug_log: bool, optional
-    :param resource_attr: Optional. Key in ``result`` passed to :meth:`_update`
-        for resource value (for multi-fidelity schedulers)
-    :type resource_attr: str, optional
-    """
-
-    MAX_RETRIES = 100
-
-    def __init__(
-        self,
-        config_space: dict,
-        metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
-        **kwargs,
-    ):
-        super().__init__(
-            config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs
-        )
-        self._hp_ranges = make_hyperparameter_ranges(config_space)
-        self._resource_attr = kwargs.get("resource_attr")
-        # Used to avoid returning the same config more than once:
-        self._excl_list = ExclusionList.empty_list(self._hp_ranges)
-        # Debug log printing (switched off by default)
-        debug_log = kwargs.get("debug_log", False)
-        if isinstance(debug_log, bool):
-            if debug_log:
-                self._debug_log = DebugLogPrinter()
-            else:
-                self._debug_log = None
-        else:
-            assert isinstance(debug_log, DebugLogPrinter)
-            self._debug_log = debug_log
-
-    def configure_scheduler(self, scheduler):
-        from syne_tune.optimizer.schedulers.multi_fidelity import (
-            MultiFidelitySchedulerMixin,
-        )
-
-        super().configure_scheduler(scheduler)
-        # If the scheduler is multi-fidelity, we want to know the resource
-        # attribute, this is used for ``debug_log``
-        if isinstance(scheduler, MultiFidelitySchedulerMixin):
-            self._resource_attr = scheduler.resource_attr
-
-    def get_config(self, **kwargs) -> Optional[dict]:
-        """Sample a new configuration at random
-
-        This is done without replacement, so previously returned configs are
-        not suggested again.
-
-        :param trial_id: Optional. Used for ``debug_log``
-        :return: New configuration, or None
-        """
-        new_config = self._next_initial_config()
-        if new_config is None:
-            if not self._excl_list.config_space_exhausted():
-                for _ in range(self.MAX_RETRIES):
-                    _config = self._hp_ranges.random_config(self.random_state)
-                    if not self._excl_list.contains(_config):
-                        new_config = _config
-                        break
-
-        if new_config is not None:
-            self._excl_list.add(new_config)  # Should not be suggested again
-            if self._debug_log is not None:
-                trial_id = kwargs.get("trial_id")
-                self._debug_log.start_get_config("random", trial_id=trial_id)
-                self._debug_log.set_final_config(new_config)
-                # All get_config debug log info is only written here
-                self._debug_log.write_block()
-        else:
-            msg = (
-                "Failed to sample a configuration not already chosen "
-                + f"before. Exclusion list has size {len(self._excl_list)}."
-            )
-            cs_size = self._excl_list.configspace_size
-            if cs_size is not None:
-                msg += f" Configuration space has size {cs_size}."
-            logger.warning(msg)
-        return new_config
-
-    def _update(self, trial_id: str, config: dict, result: dict):
-        if self._debug_log is not None:
-            metric_val = result[self._metric]
-            if self._resource_attr is not None:
-                # For HyperbandScheduler, also add the resource attribute
-                resource = int(result[self._resource_attr])
-                trial_id = trial_id + f":{resource}"
-            msg = f"Update for trial_id {trial_id}: metric = {metric_val:.3f}"
-            logger.info(msg)
-
-    def clone_from_state(self, state: dict):
-        new_searcher = RandomSearcher(
-            self.config_space,
-            metric=self._metric,
-            points_to_evaluate=[],
-            debug_log=self._debug_log,
-        )
-        new_searcher._resource_attr = self._resource_attr
-        new_searcher._restore_from_state(state)
-        return new_searcher
-
-    @property
-    def debug_log(self):
-        return self._debug_log
-
-
-class GridSearcher(SearcherWithRandomSeed):
-    """Searcher that samples configurations from an equally spaced grid over config_space.
-
-    It first evaluates configurations defined in points_to_evaluate and then
-    continues with the remaining points from the grid.
-
-    Additional arguments on top of parent class :class:`SearcherWithRandomSeed`.
-
-    :param num_samples: Dictionary, optional. Number of samples per
-        hyperparameter. This is required for hyperparameters of type float,
-        optional for integer hyperparameters, and will be ignored for
-        other types (categorical, scalar). If left unspecified, a default
-        value of :const:`DEFAULT_NSAMPLE` will be used for float parameters, and
-        the smallest of :const:`DEFAULT_NSAMPLE` and integer range will be used
-        for integer parameters.
-    :param shuffle_config: If ``True`` (default), the order of configurations
-        suggested after those specified in ``points_to_evaluate`` is
-        shuffled. Otherwise, the order will follow the Cartesian product
-        of the configurations.
-    """
-
-    def __init__(
-        self,
-        config_space: dict,
-        metric: str,
-        points_to_evaluate: Optional[List[dict]] = None,
-        num_samples: Optional[Dict[str, int]] = None,
-        shuffle_config: bool = True,
-        **kwargs,
-    ):
-        super().__init__(
-            config_space, metric, points_to_evaluate=points_to_evaluate, **kwargs
-        )
-        self._validate_config_space(config_space, num_samples)
-        self._hp_ranges = make_hyperparameter_ranges(config_space)
-
-        if not isinstance(shuffle_config, bool):
-            shuffle_config = True
-        self._shuffle_config = shuffle_config
-        self._generate_all_candidates_on_grid()
-        self._next_index = 0
-
-    def _validate_config_space(self, config_space: dict, num_samples: dict):
-        """
-        Validates config_space from two aspects: first, that all hyperparameters
-        are of acceptable types (i.e. float, integer, categorical). Second, num_samples is specified
-        for float hyperparameters. Num_samples for categorical variables are ignored as all of their
-        values is used in GridSearch. Num_samples for integer variables is optional, if specified it
-        will be used and will be capped at their range length.
-        Args:
-            config_space: The configuration space that defines search space grid.
-            num_samples: Number of samples for each hyperparameters. Only required for float hyperparameters.
-        """
-        if num_samples is None:
-            num_samples = dict()
-        self.num_samples = num_samples
-        for hp, hp_range in config_space.items():
-            # num_sample is required for float hp. If not specified default DEFAULT_NSAMPLE is used.
-            if isinstance(hp_range, Float):
-                if hp not in self.num_samples:
-                    self.num_samples[hp] = DEFAULT_NSAMPLE
-                    logger.warning(
-                        "number of samples is required for {}. By default, {} is set as number of samples".format(
-                            hp, DEFAULT_NSAMPLE
-                        )
-                    )
-            # num_sample for integer hp must be capped at length of the range when specified. Otherwise,
-            # minimum of default value DEFAULT_NSAMPLE and the interger range is used.
-            if isinstance(hp_range, Integer):
-                if hp in self.num_samples:
-                    if self.num_samples[hp] > len(hp_range):
-                        self.num_samples[hp] = min(len(hp_range), DEFAULT_NSAMPLE)
-                        logger.info(
-                            'number of samples for "{}" is larger than its range. We set it to the minimum of the default number of samples (i.e. {}) and its range length (i.e. {}).'.format(
-                                hp, DEFAULT_NSAMPLE, len(hp_range)
-                            )
-                        )
-                else:
-                    self.num_samples[hp] = min(len(hp_range), DEFAULT_NSAMPLE)
-            # num_samples is ignored for categorical hps.
-            if isinstance(hp_range, Categorical) or isinstance(hp_range, FiniteRange):
-                if hp in self.num_samples:
-                    logger.info(
-                        'number of samples for categorical variable "{}" is ignored.'.format(
-                            hp
-                        )
-                    )
-
-    def _generate_all_candidates_on_grid(self):
-        """
-        Generates all configurations to be evaluated by placing a regular,
-        equally spaced grid over the configuration space.
-        """
-        hp_keys = []
-        hp_values = []
-        # adding categorical, finiteRange, scalar parameters
-        for hp, hp_range in reversed(list(self.config_space.items())):
-            if isinstance(hp_range, Float) or isinstance(hp_range, Integer):
-                continue
-            if isinstance(hp_range, Categorical):
-                hp_keys.append(hp)
-                values = list(OrderedDict.fromkeys(hp_range.categories))
-                hp_values.append(values)
-            elif isinstance(hp_range, FiniteRange):
-                hp_keys.append(hp)
-                hp_values.append(hp_range.values)
-            elif not isinstance(hp_range, Domain):
-                hp_keys.append(hp)
-                hp_values.append([hp_range])
-
-        # adding float, integer parameters
-        for hpr in self._hp_ranges._hp_ranges:
-            if hpr.name not in hp_keys:
-                _hpr_nsamples = self.num_samples[hpr.name]
-                _normalized_points = [
-                    (idx + 0.5) / _hpr_nsamples for idx in range(_hpr_nsamples)
-                ]
-                _hpr_points = [
-                    hpr.from_ndarray(np.array([point])) for point in _normalized_points
-                ]
-                _hpr_points = list(set(_hpr_points))
-                hp_keys.append(hpr.name)
-                hp_values.append(_hpr_points)
-
-        self.hp_keys = hp_keys
-        self.hp_values_combinations = list(product(*hp_values))
-
-        if self._shuffle_config:
-            self.random_state.shuffle(self.hp_values_combinations)
-
-    def get_config(self, **kwargs) -> Optional[dict]:
-        """Select the next configuration from the grid.
-
-        This is done without replacement, so previously returned configs are
-        not suggested again.
-
-        :return: A new configuration that is valid, or None if no new config
-            can be suggested. The returned configuration is a dictionary that
-            maps hyperparameters to its values.
-        """
-
-        new_config = self._next_initial_config()
-        if new_config is None:
-            values = self._next_candidate_on_grid()
-            if values is not None:
-                new_config = dict(zip(self.hp_keys, values))
-        if new_config is not None:
-            # Write debug log for the config
-            entries = ["{}: {}".format(k, v) for k, v in new_config.items()]
-            msg = "\n".join(entries)
-            trial_id = kwargs.get("trial_id")
-            if trial_id is not None:
-                msg = "get_config[grid] for trial_id {}\n".format(trial_id) + msg
-            else:
-                msg = "get_config[grid]: \n".format(trial_id) + msg
-            logger.debug(msg)
-        else:
-            msg = "All the configurations has already been evaluated."
-            cs_size = config_space_size(self.config_space)
-            if cs_size is not None:
-                msg += " Configuration space has size".format(cs_size)
-            logger.warning(msg)
-        return new_config
-
-    def _next_candidate_on_grid(self) -> Optional[tuple]:
-        """
-        :return: Next configuration from the set of grid candidates
-            or None if no candidate is left.
-        """
-
-        if self._next_index < len(self.hp_values_combinations):
-            candidate = self.hp_values_combinations[self._next_index]
-            self._next_index += 1
-            return candidate
-        else:
-            # No more candidates
-            return None
-
-    def get_state(self) -> dict:
-        state = dict(
-            super().get_state(),
-            _next_index=self._next_index,
-        )
-        return state
-
-    def clone_from_state(self, state: dict):
-        new_searcher = GridSearcher(
-            config_space=self.config_space,
-            num_samples=self.num_samples,
-            metric=self._metric,
-            shuffle_config=self._shuffle_config,
-        )
-        new_searcher._restore_from_state(state)
-        return new_searcher
-
-    def _restore_from_state(self, state: dict):
-        super()._restore_from_state(state)
-        self._next_index = state["_next_index"]
-
-    def _update(self, trial_id: str, config: dict, result: dict):
-        pass

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -136,6 +136,7 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
             reduction_factor=self.reduction_factor,
             num_brackets=kwargs.get("brackets"),
         )
+        print(f"*** bracket_rungs = {bracket_rungs}")
         self._create_internal(bracket_rungs, **filter_by_key(kwargs, _ARGUMENT_KEYS))
 
 

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_impl.py
@@ -136,7 +136,6 @@ class SynchronousGeometricHyperbandScheduler(SynchronousHyperbandScheduler):
             reduction_factor=self.reduction_factor,
             num_brackets=kwargs.get("brackets"),
         )
-        print(f"*** bracket_rungs = {bracket_rungs}")
         self._create_internal(bracket_rungs, **filter_by_key(kwargs, _ARGUMENT_KEYS))
 
 

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband_rung_system.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband_rung_system.py
@@ -62,11 +62,9 @@ class SynchronousHyperbandRungSystem:
         assert (
             reduction_factor >= 2
         ), f"reduction_factor = {reduction_factor} must be >= 2"
-        s_max = int(
-            np.ceil(
-                (np.log(max_resource) - np.log(min_resource)) / np.log(reduction_factor)
-            )
-        )
+        s_max = 0
+        while min_resource * np.power(reduction_factor, s_max) < max_resource:
+            s_max += 1
         if num_brackets is not None:
             SynchronousHyperbandRungSystem._assert_positive_int(
                 num_brackets, "num_brackets"

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -64,10 +64,11 @@ class ZeroShotTransfer(TransferLearningMixin, SearcherWithRandomSeed):
         use_surrogates: bool = False,
         **kwargs,
     ) -> None:
+        if "points_to_evaluate" in kwargs:
+            kwargs["points_to_evaluate"] = []
         super().__init__(
             config_space=config_space,
             metric=metric,
-            points_to_evaluate=[],
             transfer_learning_evaluations=transfer_learning_evaluations,
             metric_names=[metric],
             **kwargs,

--- a/tst/blackbox_repository/test_data_consistency.py
+++ b/tst/blackbox_repository/test_data_consistency.py
@@ -21,7 +21,7 @@ from syne_tune.blackbox_repository.simulated_tabular_backend import (
 from syne_tune.blackbox_repository import load_blackbox, add_surrogate
 from syne_tune.blackbox_repository.utils import metrics_for_configuration
 from syne_tune.blackbox_repository.blackbox_tabular import BlackboxTabular
-from syne_tune.optimizer.schedulers.searchers.searcher import RandomSearcher
+from syne_tune.optimizer.schedulers.searchers import RandomSearcher
 
 
 @dataclass

--- a/tst/schedulers/test_random_searcher.py
+++ b/tst/schedulers/test_random_searcher.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from syne_tune.optimizer.schedulers.searchers.searcher import RandomSearcher
+from syne_tune.optimizer.schedulers.searchers import RandomSearcher
 from syne_tune.config_space import choice, randint
 
 

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -35,6 +35,7 @@ from syne_tune.optimizer.baselines import (
     SyncBOHB,
     SyncMOBSTER,
     ZeroShotTransfer,
+    BOTorch,
     # ASHACTS,
 )
 from syne_tune.optimizer.scheduler import SchedulerDecision
@@ -44,9 +45,6 @@ from syne_tune.optimizer.schedulers import (
     HyperbandScheduler,
     PopulationBasedTraining,
     RayTuneScheduler,
-)
-from syne_tune.optimizer.schedulers.searchers.botorch import (
-    BotorchSearcher,
 )
 from syne_tune.optimizer.schedulers.multiobjective import MOASHA
 from syne_tune.optimizer.schedulers.transfer_learning import (
@@ -156,6 +154,14 @@ transfer_learning_evaluations = make_transfer_learning_evaluations()
         HyperbandScheduler(
             config_space,
             searcher="bayesopt",
+            resource_attr=resource_attr,
+            max_t=max_t,
+            metric=metric1,
+            mode=mode,
+        ),
+        HyperbandScheduler(
+            config_space,
+            searcher="kde",
             resource_attr=resource_attr,
             max_t=max_t,
             metric=metric1,
@@ -327,18 +333,14 @@ transfer_learning_evaluations = make_transfer_learning_evaluations()
         #     max_t=max_t,
         #     resource_attr=resource_attr,
         # ),
-        # FIXME: Resolve #324 and bring back in:
-        FIFOScheduler(
-            config_space,
-            searcher=BotorchSearcher(
-                config_space=config_space, metric=metric1, mode=mode
-            ),
+        BOTorch(
+            config_space=config_space,
             metric=metric1,
             mode=mode,
         ),
     ],
 )
-def test_async_schedulers_api(scheduler):
+def test_schedulers_api(scheduler):
     trial_ids = range(4)
 
     if isinstance(scheduler, MOASHA):


### PR DESCRIPTION
…in baselines

*Issue #, if available:*

*Description of changes:*
Ensures that all searchers return the same random initial configs when started with the same seed.
Also:
- New classes in baselines.py
- Split searcher.py (got too large)
- Make sure that BOHB schedulers do not return duplicates
- Fixes computation of rung levels, which relied on floating point accuracy (resolved now)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
