### PR TITLE
fix number of gpu computation

### DIFF
--- a/syne_tune/num_gpu.py
+++ b/syne_tune/num_gpu.py
@@ -42,9 +42,12 @@ def get_num_gpus() -> int:
             if proc.poll() is None:
                 raise ValueError("nvidia-smi timed out after 10 secs.")
 
-            with open("std.out", "r") as stdout:
-                _num_gpus = len(stdout.readlines())
-            return _num_gpus
+            if proc.poll() != 0:
+                return 0
+            else:
+                with open("std.out", "r") as stdout:
+                    _num_gpus = len(stdout.readlines())
+                return _num_gpus
 
         except (OSError, FileNotFoundError):
             logging.info(

--- a/syne_tune/num_gpu.py
+++ b/syne_tune/num_gpu.py
@@ -43,8 +43,11 @@ def get_num_gpus() -> int:
                 raise ValueError("nvidia-smi timed out after 10 secs.")
 
             if proc.poll() != 0:
+                # In cases when nvidia-smi fails, no GPU is available.
                 return 0
             else:
+                # In cases when nvidia-smi success, we read the number of GPU available
+                # communicated by nvidia-smi.
                 with open("std.out", "r") as stdout:
                     _num_gpus = len(stdout.readlines())
                 return _num_gpus


### PR DESCRIPTION
*Issue #, if available:* Fix https://github.com/awslabs/syne-tune/issues/85 

*Description of changes:* The number of gpus was incorrectly detected in cases where nvidia-smi fails. I was able to reproduce the error and that this patch fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
