### PR TITLE
lock dependency versions to fix `launch_rl_tuning.py` example

### DIFF
--- a/examples/training_scripts/rl_cartpole/requirements.txt
+++ b/examples/training_scripts/rl_cartpole/requirements.txt
@@ -1,7 +1,7 @@
-tensorboardX
+tensorboardX==2.5.1
 opencv-python
-ray[rllib]
-dm-tree
-gym
-tensorflow
-pygame
+ray[rllib]==2.2.0
+dm-tree==0.1.8
+gym==0.23.1
+tensorflow==2.11.0
+pygame==2.1.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Problem: `examples/launch_rl_tuning.py` started failing, see for example https://github.com/awslabs/syne-tune/actions/runs/4108215352/jobs/7088647693#step:7:1

Solution: lock to specific dependency versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
