### PR TITLE
Modifications to use Ordinal hp as active_task.

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges_impl.py
@@ -635,9 +635,9 @@ class HyperparameterRangesImpl(HyperparameterRanges):
                 is_in_active = name in self.active_config_space
                 num_categories = len(hp_range.categories)
                 if isinstance(hp_range, Ordinal):
-                    assert (
-                        not is_in_active
-                    ), f"Parameter '{name}' of type Ordinal cannot be used in active_config_space"
+                    #assert (
+                        #not is_in_active
+                    #), f"Parameter '{name}' of type Ordinal cannot be used in active_config_space"
                     if (
                         isinstance(hp_range, OrdinalNearestNeighbor)
                         and num_categories > 1

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -48,7 +48,7 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
     prefix_keys = None
     active_config_space = None
     if task_attr is not None:
-        from syne_tune.config_space import Categorical
+        from syne_tune.config_space import Categorical, Ordinal
 
         active_task = kwargs.get("transfer_learning_active_task")
         assert (
@@ -68,7 +68,12 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
             active_config_space = config_space
         # The parameter ``task_attr`` in ``active_config_space`` must be restricted
         # to ``active_task`` as a single value
-        task_param = Categorical(categories=[active_task])
+        if isinstance(hp_range, Ordinal):
+            # If it's Ordinal, we want to make the ``task_param`` Ordinal as well
+            task_param = Ordinal(categories=[active_task])
+        else:
+            # Otherwise we make it Categorical
+            task_param = Categorical(categories=[active_task])
         active_config_space = dict(active_config_space, **{task_attr: task_param})
     return make_hyperparameter_ranges(
         config_space, active_config_space=active_config_space, prefix_keys=prefix_keys


### PR DESCRIPTION
*Issue #, if available:* #500

*Description of changes:* Correctly initiating the active `task_param` as Ordinal if that's the type of the non-active version. Also commenting out assertions stopping Ordinal `task_param`. 

**New output**
```python
Ordinal: False
{'parA': loguniform(1e-06, 1.0), 'parB': loguniform(1e-05, 10), 'problem_maker': choice([1, 2, 3])}
Works
Ordinal: True
{'parA': loguniform(1e-06, 1.0), 'parB': loguniform(1e-05, 10), 'problem_maker': ordinal([1, 2, 3], kind='equal')}
Works
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
