### PR TITLE
Don't run End-to-end tests with every push to `main`

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,6 +1,6 @@
 name: End-to-end Tests
 
-# Tests in this file run after code has been merged to `main` and before every release. 
+# Tests in this file can be invoked manually. We run them before every release.
 # These tests can invoke AWS services from our integ test account.
 
 on:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -4,9 +4,6 @@ name: End-to-end Tests
 # These tests can invoke AWS services from our integ test account.
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   # pull_request: # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
   #   branches:   # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Problem:** e2e tests are getting triggered too frequently, such that there are often multiple instances running in parallel. And the e2e tests are not designed to handle concurrent runs. Concurrent runs are also more expensive.

**Solution:** don't run the e2e tests with every push, instead, only run manually before release. In a future PR, I'll improve the automation that we use so that the e2e tests are automatically invoked before each new release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
