### PR TITLE
Fix so BoTorch scheduler is able to fit gp model.

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
@@ -186,7 +186,7 @@ class BoTorchSearcher(SearcherWithRandomSeedAndFilterDuplicates):
             Y_tensor = standardize(Tensor(y).reshape(-1, 1))
             gp = self._make_gp(X_tensor=X_tensor, Y_tensor=Y_tensor)
             mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
-            fit_gpytorch_mll(mll, max_attempts=0)
+            fit_gpytorch_mll(mll, max_attempts=1)
 
             if self.pending_trials and self.fantasising and not subsample:
                 X_pending = self._config_to_feature_matrix(self._configs_pending())


### PR DESCRIPTION
Fixes #518 

*Description of changes:*
Changing `max_attemps`from 0 to 1 fixes the problem.

*New output*
```python
--------------------
Resource summary (last result is reported):
 trial_id     status  iter  steps  width  height  step  mean_loss  epoch  worker-time
        0  Completed     5      5     10       0   4.0   2.000000    5.0     0.534248
        1  Completed     5      5      4     -63   4.0  -2.453846    5.0     0.528401
        2  Completed     5      5     10      18   4.0   3.800000    5.0     0.526259
        3  Completed     5      5      0     -43   4.0   5.700000    5.0     0.524436
        4  Completed     5      5     15     100   4.0  11.428571    5.0     0.524801
        5  Completed     5      5     16    -100   4.0  -8.648649    5.0     0.523618
        6 InProgress     3      5      9     100   2.0  13.571429    3.0     0.312065
        7 InProgress     0      5      2    -100     -          -      -            -
        8 InProgress     0      5     20     -82     -          -      -            -
        9 InProgress     0      5      6    -100     -          -      -            -
4 trials running, 6 finished (6 until the end), 4.64s wallclock-time

mean_loss: best -8.64864864864865 for trial-id 5
--------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
