### PR TITLE
Some changes in benchmarking

### DIFF
--- a/benchmarking/commons/benchmark_definitions/yahpo.py
+++ b/benchmarking/commons/benchmark_definitions/yahpo.py
@@ -39,7 +39,7 @@ from benchmarking.commons.benchmark_definitions.lcbench import (
 
 def yahpo_nb301_benchmark(dataset_name):
     return SurrogateBenchmarkDefinition(
-        max_wallclock_time=6 * 3600,
+        max_wallclock_time=12 * 3600,
         n_workers=4,
         elapsed_time_attr="runtime",
         metric="val_accuracy",

--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -54,7 +54,14 @@ def parse_args(
         default_experiment_tag = generate_slug(2)
     except Exception:
         default_experiment_tag = "syne-tune-experiment"
-    parser = ArgumentParser()
+    parser = ArgumentParser(
+        description=(
+            "Run Syne Tune experiments for several HPO methods, benchmarks, "
+            "and seeds (repetitions). Use hpo_main.py to launch experiments "
+            "locally, or launch_remote.py to launch experiments remotely on AWS"
+        ),
+        epilog="For more information, please visit:\nhttps://syne-tune.readthedocs.io/en/latest/tutorials/benchmarking/README.html",
+    )
     parser.add_argument(
         "--experiment_tag",
         type=str,

--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -47,7 +47,7 @@ def parse_args(
         to be passed. Must contain ``name`` for argument name (without leading
         ``"--"``), and other kwargs to ``parser.add_argument``. Optional
     :return: ``(args, method_names, seeds)``, where ``args`` is result of
-        ``parser.parse_known_args()``, ``method_names`` see ``methods``, and
+        ``parser.parse_args()``, ``method_names`` see ``methods``, and
         ``seeds`` are list of seeds specified by ``--num_seeds`` and ``--start_seed``
     """
     try:
@@ -99,6 +99,15 @@ def parse_args(
         type=int,
         help=f"Limits number of datapoints for surrogate model of MOBSTER or HyperTune",
     )
+    parser.add_argument(
+        "--scale_max_wallclock_time",
+        type=int,
+        default=0,
+        help=(
+            "If 1, benchmark.max_wallclock_time is multiplied by B / min(A, B),"
+            "where A = n_workers and B = benchmark.n_workers"
+        ),
+    )
     if extra_args is not None:
         extra_args = copy.deepcopy(extra_args)
         for kwargs in extra_args:
@@ -107,8 +116,9 @@ def parse_args(
                 name[0] != "-"
             ), f"Name entry '{name}' in extra_args invalid: No leading '-'"
             parser.add_argument("--" + name, **kwargs)
-    args, _ = parser.parse_known_args()
+    args = parser.parse_args()
     args.save_tuner = bool(args.save_tuner)
+    args.scale_max_wallclock_time = bool(args.scale_max_wallclock_time)
     seeds = list(range(args.start_seed, args.num_seeds))
     method_names = [args.method] if args.method is not None else list(methods.keys())
     return args, method_names, seeds

--- a/benchmarking/commons/hpo_main_sagemaker.py
+++ b/benchmarking/commons/hpo_main_sagemaker.py
@@ -56,7 +56,7 @@ def parse_args(
         to be passed. Must contain ``name`` for argument name (without leading
         ``"--"``), and other kwargs to ``parser.add_argument``. Optional
     :return: ``(args, method_names, seeds)``, where ``args`` is result of
-        ``parser.parse_known_args()``, ``method_names`` see ``methods``, and
+        ``parser.parse_args()``, ``method_names`` see ``methods``, and
         ``seeds`` are list of seeds specified by ``--num_seeds`` and ``--start_seed``
     """
     if extra_args is None:
@@ -83,7 +83,7 @@ def parse_args(
             dict(
                 name="warm_pool",
                 type=int,
-                default=0,
+                default=1,
                 help=(
                     "If 1, the SageMaker managed warm pools feature is used. "
                     "This can be more expensive, but also reduces startup "

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -64,6 +64,7 @@ def get_hyperparameters(
         "num_seeds": seed + 1,
         "start_seed": seed,
         "random_seed": random_seed,
+        "scale_max_wallclock_time": int(args.scale_max_wallclock_time),
     }
     for k in (
         "n_workers",

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -58,6 +58,7 @@ def get_hyperparameters(
         "method": method,
         "save_tuner": int(args.save_tuner),
         "random_seed": random_seed,
+        "scale_max_wallclock_time": int(args.scale_max_wallclock_time),
     }
     if seed is not None:
         hyperparameters["num_seeds"] = seed + 1

--- a/benchmarking/nursery/launch_local/hpo_main.py
+++ b/benchmarking/nursery/launch_local/hpo_main.py
@@ -49,4 +49,4 @@ def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str
 
 
 if __name__ == "__main__":
-    main(methods, benchmark_definitions)
+    main(methods, benchmark_definitions, extra_args, map_extra_args)

--- a/benchmarking/nursery/launch_local/launch_remote.py
+++ b/benchmarking/nursery/launch_local/launch_remote.py
@@ -17,6 +17,7 @@ from benchmarking.commons.benchmark_definitions import (
     real_benchmark_definitions as benchmark_definitions,
 )
 from benchmarking.nursery.launch_local.baselines import methods
+from benchmarking.nursery.launch_local.hpo_main import extra_args
 
 
 if __name__ == "__main__":
@@ -25,4 +26,5 @@ if __name__ == "__main__":
         entry_point=entry_point,
         methods=methods,
         benchmark_definitions=benchmark_definitions,
+        extra_args=extra_args,
     )

--- a/benchmarking/nursery/launch_sagemaker/hpo_main.py
+++ b/benchmarking/nursery/launch_sagemaker/hpo_main.py
@@ -49,4 +49,4 @@ def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str
 
 
 if __name__ == "__main__":
-    main(methods, benchmark_definitions)
+    main(methods, benchmark_definitions, extra_args, map_extra_args)

--- a/benchmarking/nursery/launch_sagemaker/launch_remote.py
+++ b/benchmarking/nursery/launch_sagemaker/launch_remote.py
@@ -17,6 +17,7 @@ from benchmarking.commons.benchmark_definitions import (
     real_benchmark_definitions as benchmark_definitions,
 )
 from benchmarking.nursery.launch_sagemaker.baselines import methods
+from benchmarking.nursery.launch_sagemaker.hpo_main import extra_args
 
 
 if __name__ == "__main__":
@@ -25,4 +26,5 @@ if __name__ == "__main__":
         entry_point=entry_point,
         methods=methods,
         benchmark_definitions=benchmark_definitions,
+        extra_args=extra_args,
     )

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -153,6 +153,12 @@ This call runs a number of experiments sequentially on the local machine:
   specified in the benchmark definitions.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
   `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+* ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
+  argument, but not ``max_wallclock_time``, the benchmark default
+  ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
+  where ``A = n_workers``, ``B = benchmark.n_workers``. This means we run for
+  longer if ``n_workers < benchmark.n_workers``, but keep
+  ``benchmark.max_wallclock_time`` the same otherwise.
 
 If you defined additional arguments via ``extra_args``, you can use them
 here as well. For example, ``--num_brackets 3`` would run all


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Increase max_wallclock_time for NB301 benchmark
- parse_known_args -> parse_args (this flags misspelled args)
- scale_max_wallclock_time argument
- main_hpo_sagemaker: warm_pool on by default
- Fix in launch_local, launch_sagemaker
- Output link to docs in commandparser


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
