### PR TITLE
Support Ordinal and OrdinalNearestNeighbor in active_config_space and…

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/hp_ranges.py
@@ -122,17 +122,15 @@ class HyperparameterRanges:
             assert (
                 k in self.config_space
             ), f"active_config_space[{k}] not in config_space"
-            same_value_type = v.value_type == self.config_space[k].value_type
-            same_log_type = is_log_space(v) == is_log_space(
-                self.config_space[k]
-            ) and is_reverse_log_space(v) == is_reverse_log_space(self.config_space[k])
-            same_domain_type = isinstance(v, type(self.config_space[k]))
-            assert (
-                k in self.config_space
-                and same_value_type
-                and same_log_type
-                and same_domain_type
-            ), f"active_config_space[{k}] has different type"
+            v2 = self.config_space[k]
+            checks = {
+                "value_type": v.value_type == v2.value_type,
+                "log_type": is_log_space(v) == is_log_space(v2)
+                and is_reverse_log_space(v) == is_reverse_log_space(v2),
+                "domain_type": isinstance(v, type(v2)),
+            }
+            for name, check in checks.items():
+                assert check, f"active_config_space[{k}] has different {name}"
 
     @property
     def internal_keys(self) -> List[str]:

--- a/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
+++ b/syne_tune/optimizer/schedulers/searchers/utils/warmstarting.py
@@ -28,28 +28,35 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.kernel import 
     KernelFunction,
     RangeKernelFunction,
 )
+from syne_tune.config_space import (
+    Categorical,
+    Ordinal,
+    OrdinalNearestNeighbor,
+)
 
 
 def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
     """
-    See :class:`GPFIFOSearcher` for details on transfer_learning_task_attr',
-    'transfer_learning_active_task', 'transfer_learning_active_config_space'
+    See :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` for
+    details on "transfer_learning_task_attr",
+    "transfer_learning_active_task", "transfer_learning_active_config_space"
     as optional fields in ``kwargs``. If given, they determine
     ``active_config_space`` and ``prefix_keys`` of ``hp_ranges`` created here,
-    and they also places constraints on 'config_space'.
+    and they also place constraints on ``config_space``.
 
     This function is not only called in ``gp_searcher_factory`` to create
-    ``hp_ranges`` for a new :class:`GPFIFOSearcher` object. It is also needed to
-    create the ``TuningJobState`` containing the data to be used in warmstarting.
-
+    ``hp_ranges`` for a new
+    :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` object. It
+    is also needed to create the
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state.TuningJobState`
+    object containing the data to be used in warmstarting.
     """
+
     task_attr = kwargs.get("transfer_learning_task_attr")
     config_space = kwargs["config_space"]
     prefix_keys = None
     active_config_space = None
     if task_attr is not None:
-        from syne_tune.config_space import Categorical
-
         active_task = kwargs.get("transfer_learning_active_task")
         assert (
             active_task is not None
@@ -68,7 +75,12 @@ def create_hp_ranges_for_warmstarting(**kwargs) -> HyperparameterRanges:
             active_config_space = config_space
         # The parameter ``task_attr`` in ``active_config_space`` must be restricted
         # to ``active_task`` as a single value
-        task_param = Categorical(categories=[active_task])
+        if isinstance(hp_range, OrdinalNearestNeighbor):
+            task_param = OrdinalNearestNeighbor(categories=[active_task])
+        elif isinstance(hp_range, Ordinal):
+            task_param = Ordinal(categories=[active_task])
+        else:
+            task_param = Categorical(categories=[active_task])
         active_config_space = dict(active_config_space, **{task_attr: task_param})
     return make_hyperparameter_ranges(
         config_space, active_config_space=active_config_space, prefix_keys=prefix_keys

--- a/tst/schedulers/bayesopt/test_hp_ranges.py
+++ b/tst/schedulers/bayesopt/test_hp_ranges.py
@@ -299,10 +299,12 @@ def test_active_ranges_valid():
         "3": randint(1, 1000),
         "4": lograndint(1, 1000),
         "5": choice(["a", "b", "c"]),
+        "6": ordinal([1, 2, 3, 4], kind="equal"),
+        "7": ordinal([1, 2, 3, 4], kind="nn"),
     }
     invalid_active_spaces = [
         {
-            "6": randint(0, 1),
+            "8": randint(0, 1),
         },
         {
             "0": uniform(2.0, 500.0),
@@ -323,6 +325,30 @@ def test_active_ranges_valid():
         {
             "2": reverseloguniform(0.9, 0.999),
             "4": lograndint(10, 1005),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([5], kind="equal"),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([1, 2, 4], kind="equal"),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([1, 3, 2], kind="equal"),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([5], kind="nn"),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([1, 2, 4], kind="nn"),
+        },
+        {
+            "3": randint(1, 100),
+            "6": ordinal([1, 4, 5], kind="nn"),
         },
     ]
     for active_config_space in invalid_active_spaces:
@@ -362,6 +388,26 @@ def test_active_ranges_valid():
             },
             {
                 "0": lograndint(3, 4),
+            },
+        ),
+        (
+            {
+                "0": uniform(1.0, 2.0),
+                "1": ordinal([1, 2, 3], kind="equal"),
+            },
+            {
+                "0": uniform(1.1, 1.9),
+                "1": ordinal([2, 3], kind="equal"),
+            },
+        ),
+        (
+            {
+                "0": uniform(1.0, 2.0),
+                "1": ordinal([1, 2, 3], kind="nn"),
+            },
+            {
+                "0": uniform(1.1, 1.9),
+                "1": ordinal([2, 3], kind="nn"),
             },
         ),
     ],


### PR DESCRIPTION
… warmstarting

*Issue #, if available:* 500

*Description of changes:*

Supports two more domains, `Ordinal` and `OrdinalNearestNeighbor`, when it comes to `active_config_space`. The latter is needed in transfer tuning, when the config space defines a range which is more narrow than what the data has. This happens if the user modifies the config space.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
