### PR TITLE
lock numpy version to <1.24.0

### DIFF
--- a/benchmarking/nursery/benchmark_automl/requirements.txt
+++ b/benchmarking/nursery/benchmark_automl/requirements.txt
@@ -1,7 +1,7 @@
 syne-tune[extra]
 tqdm
 coolname
-numpy
+numpy>=1.16.0, <1.24.0
 pandas
 fastparquet
 s3fs

--- a/requirements-bore.txt
+++ b/requirements-bore.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.16.0, <1.24.0
 xgboost
 scikit-learn
 GPy==1.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.0
+numpy>=1.16.0, <1.24.0
 dill
 pandas
 # only needed for python version lower than 3.8

--- a/syne_tune/blackbox_repository/requirements.txt
+++ b/syne_tune/blackbox_repository/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.16.0, <1.24.0
 pandas
 fastparquet
 s3fs


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

## Problem

Running the following command:
```
python examples/launch_height_ray.py
```

...results in the following error: `AttributeError: module 'numpy' has no attribute 'int'`

This error is because newer versions of numpy deprecate the `np.int` alias: https://numpy.org/doc/stable/release/1.24.0-notes.html and code in the ray side or the syne tune side has not been updated yet to use the new syntax.

## Solution

As an immediate mitigation, limit the version of numpy to less than `1.24.0` until the code can be updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
