### PR TITLE
Including additional examples using benchmarking

### DIFF
--- a/benchmarking/commons/hpo_main_local.py
+++ b/benchmarking/commons/hpo_main_local.py
@@ -73,7 +73,7 @@ def parse_args(
             dict(
                 name="benchmark",
                 type=str,
-                default="resnet_cifar10",
+                required=True,
                 help="Benchmark to run",
             ),
             dict(

--- a/benchmarking/commons/hpo_main_sagemaker.py
+++ b/benchmarking/commons/hpo_main_sagemaker.py
@@ -68,7 +68,7 @@ def parse_args(
             dict(
                 name="benchmark",
                 type=str,
-                default="resnet_cifar10",
+                required=True,
                 help="Benchmark to run",
             ),
             dict(

--- a/benchmarking/commons/utils.py
+++ b/benchmarking/commons/utils.py
@@ -73,7 +73,7 @@ def find_or_create_requirements_txt(
 ) -> Path:
     if requirements_fname is None:
         requirements_fname = "requirements.txt"
-    files = list(entry_point.parent.rglob("requirements*.txt"))
+    files = list(entry_point.parent.glob("requirements*.txt"))
     if len(files) == 0:
         print(
             f"Could not find {entry_point.parent}/requirements*.txt\n"

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -455,3 +455,36 @@ Ask Tell interface for Hyperband
 This is an extension of
 :ref:`launch_ask_tell_scheduler.py <launch_ask_tell_scheduler_script>` to run
 multi-fidelity methods such as Hyperband.
+
+
+
+
+Benchmark different HPO methods on optimizing a custom script
+=============================================================
+
+.. literalinclude:: ../../examples/launch_custom_benchmark.py
+   :name: launch_custom_benchmark
+   :caption: examples/launch_custom_benchmark.py
+   :lines: 16-
+
+Makes use of :ref:`train_height.py <train_height_script>`.
+
+This example shows how to define a custom benchmark to the syne-tune
+benchmarking suite and then use the selection of methods implemented
+in `benchmarking/commons` to optimize it. The output of this example
+can be used to determine which HPO method is best for a custom problem
+
+
+Run a custom benchmark remotely
+===============================
+
+.. literalinclude:: ../../examples/launch_custom_benchmark_remotely.py
+   :caption: examples/launch_custom_benchmark_remotely.py
+   :lines: 16-
+
+Makes use of :ref:`train_height.py <train_height_script>` and
+:ref:`launch_custom_benchmark.py <launch_custom_benchmark>`.
+
+This launcher script starts the custom benchmarking experiment
+as SageMaker training job allowing you to test multiple HPO methods
+on a custom optimization problem, while not blocking local machine.

--- a/examples/launch_custom_benchmark.py
+++ b/examples/launch_custom_benchmark.py
@@ -1,0 +1,113 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""
+This example show how to launch a tuning job with a custom benchmark
+"""
+import argparse
+import logging
+from pathlib import Path
+from typing import Dict
+
+from benchmarking.commons.benchmark_definitions import RealBenchmarkDefinition
+from benchmarking.commons.hpo_main_sagemaker import main as main_sagemaker
+from benchmarking.commons.hpo_main_local import main as main_local
+from benchmarking.nursery.launch_sagemaker.baselines import (
+    methods as all_methods,
+    Methods,
+)
+from syne_tune.config_space import randint
+from syne_tune.remote.estimators import (
+    DEFAULT_CPU_INSTANCE_SMALL,
+)
+
+
+def height_benchmark(
+    sagemaker_backend: bool = False, **kwargs
+) -> Dict[str, RealBenchmarkDefinition]:
+    """
+    This function defines the benchmark definition based on our training script
+    In order to use this benchmark, you need to specify --benchmark height_benchmark in input params
+    """
+    max_steps = 100
+    n_workers = 4
+
+    config_space = {
+        "steps": max_steps,
+        "width": randint(0, 20),
+        "height": randint(-100, 100),
+    }
+    script = (
+        Path(__file__).parent
+        / "training_scripts"
+        / "height_example"
+        / "train_height.py"
+    )
+    mode = "min"
+    metric = "mean_loss"
+
+    benchargs = dict(
+        script=script,
+        config_space=config_space,
+        max_wallclock_time=5 * 60,
+        n_workers=n_workers,
+        instance_type=DEFAULT_CPU_INSTANCE_SMALL,
+        metric=metric,
+        mode=mode,
+        max_resource_attr="epochs",
+        framework="PyTorch",
+    )
+    benchargs.update(kwargs)
+    return {"height_benchmark": RealBenchmarkDefinition(**benchargs)}
+
+
+if __name__ == "__main__":
+    """
+    Use this example to run the custom-defined benchmark with remote workers for selected SF methods.
+    The benchmark name needs to be passed using --benchmark <bench_name> command line argument.
+    Methods can be specified using --method <method>, for example <--method BO>
+    """
+    parser = argparse.ArgumentParser(
+        description="Launch a custom <train_height.py> benchmark using selected backend"
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["local", "sagemaker"],
+        required=True,
+        type=str,
+        help="Backed to use for experiment",
+    )
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        required=True,
+        help="Benchmark to run, should be <height_benchmark> for this example",
+    )
+    args, unknown = parser.parse_known_args()
+
+    logging.getLogger().setLevel(logging.INFO)
+    single_fidelity_methods = {
+        Methods.RS: all_methods[Methods.RS],
+        Methods.BO: all_methods[Methods.BO],
+    }
+
+    print(f"Got the backend argument of {args.backend}, starting tuning")
+    if args.backend == "local":
+        main_local(
+            methods=single_fidelity_methods,
+            benchmark_definitions=height_benchmark,
+        )
+    elif args.backend == "sagemaker":
+        main_sagemaker(
+            methods=single_fidelity_methods,
+            benchmark_definitions=height_benchmark,
+        )

--- a/examples/launch_custom_benchmark_remotely.py
+++ b/examples/launch_custom_benchmark_remotely.py
@@ -13,11 +13,16 @@
 """
 This example show how to launch a tuning job that will orchestrated on Sagemaker rather than on your local machine.
 """
-
+import argparse
 import logging
 from pathlib import Path
 
-from benchmarking.commons.launch_remote_sagemaker import launch_remote
+from benchmarking.commons.launch_remote_sagemaker import (
+    launch_remote as launch_remote_sagemaker,
+)
+from benchmarking.commons.launch_remote_local import (
+    launch_remote as launch_remote_local,
+)
 from benchmarking.nursery.launch_sagemaker.baselines import (
     methods as all_methods,
     Methods,
@@ -30,13 +35,38 @@ if __name__ == "__main__":
     The benchmark name needs to be passed using --benchmark <bench_name> command line argument.
     For the custom height example, one needs to specify `--benchmark height_benchmark`
     """
+    parser = argparse.ArgumentParser(
+        description="Launch a custom <train_height.py> benchmark using selected backend"
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["local", "sagemaker"],
+        required=True,
+        type=str,
+        help="Backed to use for experiment",
+    )
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        required=True,
+        help="Benchmark to run, should be <height_benchmark> for this example",
+    )
+    args, unknown = parser.parse_known_args()
+
     logging.getLogger().setLevel(logging.INFO)
     entry_point = Path(__file__).parent / "launch_custom_benchmark.py"
     single_fidelity_methods = {
         Methods.RS: all_methods[Methods.RS],
         Methods.BO: all_methods[Methods.BO],
     }
-    launch_remote(
+
+    print(f"Got the backend argument of {args.backend}, starting tuning")
+    if args.backend == "local":
+        launcher = launch_remote_local
+    elif args.backend == "sagemaker":
+        launcher = launch_remote_sagemaker
+
+    launcher(
         entry_point=entry_point,
         methods=single_fidelity_methods,
         benchmark_definitions=height_benchmark,

--- a/examples/launch_custom_benchmark_remotely.py
+++ b/examples/launch_custom_benchmark_remotely.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""
+This example show how to launch a tuning job that will orchestrated on Sagemaker rather than on your local machine.
+"""
+
+import logging
+from pathlib import Path
+
+from benchmarking.commons.launch_remote_sagemaker import launch_remote
+from benchmarking.nursery.launch_sagemaker.baselines import (
+    methods as all_methods,
+    Methods,
+)
+from examples.launch_custom_benchmark import height_benchmark
+
+if __name__ == "__main__":
+    """
+    Use this example to run the custom-defined benchmark remotely using specified methods.
+    The benchmark name needs to be passed using --benchmark <bench_name> command line argument.
+    For the custom height example, one needs to specify `--benchmark height_benchmark`
+    """
+    logging.getLogger().setLevel(logging.INFO)
+    entry_point = Path(__file__).parent / "launch_custom_benchmark.py"
+    single_fidelity_methods = {
+        Methods.RS: all_methods[Methods.RS],
+        Methods.BO: all_methods[Methods.BO],
+    }
+    launch_remote(
+        entry_point=entry_point,
+        methods=single_fidelity_methods,
+        benchmark_definitions=height_benchmark,
+        extra_args=[
+            dict(
+                name="backend",
+                choices=["local", "sagemaker"],
+                required=True,
+                type=str,
+                help="Backed to use for experiment",
+            )
+        ],
+    )

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+syne-tune[gpsearchers,aws]


### PR DESCRIPTION
Expanding the list of examples with running custom scripts using benchmarking/commons. This is an update of [PR-509](https://github.com/awslabs/syne-tune/pull/509)

Changes:

- Added new examples that use benchmarking/commons to run experiments
- Updated examples.rst to refer to new examples
- modified hpo_main_local.py to make benchmark a required argument without a default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
