### PR TITLE
chore: disable codecov inline annotations

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,6 +2,9 @@ ignore:
   - "docs/*"
   - "examples/*"
 
+github_checks:
+    annotations: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Disable inline codecov comments

Following docs: https://docs.codecov.com/docs/github-checks

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
