### PR TITLE
Fix default value for DEHB baseline

### DIFF
--- a/syne_tune/optimizer/baselines.py
+++ b/syne_tune/optimizer/baselines.py
@@ -380,7 +380,7 @@ class DEHB(GeometricDifferentialEvolutionHyperbandScheduler):
         super(DEHB, self).__init__(
             config_space=config_space,
             metric=metric,
-            searcher="random",
+            searcher="random_encoded",
             resource_attr=resource_attr,
             **kwargs,
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes wrong default value for DEHB baseline. The paper recommends "random_encoded", the old default was "random". This could have a real effect, in that previous results with DEHB could have been worse than they should be.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
