### PR TITLE
Updated stopping criterion recommended for PASHA

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -166,7 +166,7 @@ It takes only a few seconds to run, but it needs ``nasbench201`` blackbox
 to be downloaded and preprocessed, which can take a while when done
 for the first time.
 
-PASHA typically uses ``max_num_trials_started`` as the stopping criterion.
+PASHA typically uses ``max_num_trials_completed`` as the stopping criterion.
 After finding a strong configuration using PASHA, 
 the next step is to fully train a model with the configuration.
 


### PR DESCRIPTION
The previous one is misleading for a lot of folks which are not very familiar with the library. They try out the code setting a small number of evaluations to see if it runs and this often leads to a failure because the number of configuration started is smaller than the number of workers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
