### PR TITLE
refactor: Use longer descriptive names for result directories

### DIFF
--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -115,6 +115,12 @@ def parse_args(
             "where A = n_workers and B = benchmark.n_workers"
         ),
     )
+    parser.add_argument(
+        "--use_long_tuner_name_prefix",
+        type=int,
+        default=1,
+        help="Use descriptive tuner name prefix for storing results?",
+    )
     if extra_args is not None:
         extra_args = copy.deepcopy(extra_args)
         for kwargs in extra_args:
@@ -126,6 +132,7 @@ def parse_args(
     args = parser.parse_args()
     args.save_tuner = bool(args.save_tuner)
     args.scale_max_wallclock_time = bool(args.scale_max_wallclock_time)
+    args.use_long_tuner_name_prefix = bool(args.use_long_tuner_name_prefix)
     seeds = list(range(args.start_seed, args.num_seeds))
     method_names = [args.method] if args.method is not None else list(methods.keys())
     return args, method_names, seeds

--- a/benchmarking/commons/hpo_main_local.py
+++ b/benchmarking/commons/hpo_main_local.py
@@ -158,11 +158,14 @@ def create_objects_for_tuner(
         benchmark=benchmark,
         extra_args=None if extra_args is None else extra_metadata(args, extra_args),
     )
+    tuner_name = args.experiment_tag
+    if args.use_long_tuner_name_prefix:
+        tuner_name += f"-{args.benchmark}-{seed}"
     return dict(
         scheduler=scheduler,
         stop_criterion=stop_criterion,
         n_workers=benchmark.n_workers,
-        tuner_name=args.experiment_tag,
+        tuner_name=tuner_name,
         metadata=metadata,
         save_tuner=args.save_tuner,
     )

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -350,6 +350,9 @@ def main(
             metadata["predict_curves"] = int(
                 benchmark.add_surrogate_kwargs["predict_curves"]
             )
+        tuner_name = experiment_tag
+        if args.use_long_tuner_name_prefix:
+            tuner_name += f"-{benchmark_name}-{seed}"
         tuner = Tuner(
             trial_backend=trial_backend,
             scheduler=scheduler,
@@ -359,7 +362,7 @@ def main(
             callbacks=[SimulatorCallback()],
             results_update_interval=600,
             print_update_interval=600,
-            tuner_name=experiment_tag,
+            tuner_name=tuner_name,
             metadata=metadata,
             save_tuner=args.save_tuner,
         )

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -73,6 +73,17 @@ GPU with PyTorch being installed):
   for the selected benchmark by these command line arguments.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
   `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+* ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
+  argument, but not ``max_wallclock_time``, the benchmark default
+  ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
+  where ``A = n_workers``, ``B = benchmark.n_workers``. This means we run for
+  longer if ``n_workers < benchmark.n_workers``, but keep
+  ``benchmark.max_wallclock_time`` the same otherwise.
+* ``use_long_tuner_name_prefix``: If 1, results for an experiment are written
+  to a directory whose prefix is
+  :code:`f"{experiment_tag}-{benchmark_name}-{seed}"`, followed by a postfix
+  containing date-time and a 3-digit hash. If 0, the prefix is
+  :code:`experiment_tag` only. The default is 1 (long prefix).
 
 If you defined additional arguments via ``extra_args``, you can use them here
 as well.

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -70,6 +70,17 @@ arguments are:
   `below <bm_sagemaker.html#using-sagemaker-managed-warm-pools>`_.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
   `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+* ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
+  argument, but not ``max_wallclock_time``, the benchmark default
+  ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
+  where ``A = n_workers``, ``B = benchmark.n_workers``. This means we run for
+  longer if ``n_workers < benchmark.n_workers``, but keep
+  ``benchmark.max_wallclock_time`` the same otherwise.
+* ``use_long_tuner_name_prefix``: If 1, results for an experiment are written
+  to a directory whose prefix is
+  :code:`f"{experiment_tag}-{benchmark_name}-{seed}"`, followed by a postfix
+  containing date-time and a 3-digit hash. If 0, the prefix is
+  :code:`experiment_tag` only. The default is 1 (long prefix).
 
 If you defined additional arguments via ``extra_args``, you can use them here
 as well.

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -162,6 +162,11 @@ This call runs a number of experiments sequentially on the local machine:
   where ``A = n_workers``, ``B = benchmark.n_workers``. This means we run for
   longer if ``n_workers < benchmark.n_workers``, but keep
   ``benchmark.max_wallclock_time`` the same otherwise.
+* ``use_long_tuner_name_prefix``: If 1, results for an experiment are written
+  to a directory whose prefix is
+  :code:`f"{experiment_tag}-{benchmark_name}-{seed}"`, followed by a postfix
+  containing date-time and a 3-digit hash. If 0, the prefix is
+  :code:`experiment_tag` only. The default is 1 (long prefix).
 * ``restrict_configurations``: See
   `below <#restricting-scheduler-to-configurations-of-tabulated-blackbox>`_.
 * ``fcnet_ordinal``: Applies to FCNet benchmarks only. The hyperparameter


### PR DESCRIPTION
In the current code, benchmake name and seed are not contained in the directory name for the results, but just in metadata.json. A more descriptive filename makes it easier to pick out or remove specific results.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
