### PR TITLE
fix: Fix of BOHB and SyncBOHB

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -354,7 +354,18 @@ class KernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
 
         return suggestion
 
-    def _good_data_size(self, data_shape: Tuple[int, int]) -> Optional[int]:
+    def _check_data_shape_and_good_size(
+        self, data_shape: Tuple[int, int]
+    ) -> Optional[int]:
+        """
+        Determine size of data for "good" model (the rest of the data is for the
+        "bad" model). Both sizes must be larger than the number of features,
+        otherwise ``None`` is returned.
+
+        :param data_shape: Shape of ``train_data``
+        :return: Size of data for "good" model, or ``None`` (models cannot be
+            fit, too little data)
+        """
         num_data, num_features = data_shape
         n_good = max(self.num_min_data_points, (self.top_n_percent * num_data) // 100)
         if min(n_good, num_data - n_good) <= num_features:
@@ -366,7 +377,7 @@ class KernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
         self, train_data: np.ndarray, train_targets: np.ndarray
     ) -> Optional[Tuple[Any, Any]]:
         train_data = train_data.reshape((train_targets.size, -1))
-        n_good = self._good_data_size(train_data.shape)
+        n_good = self._check_data_shape_and_good_size(train_data.shape)
         if n_good is None:
             return None
 

--- a/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/kde_searcher.py
@@ -368,6 +368,8 @@ class KernelDensityEstimator(StochasticAndFilterDuplicatesSearcher):
         """
         num_data, num_features = data_shape
         n_good = max(self.num_min_data_points, (self.top_n_percent * num_data) // 100)
+        # Number of data points have to be larger than the number of features to meet
+        # the input constraints of ``statsmodels.KDEMultivariate``
         if min(n_good, num_data - n_good) <= num_features:
             return None
         else:

--- a/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, Tuple
 import logging
 import numpy as np
 
@@ -86,23 +86,38 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
         ), "This searcher requires MultiFidelitySchedulerMixin scheduler"
         self.resource_attr = scheduler.resource_attr
 
-    def _train_kde(self, train_data, train_targets):
-        # find the highest resource level we have at least num_min_data_points data points
+    def _highest_resource_model_can_fit(self, num_features: int) -> Optional[int]:
         unique_resource_levels, counts = np.unique(
             self.resource_levels, return_counts=True
         )
-        idx = np.where(counts >= self.num_min_data_points)[0]
-        if len(idx) == 0:
-            return
+        for resource, count in reversed(list(zip(unique_resource_levels, counts))):
+            if self._good_data_size((count, num_features)) is not None:
+                return resource
+        return None
 
-        # collect data on the highest resource level
-        highest_resource_level = unique_resource_levels[idx[-1]]
-        indices = np.where(self.resource_levels == highest_resource_level)[0]
+    def _train_kde(
+        self, train_data: np.ndarray, train_targets: np.ndarray
+    ) -> Optional[Tuple[Any, Any]]:
+        """
+        Find the highest resource level so that the data only at that level is
+        large enough to train KDE models both on the good part and the rest.
+        If no such resource level exists, we return ``None``.
 
-        train_data = np.array([self.X[i] for i in indices])
-        train_targets = np.array([self.y[i] for i in indices])
-
-        super()._train_kde(train_data, train_targets)
+        :param train_data: Training input features
+        :param train_targets: Training targets
+        :return: Tuple of good model, bad model; or ``None``
+        """
+        train_data = train_data.reshape((train_targets.size, -1))
+        num_features = train_data.shape[1]
+        resource = self._highest_resource_model_can_fit(num_features)
+        if resource is None:
+            return None
+        else:
+            # Models can be fit
+            indices = np.where(self.resource_levels == resource)
+            sub_data = train_data[indices]
+            sub_targets = train_targets[indices]
+            return super()._train_kde(sub_data, sub_targets)
 
     def _update(self, trial_id: str, config: Dict, result: Dict):
         super()._update(trial_id=trial_id, config=config, result=result)

--- a/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/kde/multi_fidelity_kde_searcher.py
@@ -91,7 +91,7 @@ class MultiFidelityKernelDensityEstimator(KernelDensityEstimator):
             self.resource_levels, return_counts=True
         )
         for resource, count in reversed(list(zip(unique_resource_levels, counts))):
-            if self._good_data_size((count, num_features)) is not None:
+            if self._check_data_shape_and_good_size((count, num_features)) is not None:
                 return resource
         return None
 

--- a/tst/schedulers/test_kde_searcher.py
+++ b/tst/schedulers/test_kde_searcher.py
@@ -1,0 +1,109 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import pytest
+import numpy as np
+
+from syne_tune.optimizer.schedulers.searchers.kde import (
+    MultiFidelityKernelDensityEstimator,
+)
+from syne_tune.config_space import choice
+from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
+
+
+@pytest.mark.parametrize(
+    "resource_levels, top_n_percent, resource_acq",
+    [
+        (
+            [],
+            15,
+            None,
+        ),
+        (
+            [1, 1, 1, 3, 3, 1, 1],
+            15,
+            None,
+        ),
+        (
+            [1] * 6 + [3] * 2,
+            15,
+            None,
+        ),
+        (
+            [3] * 3 + [1] * 19,
+            20,
+            None,
+        ),
+        (
+            [3] * 3 + [1] * 20,
+            20,
+            1,
+        ),
+        (
+            [3] * 20 + [1] * 25 + [9] * 9,
+            20,
+            3,
+        ),
+        (
+            [3] * 3 + [1] * 20,
+            80,
+            1,
+        ),
+        (
+            [3] * 3 + [1] * 20,
+            85,
+            None,
+        ),
+    ],
+)
+def test_train_kde_multifidelity(resource_levels, top_n_percent, resource_acq):
+    random_seed = 31415927
+    random_state = np.random.RandomState(random_seed)
+    hp_cols = ("hp_x0", "hp_x1", "hp_x2")
+    config_space = {
+        node: choice(
+            ["avg_pool_3x3", "nor_conv_3x3", "skip_connect", "nor_conv_1x1", "none"]
+        )
+        for node in hp_cols
+    }
+    metric = "error"
+    resource_attr = "epoch"
+    searcher = MultiFidelityKernelDensityEstimator(
+        config_space=config_space,
+        metric=metric,
+        points_to_evaluate=[],
+        top_n_percent=top_n_percent,
+        resource_attr=resource_attr,
+    )
+    # Sample data at random (except for ``resource_levels``)
+    hp_ranges = make_hyperparameter_ranges(config_space)
+    num_data = len(resource_levels)
+    trial_ids = list(range(num_data))
+    configs = hp_ranges.random_configs(random_state, num_data)
+    metric_values = random_state.randn(num_data)
+    # Feed data to searcher
+    for trial_id, config, resource, metric_val in zip(
+        trial_ids, configs, resource_levels, metric_values
+    ):
+        searcher._update(
+            trial_id=trial_id,
+            config=config,
+            result={metric: metric_val, resource_attr: resource},
+        )
+    # Test n_good
+    num_features = len(hp_cols)
+    assert searcher.num_min_data_points == num_features
+    assert searcher._highest_resource_model_can_fit(num_features) == resource_acq, (
+        resource_levels,
+        top_n_percent,
+        resource_acq,
+    )


### PR DESCRIPTION
Conditions in `KernelDensityEstimator` for whether KDE models can be fit are typically violated in `MultiFidelityKernelDensityEstimator`, so this did the same as ASHA. Here, I am changing the choice of `r_acq` to depend on the "can fit" decision

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
