### PR TITLE
fix: Make reference anonymous to avoid Sphinx warnings

### DIFF
--- a/docs/source/benchmarking/benchmark_dehb.rst
+++ b/docs/source/benchmarking/benchmark_dehb.rst
@@ -2,7 +2,7 @@ Code in benchmarking/nursery/benchmark_dehb
 ===========================================
 
 Comparison of
-`DEHB <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`_
+`DEHB <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`__
 against a number of baselines.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/baselines.py

--- a/docs/source/benchmarking/benchmark_hypertune.rst
+++ b/docs/source/benchmarking/benchmark_hypertune.rst
@@ -2,7 +2,7 @@ Code in benchmarking/nursery/benchmark_hypertune
 ================================================
 
 Comparison of
-`Hyper-Tune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`_
+`Hyper-Tune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`__
 against a number of baselines.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/baselines.py

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -23,7 +23,7 @@ Fine-Tuning Hugging Face Model for Sentiment Classification
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__
 * Runs on four ``ml.g4dn.xlarge`` instances
 
 In this example, we use the SageMaker backend together with the
@@ -31,10 +31,10 @@ SageMaker Hugging Face framework in order to fine-tune a DistilBERT
 model on the IMDB sentiment classification task. This task is one of
 our built-in benchmarks. For other ways to run this benchmark on
 different backends or remotely, consult
-`this tutorial <tutorials/benchmarking/README.html>`_.
+`this tutorial <tutorials/benchmarking/README.html>`__.
 
 A more advanced example for fine-tuning Hugging Face transformers is given
-`here <benchmarking/fine_tuning_transformer_glue.html>`_.
+`here <benchmarking/fine_tuning_transformer_glue.html>`__.
 
 
 Launch HPO Experiment with Python Backend
@@ -66,7 +66,7 @@ For this toy example, PBT is run with a population size of 2, so only
 two parallel workers are needed. In order to use PBT competitively,
 choose the SageMaker backend. Note that PBT requires your training
 script to
-`support checkpointing <faq.html#how-can-i-enable-trial-checkpointing>`_.
+`support checkpointing <faq.html#how-can-i-enable-trial-checkpointing>`__.
 
 
 Visualize Tuning Progress with Tensorboard
@@ -99,7 +99,7 @@ Launch HPO Experiment with Simulator Backend
 
 * Needs ``nasbench201`` blackbox to be downloaded and preprocessed. This can
   take quite a while when done for the first time
-* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`_
+* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`__
   or an S3 bucket is accessible, the blackbox files are uploaded to your S3
   bucket
 
@@ -107,7 +107,7 @@ In this example, we use the simulator backend with the NASBench-201
 blackbox. Since time is simulated, we can use
 ``max_wallclock_time=3600`` (one hour), but the experiment finishes
 in mere seconds. More details about the simulator backend is found in
-`this tutorial <tutorials/benchmarking/bm_simulator.html>`_.
+`this tutorial <tutorials/benchmarking/bm_simulator.html>`__.
 
 
 Joint Tuning of Instance Type and Hyperparameters using MOASHA
@@ -119,7 +119,7 @@ Joint Tuning of Instance Type and Hyperparameters using MOASHA
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__
 * Runs training jobs on instances of type ``ml.g4dn.xlarge``, ``ml.g5.xlarge``,
   ``ml.g4dn.2xlarge``, ``ml.p2.xlarge``, ``ml.g5.2xlarge``, ``ml.g5.4xlarge``,
   ``ml.g4dn.4xlarge``, ``ml.g5.8xlarge``, ``ml.g4dn.8xlarge``,
@@ -198,12 +198,12 @@ Restrict Scheduler to Tabulated Configurations with Simulator Backend
 
 * Needs ``lcbench`` blackbox to be downloaded and preprocessed. This can
   take quite a while when done for the first time
-* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`_
+* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`__
   or an S3 bucket is accessible, the blackbox files are uploaded to your S3
   bucket
 
 This example is similar to the one
-`above <#launch-hpo-experiment-with-simulator-backend>`_, but here we use
+`above <#launch-hpo-experiment-with-simulator-backend>`__, but here we use
 the tabulated LCBench benchmark, whose configuration space is infinite, and
 whose objective values have not been evaluated on a grid. With such a
 benchmark, we can either use a surrogate to interpolate objective values, or
@@ -213,7 +213,7 @@ been observed in the benchmark. This example demonstrates the latter.
 Since time is simulated, we can use ``max_wallclock_time=3600`` (one hour),
 but the experiment finishes in mere seconds. More details about the simulator
 backend is found in
-`this tutorial <tutorials/benchmarking/bm_simulator.html>`_.
+`this tutorial <tutorials/benchmarking/bm_simulator.html>`__.
 
 
 Tuning Reinforcement Learning
@@ -247,11 +247,11 @@ Launch HPO Experiment with SageMaker Backend
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
   More details are provided in
-  `this tutorial <tutorials/basics/basics_backend.html>`_.
+  `this tutorial <tutorials/basics/basics_backend.html>`__.
 * This example can be sped up by using SageMaker managed warm pools, as in
-  `this example <#sagemaker-backend-and-checkpointing>`_.
+  `this example <#sagemaker-backend-and-checkpointing>`__.
 
 Makes use of :ref:`train_height.py <train_height_script>`.
 
@@ -265,7 +265,7 @@ SageMaker Backend and Checkpointing
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 
 This launcher script is using the following
 :ref:`train_height_checkpoint.py <train_height_checkpoint_script>` training script:
@@ -285,7 +285,7 @@ SageMaker managed warm pools:
 Managed warm pools reduce both start-up and stop delays substantially, they
 are strongly recommended for multi-fidelity HPO with the SageMaker backend.
 More details are found in
-`this tutorial <tutorials/benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`_.
+`this tutorial <tutorials/benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`__.
 
 
 Retrieving the Best Checkpoint
@@ -313,7 +313,7 @@ Launch with SageMaker Backend and Custom Docker Image
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 * This example is incomplete. If your training script has dependencies which
   you would to provide as a Docker image, you need to upload it to ECR,
   after which you can refer to it with ``image_uri``.
@@ -330,14 +330,14 @@ Launch Experiments Remotely on SageMaker
 
 **Requirements**:
 
-* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+* `Access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 
 Makes use of :ref:`train_height.py <train_height_script>`.
 
 This launcher script starts the HPO experiment as SageMaker training job,
 which allows you to select any instance type you like, while not having
 your local machine being blocked.
-`This tutorial <tutorials/benchmarking/README.html>`_ explains how to
+`This tutorial <tutorials/benchmarking/README.html>`__ explains how to
 run many such remote experiments in parallel, so to speed up comparisons
 between alternatives.
 
@@ -353,7 +353,7 @@ Makes use of :ref:`train_height.py <train_height_script>`.
 
 For a more thorough introduction on how to develop new schedulers and
 searchers in Syne Tune, consider
-`this tutorial <tutorials/developer/README.html>`_.
+`this tutorial <tutorials/developer/README.html>`__.
 
 
 Launch HPO Experiment on mlp_fashionmnist Benchmark
@@ -366,7 +366,7 @@ Launch HPO Experiment on mlp_fashionmnist Benchmark
 In this example, we tune one of the built-in benchmark problems, which
 is useful in order to compare different HPO methods. More details on
 benchmarking is provided in
-`this tutorial <tutorials/benchmarking/README.html>`_.
+`this tutorial <tutorials/benchmarking/README.html>`__.
 
 
 Transfer Tuning on NASBench-201
@@ -380,7 +380,7 @@ Transfer Tuning on NASBench-201
 
 * Needs ``nasbench201`` blackbox to be downloaded and preprocessed. This can
   take quite a while when done for the first time
-* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`_
+* If `AWS SageMaker is used  <faq.html#how-can-i-run-on-aws-and-sagemaker>`__
   or an S3 bucket is accessible, the blackbox files are uploaded to your S3
   bucket
 
@@ -404,7 +404,7 @@ Transfer Learning Example
 An example of how to use evaluations collected in Syne Tune to run a transfer
 learning scheduler. Makes use of :ref:`train_height.py <train_height_script>`.
 Used in the
-`transfer learning tutorial <tutorials/transfer_learning/transfer_learning.html>`_.
+`transfer learning tutorial <tutorials/transfer_learning/transfer_learning.html>`__.
 To plot the figures, run as
 `python launch_transfer_learning_example.py --generate_plots`.
 
@@ -433,7 +433,7 @@ Pass Configuration as JSON File to Training Script
 **Requirements**:
 
 * If ``use_sagemaker_backend = True``, needs
-  `access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+  `access to AWS SageMaker <faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 
 Makes use of the following
 :ref:`train_height_config_json.py <train_height_config_json_script>` training

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,8 +4,8 @@ Why should I use Syne Tune?
 Hyperparameter Optimization (HPO) has been an important problem for many years,
 and a variety of commercial and open-source tools are available to help
 practitioners run HPO efficiently. Notable examples for open source
-tools are `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`_ and
-`Optuna <https://optuna.readthedocs.io/en/stable/>`_. Here are some reasons
+tools are `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__ and
+`Optuna <https://optuna.readthedocs.io/en/stable/>`__. Here are some reasons
 why you may prefer Syne Tune over these alternatives:
 
 * **Lightweight and platform-agnostic**: Syne Tune is designed to work with
@@ -16,16 +16,16 @@ why you may prefer Syne Tune over these alternatives:
   population based training.
 * **Simple, modular design**: Rather than wrapping all sorts of other HPO
   frameworks, Syne Tune provides simple APIs and scheduler templates, which can
-  easily be `extended to your specific needs <tutorials/developer/README.html>`_.
+  easily be `extended to your specific needs <tutorials/developer/README.html>`__.
 * **Industry-strength Bayesian optimization**: Syne Tune has special support
-  for `Gaussian process based Bayesian optimization <tutorials/basics/basics_bayesopt.html>`_.
+  for `Gaussian process based Bayesian optimization <tutorials/basics/basics_bayesopt.html>`__.
   The same code powers modalities like multi-fidelity HPO, constrained HPO, or
   cost-aware HPO, having been tried and tested for several years.
 * **Special support for researchers**: Syne Tune allows for rapid development
   and comparison between different tuning algorithms. Its
-  `blackbox repository and simulator backend <tutorials/multifidelity/mf_setup.html>`_
+  `blackbox repository and simulator backend <tutorials/multifidelity/mf_setup.html>`__
   run realistic simulations of experiments many times faster than real time.
-  `Benchmarking <tutorials/benchmarking/README.html>`_ is simple and efficient.
+  `Benchmarking <tutorials/benchmarking/README.html>`__ is simple and efficient.
 
 If you are an AWS customer, there are additional good reasons to use Syne Tune
 over the alternatives:
@@ -33,7 +33,7 @@ over the alternatives:
 * If you use AWS services or SageMaker frameworks day to day, Syne Tune works
   out of the box and fits into your normal workflow.
 * Syne Tune is developed in collaboration with the team behind the
-  `Automatic Model Tuning <https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html>`_
+  `Automatic Model Tuning <https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html>`__
   service.
 
 What are the different installation options supported?
@@ -54,7 +54,7 @@ Ray Tune or Bore optimizer, you can run ``pip install 'syne-tune[X]'`` where
   :class:`~syne_tune.optimizer.baselines.MOBSTER`, or
   :class:`~syne_tune.optimizer.baselines.HyperTune`)
 * ``aws``: AWS SageMaker dependencies. These are required for
-  `remote launching <#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`_
+  `remote launching <#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`__
   or for the :class:`~syne_tune.backend.SageMakerBackend`
 * ``raytune``: For Ray Tune optimizers (see
   :class:`~syne_tune.optimizer.schedulers.RayTuneScheduler`), installs all Ray
@@ -108,11 +108,11 @@ your local machine, you will need access to AWS and SageMaker on your machine.
 Make sure that:
 
 * ``awscli`` is installed (see
-  `this link <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html>`_)
+  `this link <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html>`__)
 * AWS credentials have been set properly (see
-  `this link <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>`_).
+  `this link <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>`__).
 * The necessary SageMaker role has been created (see
-  `this page <https://docs.aws.amazon.com/glue/latest/dg/create-an-iam-role-sagemaker-notebook.html>`_
+  `this page <https://docs.aws.amazon.com/glue/latest/dg/create-an-iam-role-sagemaker-notebook.html>`__
   for instructions. If you’ve created a SageMaker notebook in the past, this
   role should already have been created for you).
 
@@ -162,7 +162,7 @@ To utilize multiple GPUs you can either use the backend
 :class:`~syne_tune.backend.LocalBackend`, which will run on the GPU available
 in a local machine. You can also run on a remote AWS instance with multiple GPUs
 using the local backend and the remote launcher, see
-`here <#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`_,
+`here <#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`__,
 or run with the :class:`~syne_tune.backend.SageMakerBackend` which spins-up one
 training job per trial.
 
@@ -245,15 +245,15 @@ checkpointing enabled:
    :lines: 13-
 
 When using the SageMaker backend, we use the
-`SageMaker checkpoint mechanism <https://docs.aws.amazon.com/sagemaker/latest/dg/model-checkpoints.html>`_
+`SageMaker checkpoint mechanism <https://docs.aws.amazon.com/sagemaker/latest/dg/model-checkpoints.html>`__
 under the hood to sync local checkpoints to S3. Checkpoints are synced to
 ``s3://{sagemaker-default-bucket}/syne-tune/{tuner-name}/{trial-id}/``,
 where ``sagemaker-default-bucket`` is the default bucket for SageMaker. A complete
 example is given by
-`examples/launch_height_sagemaker_checkpoints.py <examples.html#sageMaker-backend-and-checkpointing>`_.
+`examples/launch_height_sagemaker_checkpoints.py <examples.html#sageMaker-backend-and-checkpointing>`__.
 
 The same mechanism is used to regularly write the
-`tuning results to S3 during remote tuning <#where-can-i-find-the-output-of-the-tuning>`_.
+`tuning results to S3 during remote tuning <#where-can-i-find-the-output-of-the-tuning>`__.
 However, during remote tuning with the *local backend*, we do not want
 checkpoints to be synced to S3, since they are only required temporarily on the
 same instance. Syncing them to S3 would be costly and error-prone, because the
@@ -262,14 +262,14 @@ and reading from the sync directory concurrently. In this case, we can switch
 off syncing checkpoints to S3 (but not tuning results!) by setting
 ``trial_backend_path=backend_path_not_synced_to_s3()`` when creating the
 :class:`~syne_tune.Tuner` object. An example is
-`fine_tuning_transformer_glue/hpo_main.py <benchmarking/fine_tuning_transformer_glue.html>`_.
+`fine_tuning_transformer_glue/hpo_main.py <benchmarking/fine_tuning_transformer_glue.html>`__.
 It is also supported by default in the
-`benchmarking framework <tutorials/benchmarking/README.html>`_ and in
+`benchmarking framework <tutorials/benchmarking/README.html>`__ and in
 :class:`~syne_tune.remote.RemoteLauncher`.
 
 There are some convenience functions which help you to implement checkpointing
 for your training script. Have a look at
-`resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`_:
+`resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`__:
 
 * Checkpoints have to be written at the end of certain epochs (namely
   those after which the scheduler may pause the trial). This is dealt with
@@ -301,7 +301,7 @@ How can I retrieve the best checkpoint obtained after tuning?
 =============================================================
 
 You can take a look at this example
-`examples/launch_checkpoint_example.py <examples.html#retrieving-the-best-checkpoint>`_
+`examples/launch_checkpoint_example.py <examples.html#retrieving-the-best-checkpoint>`__
 which shows how to retrieve the best checkpoint obtained after tuning an XGBoost model.
 
 Which schedulers make use of checkpointing?
@@ -394,7 +394,7 @@ How can I plot the results of a tuning?
 
 Some basic plots can be obtained via
 :class:`~syne_tune.experiments.ExperimentResult`. An example is given in
-`examples/launch_plot_results.py <examples.html#plot-results-of-tuning-experiment>`_.
+`examples/launch_plot_results.py <examples.html#plot-results-of-tuning-experiment>`__.
 
 How can I specify additional tuning metadata?
 =============================================
@@ -428,7 +428,7 @@ information, you can inherit from this class. An example is given in
 
 If you run experiments with tabulated benchmarks using the
 :class:`~syne_tune.blackbox_repository.BlackboxRepositoryBackend`, as demonstrated in
-`launch_nasbench201_simulated.py <examples.html#launch-hpo-experiment-with-simulator-backend>`_,
+`launch_nasbench201_simulated.py <examples.html#launch-hpo-experiment-with-simulator-backend>`__,
 results are stored by
 :class:`~syne_tune.backend.simulator_backend.simulator_callback.SimulatorCallback`
 instead, and you need to inherit from this class. An example is given in
@@ -452,25 +452,25 @@ trials will be evaluated on the remote machine (one use-case being to use a
 beefy machine), in the latter case trials will be evaluated as separate
 SageMaker training jobs. An example for running the remote launcher is
 given in
-`launch_height_sagemaker_remotely.py <examples.html#launch-experiments-remotely-on-sagemaker>`_.
+`launch_height_sagemaker_remotely.py <examples.html#launch-experiments-remotely-on-sagemaker>`__.
 
 Remote launching for benchmarking (i.e., running many remote experiments
 in order to compare multiple methods) is detailed in
-`this tutorial <tutorials/benchmarking/README.html>`_.
+`this tutorial <tutorials/benchmarking/README.html>`__.
 
 How can I run many experiments in parallel?
 ===========================================
 
 You can remotely launch any number of experiments, which will then run
 in parallel, as detailed in
-`this tutorial <tutorials/benchmarking/README.html>`_, see also these examples:
+`this tutorial <tutorials/benchmarking/README.html>`__, see also these examples:
 
 * Local backend:
-  `benchmarking/nursery/launch_local/ <benchmarking/launch_local.html>`_
+  `benchmarking/nursery/launch_local/ <benchmarking/launch_local.html>`__
 * Simulator backend:
-  `benchmarking/nursery/benchmark_dehb/ <benchmarking/benchmark_dehb.html>`_
+  `benchmarking/nursery/benchmark_dehb/ <benchmarking/benchmark_dehb.html>`__
 * SageMaker backend:
-  `benchmarking/nursery/launch_sagemaker/ <benchmarking/launch_sagemaker.html>`_
+  `benchmarking/nursery/launch_sagemaker/ <benchmarking/launch_sagemaker.html>`__
 
 How can I access results after tuning remotely?
 ===============================================
@@ -501,31 +501,31 @@ When you run remote code, you often need to install packages
   launcher or on a SageMaker framework to a list of folders. The
   folders indicated will be compressed, sent to S3 and added to the
   python path when the container starts. More details are given in
-  `this tutorial <tutorials/benchmarking/bm_sagemaker.html>`_.
+  `this tutorial <tutorials/benchmarking/bm_sagemaker.html>`__.
 
 How can I benchmark different methods?
 ======================================
 
 The most flexible way to do so is to write a custom launcher script, as
-detailed in `this tutorial <tutorials/benchmarking/README.html>`_, see
+detailed in `this tutorial <tutorials/benchmarking/README.html>`__, see
 also these examples:
 
 * Local backend:
-  `benchmarking/nursery/launch_local/ <benchmarking/launch_local.html>`_
+  `benchmarking/nursery/launch_local/ <benchmarking/launch_local.html>`__
 * Simulator backend:
-  `benchmarking/nursery/benchmark_dehb/ <benchmarking/benchmark_dehb.html>`_
+  `benchmarking/nursery/benchmark_dehb/ <benchmarking/benchmark_dehb.html>`__
 * SageMaker backend:
-  `benchmarking/nursery/launch_sagemaker/ <benchmarking/launch_sagemaker.html>`_
+  `benchmarking/nursery/launch_sagemaker/ <benchmarking/launch_sagemaker.html>`__
 * Fine-tuning transformers:
-  `benchmarking/nursery/fine_tuning_transformer_glue/ <benchmarking/fine_tuning_transformer_glue.html>`_
+  `benchmarking/nursery/fine_tuning_transformer_glue/ <benchmarking/fine_tuning_transformer_glue.html>`__
 * Hyper-Tune:
-  `benchmarking/nursery/benchmark_hypertune/ <benchmarking/benchmark_hypertune.html>`_
+  `benchmarking/nursery/benchmark_hypertune/ <benchmarking/benchmark_hypertune.html>`__
 
 What different schedulers do you support? What are the main differences between them?
 =====================================================================================
 
 A succinct overview of supported schedulers is provided
-`here <getting_started.html#supported-hpo-methods>`_.
+`here <getting_started.html#supported-hpo-methods>`__.
 
 Most methods can be accessed with short names by from
 :mod:`syne_tune.optimizer.baselines`, which is the best place to start.
@@ -549,26 +549,26 @@ single-objective case are:
   The latter can be more expensive if a lot of trials are run, but can also
   be more sample-efficient.
 
-An overview of this landscape is given `here <schedulers.html>`_.
+An overview of this landscape is given `here <schedulers.html>`__.
 
 Here is a
-`tutorial for multi-fidelity schedulers <tutorials/multifidelity/README.html>`_.
+`tutorial for multi-fidelity schedulers <tutorials/multifidelity/README.html>`__.
 Further schedulers provided by Syne Tune include:
 
-* `Population based training (PBT) <examples.html#population-based-training-pbt>`_
-* `Multi-objective asynchronous successive halving (MOASHA) <examples.html#multi-objective-asynchronous-successive-halving-moasha>`_
-* `Constrained Bayesian optimization <examples.html#constrained-bayesian-optimization>`_
+* `Population based training (PBT) <examples.html#population-based-training-pbt>`__
+* `Multi-objective asynchronous successive halving (MOASHA) <examples.html#multi-objective-asynchronous-successive-halving-moasha>`__
+* `Constrained Bayesian optimization <examples.html#constrained-bayesian-optimization>`__
 * Bayesian optimization by density-ratio estimation:
   :class:`~syne_tune.optimizer.baselines.BORE`
 * Regularized evolution: :class:`~syne_tune.optimizer.baselines.REA`
 * Median stopping rule:
   :class:`~syne_tune.optimizer.schedulers.median_stopping_rule.MedianStoppingRule`
-* `Synchronous Hyperband <tutorials/multifidelity/mf_syncsh.html>`_
-* `Differential Evolution Hyperband (DEHB) <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`_
-* `Hyper-Tune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`_
-* `DyHPO <tutorials/multifidelity/mf_async_model.html#dyhpo>`_
-* `Transfer learning schedulers <examples.html#transfer-tuning-on-nasbench-201>`_
-* `Wrappers for Ray Tune schedulers <examples.html#launch-hpo-experiment-with-ray-tune-scheduler>`_
+* `Synchronous Hyperband <tutorials/multifidelity/mf_syncsh.html>`__
+* `Differential Evolution Hyperband (DEHB) <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`__
+* `Hyper-Tune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`__
+* `DyHPO <tutorials/multifidelity/mf_async_model.html#dyhpo>`__
+* `Transfer learning schedulers <examples.html#transfer-tuning-on-nasbench-201>`__
+* `Wrappers for Ray Tune schedulers <examples.html#launch-hpo-experiment-with-ray-tune-scheduler>`__
 
 How do I define the search space?
 =================================
@@ -577,7 +577,7 @@ While the training script defines the function to be optimized, some
 care needs to be taken to define the search space for the hyperparameter
 optimization problem. This being a global optimization problem without
 gradients easily available, it is most important to reduce the number of
-parameters. Some advice is given `here <search_space.html>`_.
+parameters. Some advice is given `here <search_space.html>`__.
 
 A powerful approach is to run experiments in parallel. Namely, split
 your hyperparameters into groups A, B, such that HPO over B is
@@ -585,7 +585,7 @@ tractable. Draw a set of N configurations from A at random, then start N
 HPO experiments in parallel, where in each of them the search space is
 over B only, while the parameters in A are fixed. Syne Tune supports
 massively parallel experimentation, see
-`this tutorial <tutorials/benchmarking/README.html>`_.
+`this tutorial <tutorials/benchmarking/README.html>`__.
 
 How do I set arguments of multi-fidelity schedulers?
 ====================================================
@@ -599,7 +599,7 @@ or :class:`~syne_tune.optimizer.baselines.DEHB`, there are mandatory parameters
 What are they for?
 
 Full details are given in this
-`tutorial <tutorials/multifidelity/README.html>`_. Multi-fidelity HPO needs
+`tutorial <tutorials/multifidelity/README.html>`__. Multi-fidelity HPO needs
 metric values to be reported at regular intervals during training, for example
 after every epoch, or for successively larger training datasets. These
 reports are indexed by a *resource value*, which is a positive integer (for
@@ -624,7 +624,7 @@ example, the number of epochs already trained).
   maximum resource value in your configuration space, you can pass the
   value directly as ``max_t``. However, this can lead to avoidable errors,
   and may be
-  `inefficient for some schedulers <tutorials/multifidelity/mf_setup.html#the-launcher-script>`_.
+  `inefficient for some schedulers <tutorials/multifidelity/mf_setup.html#the-launcher-script>`__.
 
 .. note::
    When creating a multi-fidelity scheduler, we recommend to use
@@ -635,7 +635,7 @@ How can I visualize the progress of my tuning experiment with Tensorboard?
 ==========================================================================
 
 To visualize the progress of Syne Tune in
-`Tensorboard <https://www.tensorflow.org/tensorboard>`_, you can pass
+`Tensorboard <https://www.tensorflow.org/tensorboard>`__, you can pass
 the :class:`~syne_tune.callbacks.TensorboardCallback` to the
 :class:`~syne_tune.Tuner` object:
 
@@ -649,7 +649,7 @@ the :class:`~syne_tune.callbacks.TensorboardCallback` to the
    )
 
 Note that, you need to install
-`TensorboardX <https://github.com/lanpa/tensorboardX>`_ to use this callback:
+`TensorboardX <https://github.com/lanpa/tensorboardX>`__ to use this callback:
 
 .. code:: bash
 
@@ -666,17 +666,17 @@ If you want to plot the cumulative optimum of the metric you want to
 optimize, you can pass the ``target_metric`` argument to
 class:`syne_tune.callbacks.TensorboardCallback`. This will also report the best
 found hyperparameter configuration over time. A complete example is
-`examples/launch_tensorboard_example.py <examples.html#visualize-tuning-progress-with-tensorboard>`_.
+`examples/launch_tensorboard_example.py <examples.html#visualize-tuning-progress-with-tensorboard>`__.
 
 How can I add a new scheduler?
 ==============================
 
 This is explained in detail in
-`this tutorial <tutorials/developer/README.html>`_, and also in
-`examples/launch_height_standalone_scheduler <examples.html#launch-hpo-experiment-with-home-made-scheduler>`_.
+`this tutorial <tutorials/developer/README.html>`__, and also in
+`examples/launch_height_standalone_scheduler <examples.html#launch-hpo-experiment-with-home-made-scheduler>`__.
 
 Please do consider
-`contributing back <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_
+`contributing back <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__
 your efforts to the Syne Tune community, thanks!
 
 How can I add a new tabular or surrogate benchmark?
@@ -696,7 +696,7 @@ To add a new dataset of tabular evaluations, you need to:
   it available in Syne Tune.
 
 Further details are given
-`here <tutorials/benchmarking/bm_contributing.html#contributing-a-tabulated-benchmark>`_.
+`here <tutorials/benchmarking/bm_contributing.html#contributing-a-tabulated-benchmark>`__.
 
 How can I reduce delays in starting trials with the SageMaker backend?
 ======================================================================
@@ -704,10 +704,10 @@ How can I reduce delays in starting trials with the SageMaker backend?
 The SageMaker backend executes each trial as a SageMaker training job, which
 encurs start-up delays up to several minutes. These delays can be reduced to
 about 20 seconds with
-`SageMaker managed warm pools <https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html>`_,
+`SageMaker managed warm pools <https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html>`__,
 as is detailed in
-`this tutorial <tutorials/benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`_
-or `this example <examples.html#sagemaker-backend-and-checkpointing>`_. We
+`this tutorial <tutorials/benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`__
+or `this example <examples.html#sagemaker-backend-and-checkpointing>`__. We
 strongly recommend to use managed warm pools with the SageMaker backend.
 
 How can I pass lists or dictionaries to the training script?
@@ -733,7 +733,7 @@ as follows:
    :lines: 74-79
 
 The complete example is
-`here <examples.html#pass-configuration-as-json-file-to-training-script>`_.
+`here <examples.html#pass-configuration-as-json-file-to-training-script>`__.
 Note that entries automatically appended to the configuration by Syne Tune, such
 as :const:`~syne_tune.constants.ST_CHECKPOINT_DIR`, are passed as command line
 arguments in any case.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -8,7 +8,7 @@ To install Syne Tune from pip, you can simply do:
    pip install 'syne-tune[extra]'
 
 For development, you may want to get the latest version from
-`github <https://github.com/awslabs/syne-tune>`_:
+`github <https://github.com/awslabs/syne-tune>`__:
 
 .. code-block:: bash
 
@@ -24,12 +24,12 @@ this environment before working with Syne Tune. We also recommend building the
 virtual environment from scratch now and then, in particular when you pull a new
 release, as dependencies may have changed.
 
-See our `change log <https://github.com/awslabs/syne-tune/blob/main/CHANGELOG.md>`_ to
+See our `change log <https://github.com/awslabs/syne-tune/blob/main/CHANGELOG.md>`__ to
 check what has changed in the latest version.
 
 In the examples above, Syne Tune is installed with the union of all its
 dependencies, which can be a lot. If you only need specific features, you may
-be able to use `partial dependencies <faq.html#what-are-the-different-installations-options-supported>`_.
+be able to use `partial dependencies <faq.html#what-are-the-different-installations-options-supported>`__.
 
 First Example
 =============
@@ -96,7 +96,7 @@ tuning experiment as follows:
    )
    tuner.run()
 
-This example runs `ASHA <tutorials/multifidelity/mf_asha.html>`_ with
+This example runs `ASHA <tutorials/multifidelity/mf_asha.html>`__ with
 ``n_workers=4`` asynchronously parallel workers for ``max_wallclock_time=15``
 seconds on the local machine it is called on
 (:code:`trial_backend=LocalBackend(entry_point="train_height.py")`).
@@ -106,71 +106,71 @@ Supported HPO Methods
 
 The following hyperparameter optimization (HPO) methods are available in Syne Tune:
 
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| Method                                                                                | Reference                                                                      | Searcher      | Asynchronous? | Multi-fidelity? | Transfer? |
-+=======================================================================================+================================================================================+===============+===============+=================+===========+
-| `Grid Search <tutorials/basics/basics_randomsearch.html>`_                            |                                                                                | deterministic | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `Random Search <tutorials/basics/basics_randomsearch.html>`_                          | `Bergstra, et al. (2011) <https://www.jmlr.org/papers/v13/bergstra12a.html>`_  | random        | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `Bayesian Optimization <tutorials/basics/basics_bayesopt.html>`_                      | `Snoek, et al. (2012) <https://arxiv.org/abs/1206.2944>`_                      | model-based   | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.baselines.BORE`                                          | `Tiao, et al. (2021) <https://proceedings.mlr.press/v139/tiao21a.html>`_       | model-based   | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.schedulers.MedianStoppingRule`                           | `Golovin, et al. (2017) <https://dl.acm.org/doi/10.1145/3097983.3098043>`_     | any           | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `SyncHyperband <tutorials/multifidelity/mf_syncsh.html>`_                             | `Li, et al. (2018) <https://jmlr.org/papers/v18/16-558.html>`_                 | random        | no            | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `SyncBOHB <tutorials/multifidelity/mf_sync_model.html#synchronous-bohb>`_             | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`_                   | model-based   | no            | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `SyncMOBSTER <tutorials/multifidelity/mf_sync_model.html#synchronous-mobster>`_       | `Klein, et al. (2020) <https://openreview.net/forum?id=a2rFihIU7i>`_           | model-based   | no            | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `ASHA <tutorials/multifidelity/mf_sync_model.html>`_                                  | `Li, et al. (2019) <https://arxiv.org/abs/1810.05934>`_                        | random        | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `BOHB <tutorials/multifidelity/mf_asha.html>`_                                        | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`_                   | model-based   | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `MOBSTER <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`_         | `Klein, et al. (2020) <https://openreview.net/forum?id=a2rFihIU7i>`_           | model-based   | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `DEHB <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`_ | `Awad, et al. (2021) <https://arxiv.org/abs/2105.09821>`_                      | evolutionary  | no            | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `HyperTune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`_                 | `Li, et al. (2022) <https://arxiv.org/abs/2201.06834>`_                        | model-based   | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `DyHPO <tutorials/multifidelity/mf_async_model.html#dyhpo>`_                          | `Wistuba, et al. (2022) <https://arxiv.org/abs/2202.09774>`_                   | model-based   | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.baselines.ASHABORE`                                      | `Tiao, et al. (2021) <https://proceedings.mlr.press/v139/tiao21a.html>`_       | model-based   | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| `PASHA <tutorials/pasha/pasha.html>`_                                                 | `Bohdal, et al. (2022) <https://arxiv.org/abs/2207.06940>`_                    | random        | yes           | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.baselines.REA`                                           | `Real, et al. (2019) <https://arxiv.org/abs/1802.01548>`_                      | evolutionary  | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.baselines.KDE`                                           | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`_                   | model-based   | yes           | no              | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining`                      | `Jaderberg, et al. (2017) <https://arxiv.org/abs/1711.09846>`_                 | evolutionary  | no            | yes             | no        |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.baselines.ZeroShotTransfer`                              | `Wistuba, et al. (2015) <https://ieeexplore.ieee.org/document/7373431>`_       | deterministic | yes           | no              | yes       |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| ASHA-CTS (:class:`~syne_tune.optimizer.baselines.ASHACTS`)                            | `Salinas, et al. (2021) <https://proceedings.mlr.press/v119/salinas20a.html>`_ | random        | yes           | yes             | yes       |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| RUSH (:class:`~syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`)       | `Zappella, et al. (2021) <https://arxiv.org/abs/2103.16111>`_                  | random        | yes           | yes             | yes       |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.schedulers.transfer_learning.BoundingBox`                | `Perrone, et al. (2019) <https://arxiv.org/abs/1909.12552>`_                   | any           | yes           | yes             | yes       |
-+---------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| Method                                                                                 | Reference                                                                       | Searcher      | Asynchronous? | Multi-fidelity? | Transfer? |
++========================================================================================+=================================================================================+===============+===============+=================+===========+
+| `Grid Search <tutorials/basics/basics_randomsearch.html>`__                            |                                                                                 | deterministic | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `Random Search <tutorials/basics/basics_randomsearch.html>`__                          | `Bergstra, et al. (2011) <https://www.jmlr.org/papers/v13/bergstra12a.html>`__  | random        | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `Bayesian Optimization <tutorials/basics/basics_bayesopt.html>`__                      | `Snoek, et al. (2012) <https://arxiv.org/abs/1206.2944>`__                      | model-based   | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.BORE`                                           | `Tiao, et al. (2021) <https://proceedings.mlr.press/v139/tiao21a.html>`__       | model-based   | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.schedulers.MedianStoppingRule`                            | `Golovin, et al. (2017) <https://dl.acm.org/doi/10.1145/3097983.3098043>`__     | any           | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `SyncHyperband <tutorials/multifidelity/mf_syncsh.html>`__                             | `Li, et al. (2018) <https://jmlr.org/papers/v18/16-558.html>`__                 | random        | no            | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `SyncBOHB <tutorials/multifidelity/mf_sync_model.html#synchronous-bohb>`__             | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`__                   | model-based   | no            | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `SyncMOBSTER <tutorials/multifidelity/mf_sync_model.html#synchronous-mobster>`__       | `Klein, et al. (2020) <https://openreview.net/forum?id=a2rFihIU7i>`__           | model-based   | no            | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `ASHA <tutorials/multifidelity/mf_sync_model.html>`__                                  | `Li, et al. (2019) <https://arxiv.org/abs/1810.05934>`__                        | random        | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `BOHB <tutorials/multifidelity/mf_asha.html>`__                                        | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`__                   | model-based   | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `MOBSTER <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`__         | `Klein, et al. (2020) <https://openreview.net/forum?id=a2rFihIU7i>`__           | model-based   | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `DEHB <tutorials/multifidelity/mf_sync_model.html#differential-evolution-hyperband>`__ | `Awad, et al. (2021) <https://arxiv.org/abs/2105.09821>`__                      | evolutionary  | no            | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `HyperTune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`__                 | `Li, et al. (2022) <https://arxiv.org/abs/2201.06834>`__                        | model-based   | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `DyHPO <tutorials/multifidelity/mf_async_model.html#dyhpo>`__                          | `Wistuba, et al. (2022) <https://arxiv.org/abs/2202.09774>`__                   | model-based   | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.ASHABORE`                                       | `Tiao, et al. (2021) <https://proceedings.mlr.press/v139/tiao21a.html>`__       | model-based   | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| `PASHA <tutorials/pasha/pasha.html>`__                                                 | `Bohdal, et al. (2022) <https://arxiv.org/abs/2207.06940>`__                    | random        | yes           | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.REA`                                            | `Real, et al. (2019) <https://arxiv.org/abs/1802.01548>`__                      | evolutionary  | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.KDE`                                            | `Falkner, et al. (2018) <https://arxiv.org/abs/1807.01774>`__                   | model-based   | yes           | no              | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining`                       | `Jaderberg, et al. (2017) <https://arxiv.org/abs/1711.09846>`__                 | evolutionary  | no            | yes             | no        |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.baselines.ZeroShotTransfer`                               | `Wistuba, et al. (2015) <https://ieeexplore.ieee.org/document/7373431>`__       | deterministic | yes           | no              | yes       |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| ASHA-CTS (:class:`~syne_tune.optimizer.baselines.ASHACTS`)                             | `Salinas, et al. (2021) <https://proceedings.mlr.press/v119/salinas20a.html>`__ | random        | yes           | yes             | yes       |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| RUSH (:class:`~syne_tune.optimizer.schedulers.transfer_learning.RUSHScheduler`)        | `Zappella, et al. (2021) <https://arxiv.org/abs/2103.16111>`__                  | random        | yes           | yes             | yes       |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.schedulers.transfer_learning.BoundingBox`                 | `Perrone, et al. (2019) <https://arxiv.org/abs/1909.12552>`__                   | any           | yes           | yes             | yes       |
++----------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------+---------------+-----------------+-----------+
 
 The searchers fall into four broad categories, **deterministic**, **random**, **evolutionary** and **model-based**. The random searchers sample candidate hyperparameter configurations uniformly at random, while the model-based searchers sample them non-uniformly at random, according to a model (e.g., Gaussian process, density ration estimator, etc.) and an acquisition function. The evolutionary searchers make use of an evolutionary algorithm.
 
-Syne Tune also supports `BoTorch <https://github.com/pytorch/botorch>`_ searchers,
+Syne Tune also supports `BoTorch <https://github.com/pytorch/botorch>`__ searchers,
 see :class:`~syne_tune.optimizer.baselines.BoTorch`.
 
 Supported multi-objective optimization methods
 ----------------------------------------------
 
-+-------------------------------------------------------------------------+----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
-| Method                                                                  | Reference                                                                  | Searcher    | Asynchronous? | Multi-fidelity? | Transfer? |
-+=========================================================================+============================================================================+=============+===============+=================+===========+
-| :class:`~syne_tune.optimizer.baselines.ConstrainedBayesianOptimization` | `Gardner, et al. (2014) <http://proceedings.mlr.press/v32/gardner14.pdf>`_ | model-based | yes           | no              | no        |
-+-------------------------------------------------------------------------+----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
-| :class:`~syne_tune.optimizer.schedulers.multiobjective.MOASHA`          | `Schmucker, et al. (2021) <https://arxiv.org/abs/2106.12639>`_             | random      | yes           | yes             | no        |
-+-------------------------------------------------------------------------+----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
++-------------------------------------------------------------------------+-----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
+| Method                                                                  | Reference                                                                   | Searcher    | Asynchronous? | Multi-fidelity? | Transfer? |
++=========================================================================+=============================================================================+=============+===============+=================+===========+
+| :class:`~syne_tune.optimizer.baselines.ConstrainedBayesianOptimization` | `Gardner, et al. (2014) <http://proceedings.mlr.press/v32/gardner14.pdf>`__ | model-based | yes           | no              | no        |
++-------------------------------------------------------------------------+-----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
+| :class:`~syne_tune.optimizer.schedulers.multiobjective.MOASHA`          | `Schmucker, et al. (2021) <https://arxiv.org/abs/2106.12639>`__             | random      | yes           | yes             | no        |
++-------------------------------------------------------------------------+-----------------------------------------------------------------------------+-------------+---------------+-----------------+-----------+
 
 HPO methods listed can be used in a multi-objective setting by scalarization
 (:class:`~syne_tune.optimizer.schedulers.multiobjective.multiobjective_priority.LinearScalarizationPriority`)
@@ -180,7 +180,7 @@ or non-dominated sorting
 Security
 ========
 
-See `CONTRIBUTING <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md#security-issue-notifications>`_
+See `CONTRIBUTING <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md#security-issue-notifications>`__
 for more information.
 
 Citing Syne Tune
@@ -188,7 +188,7 @@ Citing Syne Tune
 
 If you use Syne Tune in a scientific publication, please cite the following paper:
 
-`Syne Tune: A Library for Large Scale Hyperparameter Tuning and Reproducible Research <https://openreview.net/forum?id=BVeGJ-THIg9&referrer=%5BAuthor%20Console%5D(%2Fgroup%3Fid%3Dautoml.cc%2FAutoML%2F2022%2FTrack%2FMain%2FAuthors%23your-submissions>`_
+`Syne Tune: A Library for Large Scale Hyperparameter Tuning and Reproducible Research <https://openreview.net/forum?id=BVeGJ-THIg9&referrer=%5BAuthor%20Console%5D(%2Fgroup%3Fid%3Dautoml.cc%2FAutoML%2F2022%2FTrack%2FMain%2FAuthors%23your-submissions>`__
 
 .. code-block:: bibtex
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,32 +32,32 @@ What's New?
 -----------
 
 * New tutorial:
-  `Using Syne Tune for Transfer Learning <tutorials/transfer_learning/transfer_learning.html>`_.
+  `Using Syne Tune for Transfer Learning <tutorials/transfer_learning/transfer_learning.html>`__.
   Transfer learning allows us to speed up our current optimisation by learning
   from related optimisation runs. Syne Tune provides a number of transfer HPO
   methods and makes it easy to implement new ones. Thanks to
-  `Sigrid <https://github.com/sighellan>`_ for this contribution.
+  `Sigrid <https://github.com/sighellan>`__ for this contribution.
 * New scheduler: :class:`~syne_tune.optimizer.baselines.DyHPO`.
   This is a recent multi-fidelity method, which can be seen as alternative to
-  `ASHA <tutorials/multifidelity/mf_sync_model.html>`_,
-  `MOBSTER <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`_
-  or `HyperTune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`_.
+  `ASHA <tutorials/multifidelity/mf_sync_model.html>`__,
+  `MOBSTER <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`__
+  or `HyperTune <tutorials/multifidelity/mf_async_model.html#hyper-tune>`__.
   Different to these, decisions on whether to promote paused trials are done
   based on the surrogate model. Our implementation differs from the published
   work by using a Gaussian process surrogate model, and by a promotion rule which
   is a hybrid between DyHPO and ASHA.
-* New tutorial: `How to Contribute a New Scheduler <tutorials/developer/README.html>`_.
+* New tutorial: `How to Contribute a New Scheduler <tutorials/developer/README.html>`__.
   Learn how to implement your own scheduler, wrap external code, or modify
   one of the existing templates in order to get your job done.
-* New tutorial: `Benchmarking in Syne Tune <tutorials/benchmarking/README.html>`_.
+* New tutorial: `Benchmarking in Syne Tune <tutorials/benchmarking/README.html>`__.
   You'd like to run many experiments in parallel, or launch training jobs on
   different instances, all by modifying some simple scripts to your needs? Then
   our benchmarking mechanism is for you.
-* New tutorial: `Progressive ASHA <tutorials/pasha/pasha.html>`_. PASHA is a
+* New tutorial: `Progressive ASHA <tutorials/pasha/pasha.html>`__. PASHA is a
   variant of ASHA where the maximum number of resources (e.g., maximum number
   of training epochs) is not fixed up front, but is adapted. This can lead to
   savings when training on large datasets. Thanks to
-  `Ondre <https://github.com/ondrejbohdal>`_ for this contribution.
+  `Ondre <https://github.com/ondrejbohdal>`__ for this contribution.
 
 
 .. toctree::

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -3,9 +3,9 @@ Using the Built-in Schedulers
 
 In this tutorial, you will learn how to use and configure the most important
 built-in HPO algorithms. Alternatively, you can also use most algorithms from
-`Ray Tune <https://docs.ray.io/en/master/tune/index.html>`_.
+`Ray Tune <https://docs.ray.io/en/master/tune/index.html>`__.
 
-`This tutorial <tutorials/basics/README.html>`_ provides a walkthrough of
+`This tutorial <tutorials/basics/README.html>`__ provides a walkthrough of
 some of the topics addressed here.
 
 Schedulers and Searchers
@@ -159,7 +159,7 @@ The simplest HPO baseline is **random search**, which you obtain with
 ``FIFOScheduler``. Search decisions are not based on past data, a new
 configuration is chosen by sampling attribute values at random, from
 distributions specified in ``config_space``. These distributions are detailed
-`here <search_space.html#domains>`_.
+`here <search_space.html#domains>`__.
 
 If ``points_to_evaluate`` is specified, configurations are first taken from
 this list before any are drawn at random. Options for configuring the searcher
@@ -177,7 +177,7 @@ Bayesian Optimization
 **Bayesian optimization** is obtained by ``searcher='bayesopt'``, or by using
 :class:`~syne_tune.optimizer.baselines.BayesianOptimization` instead of
 ``FIFOScheduler``. More information about Bayesian optimization is provided
-`here <tutorials/basics/basics_bayesopt.html>`_.
+`here <tutorials/basics/basics_bayesopt.html>`__.
 
 Options for configuring the searcher are given in ``search_options``. These
 include options for the random searcher.
@@ -221,7 +221,7 @@ much better than ``FIFOScheduler``. You may have read about successive halving
 and Hyperband before. Chances are you read about **synchronous scheduling** of
 parallel evaluations, while both ``HyperbandScheduler`` and ``FIFOScheduler``
 implement **asynchronous scheduling**, which can be substantially more
-efficient. `This tutorial <tutorials/multifidelity/README.html>`_ provides
+efficient. `This tutorial <tutorials/multifidelity/README.html>`__ provides
 details about synchronous and asynchronous variants of successive halving and
 Hyperband.
 
@@ -287,7 +287,7 @@ of extra arguments we will explain in the sequel (``type``,
 ``max_resource_attr``, ``grace_period``, ``reduction_factor``,
 ``resource_attr``). The ``mlp_fashionmnist`` benchmark trains a two-layer MLP
 on ``FashionMNIST`` (more details are
-`here <tutorials/basics/basics_setup.html>`_). The accuracy is computed and
+`here <tutorials/basics/basics_setup.html>`__). The accuracy is computed and
 reported at the end of each epoch:
 
 .. code-block:: python
@@ -333,7 +333,7 @@ no better than the best 1/3 of previous values (the list includes the current
 ``accuracy`` value), otherwise it is stopped.
 
 Further details about ``HyperbandScheduler`` and multi-fidelity HPO methods
-are given in `this tutorial <tutorials/multifidelity/README.html>`_.
+are given in `this tutorial <tutorials/multifidelity/README.html>`__.
 :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` provides the full
 range of arguments. Here, we list the most important ones:
 
@@ -342,7 +342,7 @@ range of arguments. Here, we list the most important ones:
   resource attribute is a positive integer. We need ``reduction_factor >= 2``.
   Note that instead of ``max_resource_attr``, you can also use ``max_t``,
   as detailed
-  `here <tutorials/multifidelity/mf_setup.html#the-launcher-script>`_.
+  `here <tutorials/multifidelity/mf_setup.html#the-launcher-script>`__.
 * ``rung_increment``: This parameter can be used instead of ``reduction_factor``
   (the latter takes precedence). In this case, rung levels are spaced linearly:
   :math:`r_{min} + j \nu, j = 0, 1, 2, \dots`, where :math:`\nu` is
@@ -356,18 +356,18 @@ range of arguments. Here, we list the most important ones:
   above).
 * ``brackets``: Number of brackets to be used in Hyperband. More details are
   found
-  `here <tutorials/multifidelity/mf_asha.html#asynchronous-hyperband>`_.
+  `here <tutorials/multifidelity/mf_asha.html#asynchronous-hyperband>`__.
   The default is 1 (successive halving).
 
 Depending on the searcher, this scheduler supports:
 
-* `Asynchronous successive halving (ASHA) <../multifidelity/mf_asha.html>`_
+* `Asynchronous successive halving (ASHA) <../multifidelity/mf_asha.html>`__
   [``searcher="random"``]
-* `MOBSTER <../multifidelity/mf_async_model.html#asynchronous-mobster>`_
+* `MOBSTER <../multifidelity/mf_async_model.html#asynchronous-mobster>`__
   [``searcher="bayesopt"``]
-* `Asynchronous BOHB <../multifidelity/mf_async_model.html#asynchronous-mobster>`_
+* `Asynchronous BOHB <../multifidelity/mf_async_model.html#asynchronous-mobster>`__
   [``searcher="kde"``]
-* `Hyper-Tune <../multifidelity/mf_async_model.html#hyper-tune>`_
+* `Hyper-Tune <../multifidelity/mf_async_model.html#hyper-tune>`__
   [``searcher="hypertune"``]
 * Cost-aware Bayesian optimization [``searcher="bayesopt_cost"``]
 * Bore [``searcher="bore"``]
@@ -380,8 +380,8 @@ Asynchronous Hyperband (ASHA)
 
 If :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` is configured
 with a random searcher, we obtain ASHA, as proposed in
-`A System for Massively Parallel Hyperparameter Tuning <https://arxiv.org/abs/1810.05934>`_.
-More details are provided `here <tutorials/multifidelity/mf_asha.html>`_.
+`A System for Massively Parallel Hyperparameter Tuning <https://arxiv.org/abs/1810.05934>`__.
+More details are provided `here <tutorials/multifidelity/mf_asha.html>`__.
 Nothing much can be configured via ``search_options`` in this case. The
 arguments are the same as for random search with ``FIFOScheduler``.
 
@@ -390,10 +390,10 @@ Model-based Asynchronous Hyperband (MOBSTER)
 
 If :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` is configured with
 a Bayesian optimization searcher, we obtain MOBSTER, as proposed in
-`Model-based Asynchronous Hyperparameter and Neural Architecture Search <https://openreview.net/forum?id=a2rFihIU7i>`_.
+`Model-based Asynchronous Hyperparameter and Neural Architecture Search <https://openreview.net/forum?id=a2rFihIU7i>`__.
 By default, MOBSTER uses a multi-task Gaussian process surrogate model for
 metrics data observed at all resource levels. More details are provided
-`here <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`_.
+`here <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`__.
 
 Recommendations
 ---------------
@@ -407,7 +407,7 @@ schedulers.
   (:class:`~syne_tune.optimizer.baselines.ASHA`) instead. The default for ASHA
   is ``type="stopping"``, but you should consider ``type="promotion"`` as well
   (more details on this choice are given
-  `here <tutorials/multifidelity/mf_asha.html#asynchronous-successive-halving-promotion-variant>`_.
+  `here <tutorials/multifidelity/mf_asha.html#asynchronous-successive-halving-promotion-variant>`__.
 * Use these baseline runs to get an idea how long your experiment needs to run.
   It is recommended to use a stopping criterion of the form
   ``stop_criterion=StoppingCriterion(max_wallclock_time=X)``, so that the
@@ -437,6 +437,6 @@ schedulers.
   evaluations, the searchers based on GP surrogate models may end up expensive.
   In fact, once the number of evaluations surpassed a certain threshold, the
   data is filtered down before fitting the surrogate model (see
-  `here <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`_).
+  `here <tutorials/multifidelity/mf_async_model.html#asynchronous-mobster>`__).
   You can adjust this threshold or change ``opt_skip_period`` in order to speed
   up MOBSTER.

--- a/docs/source/search_space.rst
+++ b/docs/source/search_space.rst
@@ -108,7 +108,7 @@ cases. Here, we provide some recommendations:
   parameter is numerical, therefore has a linear ordering. They cannot
   do that if you do not tell them, and search performance will normally
   suffer. A good example is
-  `Bayesian optimization <tutorials/basics/basics_bayesopt.html>`_.
+  `Bayesian optimization <tutorials/basics/basics_bayesopt.html>`__.
   Numerical parameters are encoded as themselves (the int domain is relaxed to
   the corresponding float interval), allowing the surrogate model (e.g.,
   Gaussian process covariance kernel) to exploit ordering and distance in these
@@ -143,5 +143,5 @@ cases. Here, we provide some recommendations:
   of magnitude. Examples are learning rates or regularization constants.
 * **Use points_to_evaluate**. On top of refining your configuration space, we
   strongly recommend to
-  `specify initial default configurations <schedulers.html#fifoscheduler>`_
+  `specify initial default configurations <schedulers.html#fifoscheduler>`__
   by ``points_to_evaluate``.

--- a/docs/source/tutorials/basics/basics_asha.rst
+++ b/docs/source/tutorials/basics/basics_asha.rst
@@ -130,7 +130,7 @@ In this section, we will focus on the *stopping* variant of ASHA, leaving
 the promotion variant for later. First, we need to modify our training
 script. In order to support early stopping decisions, it needs to compute and
 report validation errors during training. Recall
-`traincode_report_end.py <basics_setup.html#annotating-the-training-script>`_
+`traincode_report_end.py <basics_setup.html#annotating-the-training-script>`__
 used with random search and Bayesian optimization. We will replace
 ``objective`` with the following code snippet, giving rise to
 ``traincode_report_eachepoch.py``:
@@ -172,14 +172,14 @@ and we can keep our script simple. Moreover, Syne Tune provides some advanced
 model-based extensions of ASHA scheduling, which make good use of metric data
 reported at the end of every epoch.
 
-Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`_
+Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__
 runs stopping-based ASHA with the argument ``--method ASHA-STOP``. Note that
 the entry point is ``traincode_report_eachepoch.py`` in this case, and the
 scheduler is ``ASHA``. Also, we need to pass the name of the resource attribute
 in ``resource_attr``. Finally, ``mode="stopping"` selects the stopping
 variant. Further details about ASHA and relevant additional arguments (for
 which we use defaults here) are found in
-`this tutorial <../multifidelity/README.html>`_.
+`this tutorial <../multifidelity/README.html>`__.
 
 When you run this script, you will note that many more trials are started than
 for random search, and that the majority of trials are stopped after 1 or 3

--- a/docs/source/tutorials/basics/basics_backend.rst
+++ b/docs/source/tutorials/basics/basics_backend.rst
@@ -30,10 +30,10 @@ Launcher Script for SageMaker Backend
 Syne Tune offers the SageMaker backend
 :class:`~syne_tune.backend.SageMakerBackend` as alternative to the local one.
 Using it requires some preparation, as is detailed
-`here <../../faq.html#how-can-i-run-on-aws-and-sagemaker>`_.
+`here <../../faq.html#how-can-i-run-on-aws-and-sagemaker>`__.
 
 Recall our
-`launcher script <basics_randomsearch.html#launcher-script-for-random-search>`_.
+`launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__.
 In order to use the SageMaker backend, we need to create ``trial_backend``
 differently:
 
@@ -62,7 +62,7 @@ In essence, the :class:`~syne_tune.backend.SageMakerBackend` is parameterized
 with a SageMaker estimator, which executes the training script. In our example,
 we use the ``PyTorch`` SageMaker framework as a pre-built container for the
 dependencies our training scripts requires. However, any other type of
-`SageMaker estimator <https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html>`_
+`SageMaker estimator <https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html>`__
 can be used here just as well. Finally, if you include any of the metrics reported
 by your training script in ``metrics_names``, their values are visualized in the
 dashboard for the SageMaker training job.
@@ -77,4 +77,4 @@ of the SageMaker estimator). In our example, this file needs to contain the
    This simple example avoids complications about writing results to S3 in
    a unified manner, or using special features of SageMaker which can speed
    up tuning substantially. For more information about the SageMaker backend,
-   please consider `this tutorial <../benchmarking/bm_sagemaker.html>`_.
+   please consider `this tutorial <../benchmarking/bm_sagemaker.html>`__.

--- a/docs/source/tutorials/basics/basics_bayesopt.rst
+++ b/docs/source/tutorials/basics/basics_bayesopt.rst
@@ -42,11 +42,11 @@ One of the oldest and most widely used instantiations of sequential model-based
 search is *Bayesian optimization*. There are a number of great tutorials and
 review articles on Bayesian optimization, and we won’t repeat them here:
 
-* `Slides by Ryan Adams <https://www.cs.toronto.edu/~rgrosse/courses/csc411_f18/tutorials/tut8_adams_slides.pdf>`_
-* `Review by Peter Frazier <https://arxiv.org/abs/1807.02811>`_
-* `Video by Peter Frazier <https://www.youtube.com/watch?v=c4KKvyWW_Xk>`_
-* `Video by Nando de Freitas <https://www.youtube.com/watch?v=vz3D36VXefI>`_
-* `Video by Matthew Hoffman <https://www.youtube.com/watch?v=C5nqEHpdyoE>`_
+* `Slides by Ryan Adams <https://www.cs.toronto.edu/~rgrosse/courses/csc411_f18/tutorials/tut8_adams_slides.pdf>`__
+* `Review by Peter Frazier <https://arxiv.org/abs/1807.02811>`__
+* `Video by Peter Frazier <https://www.youtube.com/watch?v=c4KKvyWW_Xk>`__
+* `Video by Nando de Freitas <https://www.youtube.com/watch?v=vz3D36VXefI>`__
+* `Video by Matthew Hoffman <https://www.youtube.com/watch?v=C5nqEHpdyoE>`__
 
 Most instances of Bayesian optimization work by modelling the objective as
 function :math:`f(\mathbf{x})`, where :math:`\mathbf{x}` is a configuration
@@ -80,7 +80,7 @@ The Bayesian optimization template requires us to make two choices:
   most popular choice in practice: expected improvement.
 
 GP-based Bayesian optimization is run by our
-`launcher script <basics_randomsearch.html#launcher-script-for-random-search>`_
+`launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__
 with the argument ``--method BO``. Many options can be specified via
 ``search_options``, but we use the defaults here. See
 :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher` for all
@@ -114,7 +114,7 @@ Recommendations
 ---------------
 
 Here, we collect some additional recommendations. Further details are
-found `here <../../schedulers.html#bayesian-optimization>`_.
+found `here <../../schedulers.html#bayesian-optimization>`__.
 
 Categorical Hyperparameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,7 +157,7 @@ lost. If you insist on a sparse “regular grid” value range, you can use
 ``logfinrange(4, 1024, 9)``, which has the same 9 values, but uses a
 latent ``int`` representation, which is encoded with a single number.
 More information can be found
-`here <../../search_space.html#recommendations>`_.
+`here <../../search_space.html#recommendations>`__.
 
 Speeding up Decision-Making
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorials/basics/basics_mobster.rst
+++ b/docs/source/tutorials/basics/basics_mobster.rst
@@ -39,11 +39,11 @@ MOBSTER
 -------
 
 A simple method combining ASHA with Bayesian optimization is
-`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`_. It restricts
+`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`__. It restricts
 Bayesian decision-making to proposing configurations for new trials, leaving
 scheduling decisions for existing trials (e.g., stopping, pausing, promoting)
 to ASHA. Recall from
-`Bayesian Optimization <basics_bayesopt.html#what-is-bayesian-optimization>`_
+`Bayesian Optimization <basics_bayesopt.html#what-is-bayesian-optimization>`__
 that we need two ingredients: a surrogate model :math:`f(\mathbf{x}, r)` and
 an acquisition function :math:`a(\mathbf{x})`:
 
@@ -54,7 +54,7 @@ an acquisition function :math:`a(\mathbf{x})`:
   done in several different ways, which are detailed below.
 
 * Acquisition function: MOBSTER adopts an idea from
-  `BOHB <https://arxiv.org/abs/1807.01774>`_, where it is argued that the
+  `BOHB <https://arxiv.org/abs/1807.01774>`__, where it is argued that the
   function of interest is really :math:`f(\mathbf{x}, r_{max})` (where
   :math:`r_{max}` is the full number of epochs), so expected improvement for
   this function would be a reasonable choice. However, this requires at least
@@ -67,13 +67,13 @@ These choices conveniently reduce MOBSTER to a Bayesian optimization searcher
 of similar form than without early stopping. One important difference is of
 course that a lot more data is available now, which has scaling implications
 for the surrogate model. More details about MOBSTER, and further options not
-discussed here, are given in `this tutorial <../multifidelity/README.html>`_.
+discussed here, are given in `this tutorial <../multifidelity/README.html>`__.
 
-Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`_
+Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__
 runs stopping-based MOBSTER with the argument ``--method MOBSTER-STOP``. At
 least if defaults are chosen, this is much the same as for ``ASHA-STOP``.
 However, we can configure the surrogate model with a range of options, which
-are detailed `here <../multifidelity/mf_async_model.html>`_.
+are detailed `here <../multifidelity/mf_async_model.html>`__.
 
 Results for MOBSTER
 -------------------
@@ -95,7 +95,7 @@ Results on NASBench201 (ImageNet-16)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We repeated this comparison on a harder benchmark problem:
-`NASBench-201 <https://arxiv.org/abs/2001.00326>`_, on the ImageNet-16
+`NASBench-201 <https://arxiv.org/abs/2001.00326>`__, on the ImageNet-16
 dataset. Here, ``r_max = 200``, and rung levels are ``1, 3, 9, 27, 81, 200``.
 We used 8 workers and 8 hours experiment time, and once more report median
 and 25/75 percentiles over 50 repeats. Now, after about 5 hours, MOBSTER

--- a/docs/source/tutorials/basics/basics_outlook.rst
+++ b/docs/source/tutorials/basics/basics_outlook.rst
@@ -14,29 +14,29 @@ experimental. Here is an incomplete overview:
   trial-and-error, which can be seen as “outer loop random search”. Syne Tune
   offers facilities to launch many tuning experiments in parallel, as SageMaker
   training jobs. More details are found in
-  `this tutorial <../benchmarking/README.html>`_, see also the
-  `FAQ <../../faq.html#how-can-i-run-many-experiments-in-parallel>`_.
+  `this tutorial <../benchmarking/README.html>`__, see also the
+  `FAQ <../../faq.html#how-can-i-run-many-experiments-in-parallel>`__.
 * **Multi-fidelity Schedulers**: Syne Tune provides many more multi-fidelity
   schedulers than ASHA and MOBSTER. An overview and categorization of supported
-  methods is given in `this tutorial <../multifidelity/README.html>`_.
+  methods is given in `this tutorial <../multifidelity/README.html>`__.
 * **Population-based Training**: This is a popular scheduler for tuning
   reinforcement learning, where optimization hyperparameters like learning rate
   can be changed at certain points during the training. An example is at
   ``examples/launch_pbt.py``, see also
   :class:`~syne_tune.optimizer.schedulers.PopulationBasedTraining`. Note that
-  `checkpointing <basics_promotion.html#pause-and-resume-checkpointing-of-trials>`_
+  `checkpointing <basics_promotion.html#pause-and-resume-checkpointing-of-trials>`__
   is mandatory for PBT.
 * **Constrained HPO**: In many applications, more than a single metric play a
   role. With constrained HPO, you can maximize recall subject to a constraint
   on precision; minimize prediction latency subject to a constraint on
   accuracy; or maximize accuracy subject to a constraint on a fairness metric.
   Constrained HPO is a special case of
-  `Bayesian Optimization <basics_bayesopt.html>`_, where
+  `Bayesian Optimization <basics_bayesopt.html>`__, where
   ``searcher='bayesopt_constrained'``, and the name of the constraint metric
   (the constraint is feasible iff this metric is non-positive) must be given
   as ``constraint_attr`` in ``search_options``. More details on constrained HPO
   and methodology adopted in Syne Tune can be found
-  `here <https://arxiv.org/abs/1910.07003>`_, see also
+  `here <https://arxiv.org/abs/1910.07003>`__, see also
   :class:`~syne_tune.optimizer.schedulers.searchers.constrained.ConstrainedGPFIFOSearcher`.
 * **Multi-objective HPO**: Another way to approach tuning problems with multiple
   metrics is trying to sample the Pareto frontier, i.e. identifying
@@ -44,6 +44,6 @@ experimental. Here is an incomplete overview:
   degrading performance along another. Syne Tune provides a range of methodology
   in this direction. An example is at ``examples/launch_height_moasha.py``.
   More details on multi-objective HPO and methodology adopted in Syne Tune can
-  be found `here <https://arxiv.org/abs/2106.12639>`_, see also
+  be found `here <https://arxiv.org/abs/2106.12639>`__, see also
   :class:`~syne_tune.optimizer.schedulers.multiobjective.MOASHA`.
-* **Transfer-learning Schedulers**: Syne Tune provides several transfer-learning schedulers. To get started check out `this tutorial <../transfer_learning/transfer_learning.html>`_.
+* **Transfer-learning Schedulers**: Syne Tune provides several transfer-learning schedulers. To get started check out `this tutorial <../transfer_learning/transfer_learning.html>`__.

--- a/docs/source/tutorials/basics/basics_promotion.rst
+++ b/docs/source/tutorials/basics/basics_promotion.rst
@@ -24,7 +24,7 @@ However, *pause and resume* needs more support from the training script, which
 has to make sure that a paused trial can be resumed later on, continuing
 training as if nothing happened in between. To this end, the *state* of the
 training job has to be checkpointed (i.e., stored into a file). The
-`training script <basics_asha.html#scripts-for-asynchronous-successive-halving>`_
+`training script <basics_asha.html#scripts-for-asynchronous-successive-halving>`__
 has to be modified once more, by replacing ``objective`` with this code:
 
 .. code-block:: python
@@ -112,7 +112,7 @@ Checkpointing requires you to implement the following:
   to the script, checkpointing is deactivated.
 
 Syne Tune provides some helper functions for checkpointing, see
-`FAQ <../../faq.html#how-can-i-enable-trial-checkpointing>`_.
+`FAQ <../../faq.html#how-can-i-enable-trial-checkpointing>`__.
 
 * ``checkpoint_model_at_rung_level(config, save_model_fn, epoch)`` stores
   a checkpoint at the end of epoch ``epoch``. The main work is done by
@@ -134,7 +134,7 @@ only be paused there. Selective checkpointing could be supported by passing the
 rung levels to the training script, but this is currently not done in Syne
 Tune.
 
-Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`_
+Our `launcher script <basics_randomsearch.html#launcher-script-for-random-search>`__
 runs promotion-based ASHA with the argument ``--method ASHA-PROM``, and
 promotion-based MOBSTER with ``--method MOBSTER-PROM``:
 

--- a/docs/source/tutorials/basics/basics_randomsearch.rst
+++ b/docs/source/tutorials/basics/basics_randomsearch.rst
@@ -281,7 +281,7 @@ fluctuations.
 .. note::
    In order to learn more about how to launch long-running HPO experiments many
    times in parallel on SageMaker, please have a look at
-   `this tutorial <../benchmarking/README.html>`_.
+   `this tutorial <../benchmarking/README.html>`__.
 
 Recommendations
 ---------------
@@ -325,4 +325,4 @@ the order given there.
    all values are selected by the mid-point rule. If you want to run pure
    random search from the start (which is not recommended), you need to set
    ``points_to_evaluate=[]``. Details are provided
-   `here <../../schedulers.html#fifoscheduler>`_.
+   `here <../../schedulers.html#fifoscheduler>`__.

--- a/docs/source/tutorials/basics/basics_setup.rst
+++ b/docs/source/tutorials/basics/basics_setup.rst
@@ -228,7 +228,7 @@ the validation accuracy after training as ``report(accuracy=accuracy)``.
    line arguments. This precludes passing arguments of complex type, such as
    lists or dictionaries, as there is also a length limit to arguments. In
    order to get around these restrictions, you can also pass
-   `arguments via a JSON file <../../faq.html#how-can-i-pass-lists-or-dictionaries-to-the-training-script>`_.
+   `arguments via a JSON file <../../faq.html#how-can-i-pass-lists-or-dictionaries-to-the-training-script>`__.
 
 Defining the Configuration Space
 --------------------------------
@@ -275,7 +275,7 @@ exploration than for model-based HPO methods. On the other hand, we should
 avoid to encode finite-sized numerical ranges as categorical for model-based
 HPO, instead using one of the more specialized types in Syne Tune. More details
 on choosing the configuration space are provided
-`here <../../search_space.html>`_, where you will also learn about more types:
+`here <../../search_space.html>`__, where you will also learn about more types:
 categorical, finite range, and ordinal.
 
 Finally, you can also tune only a subset of the hyperparameters of your

--- a/docs/source/tutorials/basics/concepts.rst
+++ b/docs/source/tutorials/basics/concepts.rst
@@ -32,8 +32,8 @@ In Syne Tune, HPO algorithms are called *schedulers* (base class
 most promising configuration and suggest it as a new trial to the tuner. Some
 schedulers may decide to resume a paused trial instead of suggesting a new one.
 Schedulers may also be in charge of stopping running trials. Syne Tune supports
-`many schedulers <../../getting_started.html#supported-hpo-methods>`_, including
-`multi-fidelity <../multifidelity/README.html>`_ methods.
+`many schedulers <../../getting_started.html#supported-hpo-methods>`__, including
+`multi-fidelity <../multifidelity/README.html>`__ methods.
 
 
 Backend
@@ -65,7 +65,7 @@ equal to the number of independent resources on this machine, e.g. the number of
 GPUs or CPU cores. Experiments with the local backend can either be launched on
 your current machine (in which case this needs to own the resources you are
 requesting, such as GPUs), or you can
-`launch the experiment remotely <../../faq.html#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`_
+`launch the experiment remotely <../../faq.html#i-dont-want-to-wait-how-can-i-launch-the-tuning-on-a-remote-machine>`__
 as a SageMaker training job, using an instance type of your choice. The figure
 below demonstrates the local backend. On the left, both scripts are executed on
 the local machine, while on the right, scripts are run remotely.
@@ -103,7 +103,7 @@ runs each trial evaluation as a separate SageMaker training job. Given sufficien
 instance limits, you can run your experiments with any number of workers you like,
 and each worker may use all resources on the executing instance. It is even
 possible to execute trials on instances of different types, which allows for
-`joint tuning of hyperparameters and compute resources <../../examples.html#joint-tuning-of-instance-type-and-hyperparameters-using-moasha>`_.
+`joint tuning of hyperparameters and compute resources <../../examples.html#joint-tuning-of-instance-type-and-hyperparameters-using-moasha>`__.
 The figure below demonstrates the SageMaker backend. On the left, the launcher
 script runs on the local machine, while on the right, it is run remotely.
 
@@ -122,12 +122,12 @@ This allows you to use any instance type and configuration you like. Also, you
 may use any of the SageMaker frameworks, from ``scikit-learn`` over ``PyTorch``
 and ``TensorFlow``, up to dedicated frameworks for distributed training. You may
 also
-`bring your own Docker image <../../examples.html#launch-with-sagemaker-backend-and-custom-docker-image>`_.
+`bring your own Docker image <../../examples.html#launch-with-sagemaker-backend-and-custom-docker-image>`__.
 
 This backend is most suited to tune models for which training is fairly expensive.
 SageMaker training jobs incur certain delays for starting or stopping, which are
 not present in the local backend. The SageMaker backend can be sped up by using
-`SageMaker managed warm pools <../benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`_.
+`SageMaker managed warm pools <../benchmarking/bm_sagemaker.html#using-sagemaker-managed-warm-pools>`__.
 
 
 Simulator Backend
@@ -139,8 +139,8 @@ It runs on a *tabulated or surrogate benchmark*, where validation metric data
 typically obtained online by running a training script has been precomputed
 offline. In a corporate setting, simulation experiments are useful for unit and
 regression testing, but also to speed up evaluations of prototypes. More details
-are given `here <../benchmarking/bm_simulator.html>`_, and in
-`this example <../../examples.html#launch-hpo-experiment-with-simulator-backend>`_.
+are given `here <../benchmarking/bm_simulator.html>`__, and in
+`this example <../../examples.html#launch-hpo-experiment-with-simulator-backend>`__.
 
 The main advantage of the simulator backend is that it allows for realistic
 experimentation at very low cost, and running order of magnitude faster than
@@ -152,13 +152,13 @@ Importantly, Syne Tune is agnostic to which execution backend is being used. You
 can easily switch between backends by changing the ``trial_backend`` argument
 in :class:`~syne_tune.Tuner`:
 
-* `launch_height_baselines.py <../../examples.html#launch-hpo-experiment-locally>`_
+* `launch_height_baselines.py <../../examples.html#launch-hpo-experiment-locally>`__
   provides an example for launching experiments with the local backend
-* `launch_height_python_backend.py <../../examples.html#launch-hpo-experiment-with-python-backend>`_
+* `launch_height_python_backend.py <../../examples.html#launch-hpo-experiment-with-python-backend>`__
   provides an example for launching experiments with the Python backend
-* `launch_height_sagemaker.py <../../examples.html#launch-hpo-experiment-with-sagemaker-backend>`_
+* `launch_height_sagemaker.py <../../examples.html#launch-hpo-experiment-with-sagemaker-backend>`__
   provides an example for launching experiments with the SageMaker backend
-* `launch_nasbench201_simulated.py <../../examples.html#launch-hpo-experiment-with-simulator-backend>`_
+* `launch_nasbench201_simulated.py <../../examples.html#launch-hpo-experiment-with-simulator-backend>`__
   provides an example for launching experiments with the simulator backend
 
 
@@ -169,5 +169,5 @@ A benchmark is a collection of meta-datasets from different configuration spaces
 where the exact dataset split, the evaluation protocol, and the performance
 measure are well-specified. Benchmarking allows for experimental reproducibility
 and assist us in comparing HPO methods on the specified configurations.
-Refer to `this tutorial <../benchmarking/README.html>`_ for a complete guide on
+Refer to `this tutorial <../benchmarking/README.html>`__ for a complete guide on
 benchmarking in Syne Tune.

--- a/docs/source/tutorials/benchmarking/bm_contributing.rst
+++ b/docs/source/tutorials/benchmarking/bm_contributing.rst
@@ -17,7 +17,7 @@ requirements:
 * The benchmark should not be excessively expensive to run
 * If your benchmark involves training a machine learning model, the code should
   work with the dependencies of a
-  `SageMaker framework <https://sagemaker.readthedocs.io/en/stable/frameworks/index.html>`_.
+  `SageMaker framework <https://sagemaker.readthedocs.io/en/stable/frameworks/index.html>`__.
   You can specify extra dependencies, but they should be small. While Syne
   Tune (and SageMaker) supports Docker containers, Syne Tune is not hosting
   them. At present, we also do not accept ``Dockerfile`` script contributions,
@@ -31,12 +31,12 @@ requirements:
 Let us have a look at the ``resnet_cifar10`` benchmark as example of what needs
 to be done:
 
-* `resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`_:
+* `resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`__:
   The training script for your benchmark should be in a subdirectory of
   ``benchmarking/training_scripts/``. The same directory can contain a file
   ``requirements.txt`` with dependencies beyond the SageMaker framework you
   specify for your code. You are invited to study the code
-  `resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`_
+  `resnet_cifar10.py <training_scripts.html#resnet-18-trained-on-cifar-10>`__
   in detail. Important points are:
 
   * Your script needs to report relevant metrics back to Syne Tune at the end
@@ -59,12 +59,12 @@ to be done:
   overwriting values in ``RealBenchmarkDefinition``. Hints:
 
   * ``framework`` should be one of the
-    `SageMaker frameworks <https://sagemaker.readthedocs.io/en/stable/frameworks/index.html>`_.
+    `SageMaker frameworks <https://sagemaker.readthedocs.io/en/stable/frameworks/index.html>`__.
     You should also specify ``framework_version`` and ``py_version`` in the
     ``estimator_kwargs`` dict.
   * ``config_space`` is the configuration space for your benchmark. Please
     make sure to
-    `choose hyperparameter domains wisely <../../search_space.html>`_.
+    `choose hyperparameter domains wisely <../../search_space.html>`__.
   * ``instance_type``, ``n_workers``: You need to specify a default instance
     type and number of workers for experiments running your benchmark. If in
     doubt, choose instances with the lowest costs. Currently, most of our GPU
@@ -98,7 +98,7 @@ find it useful, it can be graduated into :mod:`benchmarking.commons` and
 :mod:`benchmarking.training_scripts`.
 
 We are looking forward to your
-`pull request <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_.
+`pull request <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__.
 
 Contributing a Tabulated Benchmark
 ----------------------------------
@@ -111,10 +111,10 @@ used with any Syne Tune scheduler, and experiment runs are very close to what
 would be obtained by running training for real. Since time is simulated as well,
 not only are experiments very cheap to run (on basic CPU hardware), they also
 finish many times faster than real time. An overview is given
-`here <../multifidelity/mf_setup.html>`_.
+`here <../multifidelity/mf_setup.html>`__.
 
 If you have the data for a tabulated benchmark, we strongly encourage you to
-`contribute an import script to Syne Tune <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_.
+`contribute an import script to Syne Tune <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__.
 Examples for such scripts are
 :mod:`syne_tune.blackbox_repository.conversion_scripts.scripts.fcnet_import`,
 :mod:`syne_tune.blackbox_repository.conversion_scripts.scripts.nasbench201_import`,
@@ -122,4 +122,4 @@ Examples for such scripts are
 :mod:`syne_tune.blackbox_repository.conversion_scripts.scripts.yahpo_import`,
 :mod:`syne_tune.blackbox_repository.conversion_scripts.scripts.lcbench.lcbench`.
 See also
-`FAQ <../../faq.html#how-can-i-add-a-new-tabular-or-surrogate-benchmark>`_.
+`FAQ <../../faq.html#how-can-i-add-a-new-tabular-or-surrogate-benchmark>`__.

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -11,7 +11,7 @@ Defining the Experiment
 
 As usual in Syne Tune, the experiment is defined by a number of scripts.
 We will look at an example in
-`benchmarking/nursery/launch_local/ <../../benchmarking/launch_local.html>`_.
+`benchmarking/nursery/launch_local/ <../../benchmarking/launch_local.html>`__.
 Common code used in these benchmarks can be found in
 :mod:`benchmarking.commons`:
 
@@ -21,20 +21,20 @@ Common code used in these benchmarks can be found in
 
 Let us look at the scripts in order, and how you can adapt them to your needs:
 
-* `benchmarking/nursery/launch_local/baselines.py <../../benchmarking/launch_local.html#id1>`_:
+* `benchmarking/nursery/launch_local/baselines.py <../../benchmarking/launch_local.html#id1>`__:
   This is the same as in the
-  `simulator case <bm_simulator.html#defining-the-experiment>`_.
-* `benchmarking/nursery/launch_local/hpo_main.py <../../benchmarking/launch_local.html#id2>`_:
+  `simulator case <bm_simulator.html#defining-the-experiment>`__.
+* `benchmarking/nursery/launch_local/hpo_main.py <../../benchmarking/launch_local.html#id2>`__:
   This is the same as in the
-  `simulator case <bm_simulator.html#defining-the-experiment>`_, but based on
+  `simulator case <bm_simulator.html#defining-the-experiment>`__, but based on
   :mod:`benchmarking.commons.hpo_main_local`. We will see shortly how the
   launcher is called, and what happens inside.
-* `benchmarking/nursery/launch_local/launch_remote.py <../../benchmarking/launch_local.html#id3>`_:
+* `benchmarking/nursery/launch_local/launch_remote.py <../../benchmarking/launch_local.html#id3>`__:
   Much the same as in the
-  `simulator case <bm_simulator.html#defining-the-experiment>`_, but based on
+  `simulator case <bm_simulator.html#defining-the-experiment>`__, but based on
   :mod:`benchmarking.commons.launch_remote_local`. We will see shortly how the
   launcher is called, and what happens inside.
-* `benchmarking/nursery/launch_local/requirements-synetune.txt <../../benchmarking/launch_local.html#id4>`_:
+* `benchmarking/nursery/launch_local/requirements-synetune.txt <../../benchmarking/launch_local.html#id4>`__:
   This file is for defining the requirements of the SageMaker training job in
   remote launching, it mainly has to contain the Syne Tune dependencies. Your
   training script may have additional dependencies, and they are combined with
@@ -72,7 +72,7 @@ GPU with PyTorch being installed):
 * ``n_workers``, ``max_wallclock_time``: You can overwrite the default values
   for the selected benchmark by these command line arguments.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
-  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`__.
 * ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
   argument, but not ``max_wallclock_time``, the benchmark default
   ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
@@ -97,7 +97,7 @@ as well.
    ``n_workers=1``: you need to launch on a machine with 1 GPU, and with
    PyTorch being installed and properly setup to run GPU computations. If you
    cannot be bothered with all of this, please consider
-   `remote launching <bm_local.html#launching-experiments-remotely>`_ as an
+   `remote launching <bm_local.html#launching-experiments-remotely>`__ as an
    alternative. On the other hand, you can launch experiments locally without
    using SageMaker (or AWS) at all.
 

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -10,7 +10,7 @@ Defining the Experiment
 
 The scripts required to define an experiment are pretty much the same as in the
 local backend case. We will look at an example in
-`benchmarking/nursery/launch_sagemaker/ <../../benchmarking/launch_sagemaker.html>`_.
+`benchmarking/nursery/launch_sagemaker/ <../../benchmarking/launch_sagemaker.html>`__.
 Common code used in these benchmarks can be found in
 :mod:`benchmarking.commons`:
 
@@ -19,15 +19,15 @@ Common code used in these benchmarks can be found in
 * Benchmark definitions: :mod:`benchmarking.commons.benchmark_definitions`
 
 The scripts
-`benchmarking/nursery/launch_sagemaker/baselines.py <../../benchmarking/launch_sagemaker.html#id1>`_,
-`benchmarking/nursery/launch_sagemaker/hpo_main.py <../../benchmarking/launch_sagemaker.html#id2>`_, and
-`benchmarking/nursery/launch_sagemaker/launch_remote.py <../../benchmarking/launch_sagemaker.html#id3>`_
+`benchmarking/nursery/launch_sagemaker/baselines.py <../../benchmarking/launch_sagemaker.html#id1>`__,
+`benchmarking/nursery/launch_sagemaker/hpo_main.py <../../benchmarking/launch_sagemaker.html#id2>`__, and
+`benchmarking/nursery/launch_sagemaker/launch_remote.py <../../benchmarking/launch_sagemaker.html#id3>`__
 are identical in structure to what happens in the
-`local backend case <bm_local.html#defining-the-experiment>`_, with the only
+`local backend case <bm_local.html#defining-the-experiment>`__, with the only
 difference that :mod:`benchmarking.commons.hpo_main_sagemaker` or
 :mod:`benchmarking.commons.launch_remote_sagemaker` are imported from. Moreover,
 Syne Tune dependencies need to be specified in
-`benchmarking/nursery/launch_sagemaker/requirements.txt <../../benchmarking/launch_sagemaker.html#id4>`_.
+`benchmarking/nursery/launch_sagemaker/requirements.txt <../../benchmarking/launch_sagemaker.html#id4>`__.
 
 In terms of benchmarks, the same definitions can be used for the SageMaker
 backend, in particular you can select from
@@ -59,7 +59,7 @@ This call launches a single experiment on the local machine (however, each
 trial launches the training script as a SageMaker training job, using the
 instance type suggested for the benchmark). The command line arguments are the
 same as in the
-`local backend case <bm_local.html#launching-experiments-locally>`_. Additional
+`local backend case <bm_local.html#launching-experiments-locally>`__. Additional
 arguments are:
 
 * ``n_workers``, ``max_wallclock_time``: Overwrite the default values for the
@@ -67,9 +67,9 @@ arguments are:
 * ``max_failures``: Number of trials which can fail without terminating the
   entire experiment.
 * ``warm_pool``: This flag is discussed
-  `below <bm_sagemaker.html#using-sagemaker-managed-warm-pools>`_.
+  `below <bm_sagemaker.html#using-sagemaker-managed-warm-pools>`__.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
-  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`__.
 * ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
   argument, but not ``max_wallclock_time``, the benchmark default
   ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
@@ -92,13 +92,13 @@ Sagemaker backend experiments can also be launched remotely, in which case
 each experiment is run in a SageMaker training job, using a cheap instance
 type, within which trials are executed as SageMaker training jobs as well. The
 usage is the same as in the
-`local backend case <bm_local.html#launching-experiments-remotely>`_.
+`local backend case <bm_local.html#launching-experiments-remotely>`__.
 
 Using SageMaker Managed Warm Pools
 ----------------------------------
 
 The SageMaker backend supports
-`SageMaker managed warm pools <https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html>`_,
+`SageMaker managed warm pools <https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html>`__,
 a recently launched feature of SageMaker. In a nutshell, this feature allows
 customers to circumvent start-up delays for SageMaker training jobs which share
 a similar configuration (e.g., framework) with earlier jobs which have already

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -14,7 +14,7 @@ Defining the Experiment
 
 As usual in Syne Tune, the experiment is defined by a number of scripts. We
 will look at an example in
-`benchmarking/nursery/benchmark_hypertune/ <../../benchmarking/benchmark_hypertune.html>`_.
+`benchmarking/nursery/benchmark_hypertune/ <../../benchmarking/benchmark_hypertune.html>`__.
 Common code used in these benchmarks can be found in :mod:`benchmarking.commons`.
 
 * Local launcher: :mod:`benchmarking.commons.hpo_main_simulator`
@@ -23,7 +23,7 @@ Common code used in these benchmarks can be found in :mod:`benchmarking.commons`
 
 Let us look at the scripts in order, and how you can adapt them to your needs:
 
-* `benchmarking/nursery/benchmark_hypertune/baselines.py <../../benchmarking/benchmark_hypertune.html#id1>`_:
+* `benchmarking/nursery/benchmark_hypertune/baselines.py <../../benchmarking/benchmark_hypertune.html#id1>`__:
   Defines the HPO methods to take part in the experiment, in the form of a
   dictionary ``methods`` which maps method names to factory functions, which in
   turn map :class:`~benchmarking.commons.baselines.MethodArguments` to scheduler
@@ -38,7 +38,7 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   need to create different entries in ``methods``, for example
   ``Methods.MOBSTER_JOINT`` and ``Methods.MOBSTER_INDEP`` are different variants
   of MOBSTER.
-* `benchmarking/nursery/benchmark_hypertune/benchmark_definitions.py <../../benchmarking/benchmark_hypertune.html#id2>`_:
+* `benchmarking/nursery/benchmark_hypertune/benchmark_definitions.py <../../benchmarking/benchmark_hypertune.html#id2>`__:
   Defines the benchmarks to be considered in this experiment, in the form of a
   dictionary ``benchmark_definitions`` with values of type
   :class:`~benchmarking.commons.benchmark_definitions.SurrogateBenchmarkDefinition`.
@@ -47,7 +47,7 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   parameters, for example ``surrogate`` and ``surrogate_kwargs`` in order to
   select a different surrogate model, or you can change the defaults for
   ``n_workers`` or ``max_wallclock_time``.
-* `benchmarking/nursery/benchmark_hypertune/hpo_main.py <../../benchmarking/benchmark_hypertune.html#id3>`_:
+* `benchmarking/nursery/benchmark_hypertune/hpo_main.py <../../benchmarking/benchmark_hypertune.html#id3>`__:
   Script for launching experiments locally. All you typically need to do here
   is to import :mod:`benchmarking.commons.hpo_main_simulator` and (optionally)
   to add additional command line arguments you would like to parameterize your
@@ -61,7 +61,7 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   ``methods`` and ``benchmark_definitions`` dictionaries, and (optionally) with
   ``extra_args`` and ``map_extra_args``. We will see shortly how the launcher
   is called, and what happens inside.
-* `benchmarking/nursery/benchmark_hypertune/launch_remote.py <../../benchmarking/benchmark_hypertune.html#id4>`_:
+* `benchmarking/nursery/benchmark_hypertune/launch_remote.py <../../benchmarking/benchmark_hypertune.html#id4>`__:
   Script for launching experiments remotely, in that each experiment runs as its
   own SageMaker training job, in parallel with other experiments. You need to
   import :mod:`benchmarking.commons.launch_remote_simulator` and pass the same
@@ -72,14 +72,14 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   runs different seeds (repetitions) in parallel for expensive methods, but
   sequentially for cheap ones. We will see shortly how the launcher is called,
   and what happens inside.
-* `benchmarking/nursery/benchmark_hypertune/requirements.txt <../../benchmarking/benchmark_hypertune.html#id5>`_:
+* `benchmarking/nursery/benchmark_hypertune/requirements.txt <../../benchmarking/benchmark_hypertune.html#id5>`__:
   Dependencies for ``hpo_main.py`` to be run remotely as SageMaker training job,
   in the context of launching experiments remotely. In particular, this needs
   the dependencies of Syne Tune itself. A safe bet here is ``syne-tune[extra]``
   and ``tqdm`` (which is the default if ``requirements.txt`` is missing). However,
   you can decrease startup time by narrowing down the dependencies you really
   need (see
-  `FAQ <../../faq.html#what-are-the-different-installations-options-supported>`_).
+  `FAQ <../../faq.html#what-are-the-different-installations-options-supported>`__).
   In our example here, we need ``gpsearchers`` and ``kde`` for methods. For
   simulated experiments, you always need to have ``blackbox-repository`` here.
   In order to use YAHPO benchmarks, also add ``yahpo``.
@@ -108,7 +108,7 @@ by ``map_extra_kwargs`` (the modified dictionary is returned). ``args`` is the
 result of command line parsing, and ``method`` is the name of the method to
 be constructed based on these arguments. The latter argument allows
 ``map_extra_kwargs`` to depend on the method. In our example
-`benchmarking/nursery/benchmark_hypertune/hpo_main.py <../../benchmarking/benchmark_hypertune.html#id3>`_,
+`benchmarking/nursery/benchmark_hypertune/hpo_main.py <../../benchmarking/benchmark_hypertune.html#id3>`__,
 ``num_brackets`` applies to all methods, while ``num_samples`` only applies
 to the variants of Hyper-Tune. Both arguments modify the dictionary
 ``scheduler_kwargs`` in :class:`~benchmarking.commons.baselines.MethodArguments`,
@@ -151,11 +151,11 @@ This call runs a number of experiments sequentially on the local machine:
   parameter is ``start_seed`` (default: 0), giving seeds
   ``start_seed, ..., num_seeds - 1``. For example, ``--start_seed 5  --num_seeds 6``
   runs for a single seed equal to 5. The dependence of random choices on the
-  seed is detailed `below <bm_local.html#random-seeds-and-paired-comparisons>`_.
+  seed is detailed `below <bm_local.html#random-seeds-and-paired-comparisons>`__.
 * ``max_wallclock_time``, ``n_workers``: These arguments overwrite the defaults
   specified in the benchmark definitions.
 * ``max_size_data_for_model``: Parameter for MOBSTER or Hyper-Tune, see
-  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`_.
+  `here <../multifidelity/mf_async_model.html#controlling-mobster-computations>`__.
 * ``scale_max_wallclock_time``: If 1, and if ``n_workers`` is given as
   argument, but not ``max_wallclock_time``, the benchmark default
   ``benchmark.max_wallclock_time`` is multiplied by :math:``B / min(A, B)``,
@@ -168,11 +168,11 @@ This call runs a number of experiments sequentially on the local machine:
   containing date-time and a 3-digit hash. If 0, the prefix is
   :code:`experiment_tag` only. The default is 1 (long prefix).
 * ``restrict_configurations``: See
-  `below <#restricting-scheduler-to-configurations-of-tabulated-blackbox>`_.
+  `below <#restricting-scheduler-to-configurations-of-tabulated-blackbox>`__.
 * ``fcnet_ordinal``: Applies to FCNet benchmarks only. The hyperparameter
   ``hp_init_lr`` has domain ``choice([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1])``.
   Since the parameter is really ordinal, this is
-  `not a good choice <../../search_space.html#recommendations>`_. With this
+  `not a good choice <../../search_space.html#recommendations>`__. With this
   option, the domain can be switched to different variants of ``ordinal``.
   The default is ``nn-log``, which is the domain
   ``logordinal([0.0005, 0.001, 0.005, 0.01, 0.05, 0.1])``. In order to keep
@@ -312,7 +312,7 @@ Selecting Benchmarks from benchmark_definitions
 Each family of tabulated (or surrogate) blackboxes accessible to the
 benchmarking tooling discussed here, are represented by a Python file in
 :mod:`benchmarking.commons.benchmark_definitions` (the same directly also
-contains definitions for `real benchmarks <bm_local.html>`_). For example:
+contains definitions for `real benchmarks <bm_local.html>`__). For example:
 
 * NASBench201 (:mod:`benchmarking.commons.benchmark_definitions.nas201`):
   Tabulated, no surrogate needed.
@@ -349,8 +349,8 @@ The YAHPO Family
 ~~~~~~~~~~~~~~~~
 
 A rich source of blackbox surrogates in Syne Tune comes from
-`YAHPO <https://github.com/slds-lmu/yahpo_gym>`_, which is also detailed in
-this `paper <https://arxiv.org/abs/2109.03670>`_. YAHPO contains a number of
+`YAHPO <https://github.com/slds-lmu/yahpo_gym>`__, which is also detailed in
+this `paper <https://arxiv.org/abs/2109.03670>`__. YAHPO contains a number of
 blackboxes (called scenarios), some of which over a lot of datasets (called
 instances). All our definitions are in
 :mod:`benchmarking.commons.benchmark_definitions.yahpo`. Further details can

--- a/docs/source/tutorials/developer/README.rst
+++ b/docs/source/tutorials/developer/README.rst
@@ -5,7 +5,7 @@ This tutorial guides developers and researchers to contribute a new scheduler
 to Syne Tune, or to modify and extend an existing one.
 
 We hope this information inspires you to give it a try. Please do consider
-`contributing your efforts to Syne Tune <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_:
+`contributing your efforts to Syne Tune <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__:
 
 * Reproducible research: Syne Tune contains careful implementations of many
   baselines and SotA algorithms. Once your new method is in there, you can
@@ -13,7 +13,7 @@ We hope this information inspires you to give it a try. Please do consider
   rules) instead of apples against oranges.
 * Faster and cheaper: You have a great idea for a new scheduler? Test it right
   away on a large range of benchmarks. Use Syne Tune’s
-  `blackbox repository and simulator backend <../benchmarking/bm_simulator.html>`_
+  `blackbox repository and simulator backend <../benchmarking/bm_simulator.html>`__
   in order to dramatically cut compute costs and waiting time.
 * Impact: If you compared your method to a range of others, you know how hard
   it is to get full-fledged HPO code of others running. Why would it be any

--- a/docs/source/tutorials/developer/extend_async_hb.rst
+++ b/docs/source/tutorials/developer/extend_async_hb.rst
@@ -6,13 +6,13 @@ methods like successive halving and Hyperband. These can be run with
 synchronous or asynchronous decision-making. The most important generic
 templates at the moment are:
 
-* `FIFOScheduler <random_search.html#fifoscheduler-and-randomsearcher>`_:
+* `FIFOScheduler <random_search.html#fifoscheduler-and-randomsearcher>`__:
   *Full evaluation* scheduler, baseclass for many others. See also
   :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
-* `HyperbandScheduler <extend_async_hb.html#hyperbandscheduler>`_:
+* `HyperbandScheduler <extend_async_hb.html#hyperbandscheduler>`__:
   Asynchronous successive halving and Hyperband. See also
   :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`.
-* `SynchronousHyperbandScheduler <extend_sync_hb.html#synchronous-hyperband>`_:
+* `SynchronousHyperbandScheduler <extend_sync_hb.html#synchronous-hyperband>`__:
   Synchronous successive halving and Hyperband. See also
   :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 
@@ -29,7 +29,7 @@ HyperbandScheduler
 ------------------
 
 Details about asynchronous successive halving and Hyperband are given in the
-`Multi-fidelity HPO tutorial <../multifidelity/README.html>`_. This is a
+`Multi-fidelity HPO tutorial <../multifidelity/README.html>`__. This is a
 multi-fidelity scheduler, where trials report intermediate results (e.g.,
 validation error at the end of each epoch of training). We can formalize this
 notion by the concept of *resource* :math:`r = 1, 2, 3, \dots` (e.g.,
@@ -47,7 +47,7 @@ class:`~syne_tune.optimizer.schedulers.FIFOScheduler`:
   class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. They are used to
   determine the maximum resource :math:`r_{max}` (e.g., the total number of
   epochs a trial is to be trained, if not stopped before). As discussed in
-  detail `here <../multifidelity/mf_setup.html#the-launcher-script>`_, it is
+  detail `here <../multifidelity/mf_setup.html#the-launcher-script>`__, it is
   best practice reserving a field in the configuration space
   ``scheduler.config_space`` to contain :math:`r_{max}`. If this is done, its
   name should be passed in ``max_resource_attr``. Now, every configuration sent
@@ -60,12 +60,12 @@ class:`~syne_tune.optimizer.schedulers.FIFOScheduler`:
   to be passed explicitly via ``max_t`` (which is not needed if
   ``max_resource_attr`` is used).
 * ``reduction_factor``, ``grace_period``, ``brackets`` are important parameters
-  detailed in the `tutorial <../multifidelity/README.html>`_. If
+  detailed in the `tutorial <../multifidelity/README.html>`__. If
   ``brackets > 1``, we run asynchronous Hyperband with this number of brackets,
   while for ``bracket == 1`` we run asynchronous successive halving (this is the
   default).
 * As detailed in the
-  `tutorial <../multifidelity/mf_asha.html#asynchronous-successive-halving-early-stopping-variant>`_,
+  `tutorial <../multifidelity/mf_asha.html#asynchronous-successive-halving-early-stopping-variant>`__,
   ``type`` determines whether the method uses early stopping (``type="stopping"``)
   or pause-and-resume scheduling (``type="promotion"``). Further choices of
   ``type`` activate specific algorithms such as RUSH, PASHA, or cost-sensitive
@@ -76,14 +76,14 @@ Kernel Density Estimator Searcher
 
 One of the most flexible ways of extending
 :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler` is to provide it with
-a novel `searcher <first_example.html#searchers-and-schedulers>`_. In order to
+a novel `searcher <first_example.html#searchers-and-schedulers>`__. In order to
 understand how this is done, we will walk through
 :class:`~syne_tune.optimizer.schedulers.searchers.kde.MultiFidelityKernelDensityEstimator`
 and
 :class:`~syne_tune.optimizer.schedulers.searchers.kde.KernelDensityEstimator`.
 This searcher implements ``suggest`` as in
-`BOHB <https://arxiv.org/abs/1807.01774>`_, as also detailed in
-`this tutorial <../multifidelity/mf_sync_model.html#synchronous-bohb>`_. In a
+`BOHB <https://arxiv.org/abs/1807.01774>`__, as also detailed in
+`this tutorial <../multifidelity/mf_sync_model.html#synchronous-bohb>`__. In a
 nutshell, the searcher splits all observations into two parts (*good* and
 *bad*), depending on metric values lying above or below a certain quantile, and
 fits kernel density estimators to these two subsets. It then makes decisions
@@ -172,7 +172,7 @@ This searcher takes pending evaluations into account (by way of fantasizing).
 Moreover, it can be configured with a Gaussian process model and an acquisition
 function, which is optimized in a gradient-based manner.
 
-Moreover, as already noted `here <first_example.html#searchers-and-schedulers>`_,
+Moreover, as already noted `here <first_example.html#searchers-and-schedulers>`__,
 ``HyperbandScheduler`` also allows to configure the decision rule for
 stop/continue or pause/resume as part of ``on_trial_report``. Examples for this
 are found in

--- a/docs/source/tutorials/developer/extend_sync_hb.rst
+++ b/docs/source/tutorials/developer/extend_sync_hb.rst
@@ -8,7 +8,7 @@ of how to extend this template.
 
 Our example here is somewhat more advanced than the one given for asynchronous
 Hyperband. In fact, we will walk through the implementation of
-`Differential Evolution Hyperband (DEHB) <https://arxiv.org/abs/2105.09821>`_
+`Differential Evolution Hyperband (DEHB) <https://arxiv.org/abs/2105.09821>`__
 in Syne Tune. Readers who are not interested in how to extend synchronous
 Hyperband, may skip this section without loss.
 
@@ -17,19 +17,19 @@ Synchronous Hyperband
 
 The differences between synchronous and asynchronous successive halving and
 Hyperband are detailed in
-`this tutorial <../multifidelity/mf_asha.html#asynchronous-successive-halving-early-stopping-variant>`_.
+`this tutorial <../multifidelity/mf_asha.html#asynchronous-successive-halving-early-stopping-variant>`__.
 In a nutshell, synchronous Hyperband uses rung levels of a priori fixed size,
 and decisions on which trials to promote to the next level are only done when
 all slots in the current rung are filled. In other words, *promotion decisions*
 are synchronized, while the execution of parallel jobs still happens
 asynchronously. This requirement poses slight additional challenges for an
 implementation, over what is said in
-`published work <https://jmlr.org/papers/v18/16-558.html>`_. We start with an
+`published work <https://jmlr.org/papers/v18/16-558.html>`__. We start with an
 overview of
 :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 Concepts such as resource, rung, bracket, grace period :math:`r_{min}`,
 reduction factor :math:`\eta` are detailed in
-`this tutorial <../multifidelity/README.html>`_.
+`this tutorial <../multifidelity/README.html>`__.
 
 :class:`~syne_tune.optimizer.schedulers.synchronous.hyperband_bracket.SynchronousHyperbandBracket`
 represents a bracket, consisting of a list of rungs, where each rung is
@@ -103,11 +103,11 @@ Differential Evolution Hyperband
 --------------------------------
 
 We will now have a closer look at the implementation of
-`DEHB <https://arxiv.org/abs/2105.09821>`_ in Syne Tune, which is a
+`DEHB <https://arxiv.org/abs/2105.09821>`__ in Syne Tune, which is a
 recent extension of synchronous Hyperband, where configurations of
 trials are chosen by evolutionary computations (mutation, cross-over,
 selection). This example is more advanced than the
-`one above <extend_async_hb.html>`_, in that we need to do more than
+`one above <extend_async_hb.html>`__, in that we need to do more than
 furnishing
 :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`
 with a new searcher. The only time when a searcher suggests configurations is
@@ -126,7 +126,7 @@ Moreover, each configuration attached to a trial is represented by an
 encoded vector with values in :math:`[0, 1]`, where the mapping from
 vectors to configurations is not invertible if the configuration space
 contains discrete parameters. Much the same is done in Gaussian process
-based `Bayesian optimization <../basics/basics_bayesopt.html>`_.
+based `Bayesian optimization <../basics/basics_bayesopt.html>`__.
 
 The very first bracket of DEHB is processed in the same way as in
 synchronous Hyperband, so assume the current bracket is not the first.
@@ -154,7 +154,7 @@ chosen:
   to the slot.
 
 While this sounds quite foreign to what we saw
-`above <extend_sync_hb.html#synchronous-hyperband>`_, we can make
+`above <extend_sync_hb.html#synchronous-hyperband>`__, we can make
 progress by associating each candidate vector arising from mutation and
 cross-over with a new ``trial_id``. After all, in order to determine the
 winner between candidate and target, we have to evaluate the former.

--- a/docs/source/tutorials/developer/first_example.rst
+++ b/docs/source/tutorials/developer/first_example.rst
@@ -4,7 +4,7 @@ A First Example
 In this section, we start with a simple example and clarify some basic concepts.
 
 If you have not done so, we recommend you have a look at `Basics of Syne Tune
-<../basics/README.html>`_ in order to get familiar with basic concepts of Syne
+<../basics/README.html>`__ in order to get familiar with basic concepts of Syne
 Tune.
 
 First Example
@@ -12,7 +12,7 @@ First Example
 
 A simple example for a new scheduler (called ``SimpleScheduler``) is given by
 the script
-`examples/launch_height_standalone_scheduler.py <../../examples.html#launch-hpo-experiment-with-home-made-scheduler>`_.
+`examples/launch_height_standalone_scheduler.py <../../examples.html#launch-hpo-experiment-with-home-made-scheduler>`__.
 All schedulers are subclasses of
 :class:`~syne_tune.optimizer.scheduler.TrialScheduler`. Important methods
 include:
@@ -55,15 +55,15 @@ include:
 
 There are further methods in
 :class:`~syne_tune.optimizer.scheduler.TrialScheduler`, which will be discussed
-in detail `below <trial_scheduler_api.html>`_. This simple scheduler is also
+in detail `below <trial_scheduler_api.html>`__. This simple scheduler is also
 missing the ``points_to_evaluate`` argument, which we recommend every new
 scheduler to support, and which is discussed in more detail
-`here <random_search.html#fifoscheduler-and-randomsearcher>`_.
+`here <random_search.html#fifoscheduler-and-randomsearcher>`__.
 
 Basic Concepts
 --------------
 
-Recall from `Basics of Syne Tune <../basics/README.html>`_ that an HPO
+Recall from `Basics of Syne Tune <../basics/README.html>`__ that an HPO
 experiment is run as interplay between a *backend* and a *scheduler*, which is
 orchestrated by the :class:`~syne_tune.Tuner`. The backend starts, stops,
 pauses, or resumes training jobs and relays their reports. A *trial* abstracts
@@ -74,7 +74,7 @@ schedulers which can be implemented in Syne Tune, some examples are:
   trials, but do not try to interact with running trials, even if the latter
   post intermediate results. A basic example is
   :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`, to be discussed
-  `below <random_search.html#fifoscheduler-and-randomsearcher>`_.
+  `below <random_search.html#fifoscheduler-and-randomsearcher>`__.
 * Early-stopping schedulers. These require trials to post intermediate results
   (e.g., validation errors after every epoch), and their ``on_trial_result``
   may stop underperforming trials early. An example is
@@ -102,7 +102,7 @@ synchronous job execution setup, often for conceptual simplicity (examples
 include successive halving and Hyperband, as well as batch suggestions for
 Bayesian optimization). In general, it just takes a little extra effort to
 implement non-blocking versions of these, and Syne Tune provides ample support
-code for doing so, as will be `demonstrated in detail <extend_sync_hb.html>`_.
+code for doing so, as will be `demonstrated in detail <extend_sync_hb.html>`__.
 
 Searchers and Schedulers
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -123,10 +123,10 @@ Once such internal structure is recognized, we can use it to expand the range
 of methods while maintaining simple, modular implementations. In Syne Tune,
 this is done by configuring generic schedulers with internal *searchers*. A
 basic example is given
-`below <random_search.html#fifoscheduler-and-randomsearcher>`_, more advanced
+`below <random_search.html#fifoscheduler-and-randomsearcher>`__, more advanced
 examples follow further below.
 
-If you are familiar with `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`_,
+If you are familiar with `Ray Tune <https://docs.ray.io/en/latest/tune/index.html>`__,
 please note a difference in terminology. In Ray Tune, searcher and scheduler
 are two independent concepts, mapping to different decisions to be made by an
 HPO algorithm. In Syne Tune, the HPO algorithm is represented by the scheduler,
@@ -140,8 +140,8 @@ Syne Tune is this: **be lazy!**
 
 * Can your idea be implemented as a new searcher, to be plugged into an
   existing generic scheduler? Detailed examples are given
-  `here <random_search.html#fifoscheduler-and-randomsearcher>`_,
-  `here <extend_async_hb.html>`_, and `here <extend_sync_hb.html>`_.
+  `here <random_search.html#fifoscheduler-and-randomsearcher>`__,
+  `here <extend_async_hb.html>`__, and `here <extend_sync_hb.html>`__.
 * Does your idea involve changing the stop/continue or pause/resume decisions
   in asynchronous successive halving or Hyperband? All you need to do is to
   implement a new

--- a/docs/source/tutorials/developer/new_searcher.rst
+++ b/docs/source/tutorials/developer/new_searcher.rst
@@ -11,12 +11,12 @@ The Searcher Factory
 --------------------
 
 Recall that our generic schedulers, such as
-`FIFOScheduler <random_search.html#fifoscheduler-and-randomsearcher>`_ or
-`HyperbandScheduler <extend_async_hb.html#hyperbandscheduler>`_ allow the
+`FIFOScheduler <random_search.html#fifoscheduler-and-randomsearcher>`__ or
+`HyperbandScheduler <extend_async_hb.html#hyperbandscheduler>`__ allow the
 user to choose a searcher via the string argument ``searcher``, and to
 configure the searcher (away from defaults) by the dictionary argument
 ``search_options``. While ``searcher`` can also be a
-`BaseSearcher <random_search.html#fifoscheduler-and-randomsearcher>`_
+`BaseSearcher <random_search.html#fifoscheduler-and-randomsearcher>`__
 instance, it is simpler and more convenient to choose the searcher by
 name. For example:
 
@@ -61,12 +61,12 @@ like ``mode``, ``points_to_evaluate``, ``random_seed_generator``, ``scheduler``.
 Your searcher is not required to make use of them, even though we strongly
 recommend to support ``points_to_evaluate`` and to make use of
 ``random_seed_generator`` (as is
-`shown here <random_search.html#fifoscheduler-and-randomsearcher>`_). Here are
+`shown here <random_search.html#fifoscheduler-and-randomsearcher>`__). Here are
 some best practices for linking a new searcher into the factory:
 
 * The Syne Tune code is written in a way which allows to run certain scenarios
   with a restricted set of all possible dependencies (see
-  `FAQ <../../faq.html#what-are-the-different-installations-options-supported>`_).
+  `FAQ <../../faq.html#what-are-the-different-installations-options-supported>`__).
   This is achieved by conditional imports. If your searcher requires
   dependencies beyond the core, please make sure to use
   ``try ... except ImportError`` as you see in the code.
@@ -82,5 +82,5 @@ Contribute your Extension
 
 At this point, you are ready to plug in your latest idea and make it work in
 Syne Tune. Given that it works well, we would encourage you to
-`contribute it back to the community <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_.
+`contribute it back to the community <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__.
 We are looking forward to your pull request.

--- a/docs/source/tutorials/developer/random_search.rst
+++ b/docs/source/tutorials/developer/random_search.rst
@@ -31,10 +31,10 @@ consider the arguments of ``FIFOScheduler``:
 * ``searcher``, ``search_options``: These are used to configure the scheduler
   with a searcher. For ease of use, ``searcher`` can be a name, and additional
   arguments can be passed via ``search_options``. In this case, the searcher is
-  created by a factory, as detailed `below <new_searcher.html>`_. Alternatively,
+  created by a factory, as detailed `below <new_searcher.html>`__. Alternatively,
   ``searcher`` can also be a
   :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher` object.
-* ``metric``, ``mode``: As discussed `above <first_example.html#first-example>`_
+* ``metric``, ``mode``: As discussed `above <first_example.html#first-example>`__
   in ``SimpleScheduler``.
 * ``random_seed``: Several pseudo-random number generators may be used in
   scheduler and searcher. Seeds for these are drawn from a random seed generator
@@ -50,7 +50,7 @@ consider the arguments of ``FIFOScheduler``:
 * ``max_resource_attr``, ``max_t``: These arguments are relevant for
   multi-fidelity schedulers. Only one of them needs to be given. We recommend
   to use ``max_resource_attr``. More details are given
-  `below <extend_async_hb.html#hyperbandscheduler>`_.
+  `below <extend_async_hb.html#hyperbandscheduler>`__.
 
 The most important use case is to configure ``FIFOScheduler`` with a new
 searcher, and we will concentrate on this one. First, the base class of all
@@ -77,7 +77,7 @@ searchers is :class:`~syne_tune.optimizer.schedulers.searchers.BaseSearcher`:
   ``on_trial_result``, also passing the configuration of the current trial. If
   the searcher maintains a surrogate model (for example, based on a Gaussian
   process), it should update its model with ``result`` data iff ``update=True``.
-  This is discussed in more detail `below <extend_async_hb.html>`_. Note that
+  This is discussed in more detail `below <extend_async_hb.html>`__. Note that
   ``on_trial_result`` does not return anything: decisions on how to proceed
   with the trial are not done in the searcher.
 * ``register_pending``: Registers one (or more) pending evaluations, which are
@@ -111,7 +111,7 @@ desirable for most searchers:
   finite size.
 * Restrict configurations which can be suggested to a finite set. This can be
   very useful when
-  `using tabulated blackboxes <../benchmarking/bm_simulator.html#restricting-scheduler-to-configurations-of-tabulated-blackbox>`_.
+  `using tabulated blackboxes <../benchmarking/bm_simulator.html#restricting-scheduler-to-configurations-of-tabulated-blackbox>`__.
   It does not make sense for every scheduler though, as some rely on a
   continuous search over the configuration space. You can inherit from
   :class:`~syne_tune.optimizer.schedulers.searchers.StochasticAndFilterDuplicatesSearcher`

--- a/docs/source/tutorials/developer/trial_scheduler_api.rst
+++ b/docs/source/tutorials/developer/trial_scheduler_api.rst
@@ -19,12 +19,12 @@ separate *workers* (which can be different GPUs or CPU cores on the same
 instance, or different instances).
 
 In Syne Tune, this process is split between two entities: the trial backend
-and the `trial scheduler <../../schedulers.html>`_. The backend wraps the
+and the `trial scheduler <../../schedulers.html>`__. The backend wraps the
 training code to be executed for different configurations and is responsible to
 start jobs, as well as stop, pause or resume them. It also collects results
 reported by the training jobs and relays them to the scheduler. In Syne Tune,
 pause-and-resume scheduling is done via
-`checkpointing <../../faq.html#how-can-i-enable-trial-checkpointing>`_. While
+`checkpointing <../../faq.html#how-can-i-enable-trial-checkpointing>`__. While
 code to write and load checkpoints locally must be provided by the training
 script, the backend makes them available when needed. There are two basic
 events which happen repeatedly during an HPO experiment, as orchestrated by the
@@ -34,7 +34,7 @@ events which happen repeatedly during an HPO experiment, as orchestrated by the
   available. For each free worker, it calls
   :meth:`~syne_tune.optimizer.scheduler.TrialScheduler.suggest`, asking for
   what to do next. As already seen in our
-  `first example <first_example.html#first-example>`_, the scheduler will
+  `first example <first_example.html#first-example>`__, the scheduler will
   typically suggest a configuration for a new trial to be started. On the
   other hand, a pause-and-resume scheduler may also suggest to resume a
   trial which is currently paused (having been started, and then paused,
@@ -61,7 +61,7 @@ TrialScheduler API
 
 We now discuss additional aspects of the
 :class:`~syne_tune.optimizer.scheduler.TrialScheduler` API, beyond what has
-already been covered `here <first_example.html#first-example>`_:
+already been covered `here <first_example.html#first-example>`__:
 
 * ``suggest`` returns a
   :class:`~syne_tune.optimizer.scheduler.TrialSuggestion` object with fields
@@ -83,7 +83,7 @@ already been covered `here <first_example.html#first-example>`_:
 * The only reason for ``suggest`` to return ``None`` is if no further
   suggestion can be made. This can happen if the configuration space has been
   exhausted. As discussed
-  `here <first_example.html#asynchronous-job-execution>`_, the scheduler
+  `here <first_example.html#asynchronous-job-execution>`__, the scheduler
   cannot delay a ``suggest`` decision to a later point in time.
 * The helper methods ``_preprocess_config`` and ``_postprocess_config`` are
   used when interfacing with a searcher. Namely, the configuration space

--- a/docs/source/tutorials/developer/wrap_code.rst
+++ b/docs/source/tutorials/developer/wrap_code.rst
@@ -12,7 +12,7 @@ on surrogate benchmarks, or distributed across several machines.
 
 In this chapter, we will walk through an example of how to wrap Gaussian
 process based Bayesian optimization from
-`BoTorch <https://botorch.org/docs/introduction>`_.
+`BoTorch <https://botorch.org/docs/introduction>`__.
 
 BoTorchSearcher
 ---------------
@@ -20,7 +20,7 @@ BoTorchSearcher
 While Syne Tune supports Gaussian process based Bayesian optimization natively
 via :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`, with
 ``searcher="bayesopt"`` in :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`,
-you can also use `BoTorch <https://botorch.org/docs/introduction>`_ via
+you can also use `BoTorch <https://botorch.org/docs/introduction>`__ via
 :class:`~syne_tune.optimizer.schedulers.searchers.botorch.BoTorchSearcher`,
 with ``searcher="botorch"`` in
 :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`.
@@ -150,7 +150,7 @@ hyperparameter domains.
 
 With :class:`~syne_tune.optimizer.schedulers.searchers.utils.HyperparameterRanges`,
 Syne Tune provides encoding and decoding for all domains in
-:mod:`syne_tune.config_space` (see `this tutorial <../search_space.html>`_ for
+:mod:`syne_tune.config_space` (see `this tutorial <../search_space.html>`__ for
 a summary). In fact, this API can be implemented in different ways, and the
 factory function
 :func:`~syne_tune.optimizer.schedulers.searchers.utils.make_hyperparameter_ranges`
@@ -189,11 +189,11 @@ External code can come with extra dependencies. For example, ``BoTorchSearcher``
 depends on ``torch``, ``botorch``, and ``gpytorch``. If you just use Syne Tune
 for your own experiments, you do not have to worry about this. However, we
 strongly encourage you to
-`contribute back your extension <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`_.
+`contribute back your extension <https://github.com/awslabs/syne-tune/blob/main/CONTRIBUTING.md>`__.
 
 Since some applications of Syne Tune require restricted dependencies, such are
 carefully managed. There are different
-`installation options <../../faq.html#what-are-the-different-installation-options-supported>`_,
+`installation options <../../faq.html#what-are-the-different-installation-options-supported>`__,
 each of which coming with a ``requirements.txt`` file (see ``setup.py`` for
 details).
 

--- a/docs/source/tutorials/multifidelity/mf_asha.rst
+++ b/docs/source/tutorials/multifidelity/mf_asha.rst
@@ -16,7 +16,7 @@ for 1 epoch, then 81 for 3 epochs, 27 for 9 epochs, and 9 for 27 epochs. Our
 excellent trial will always be among the top :math:`1/3` of others at these
 rung levels, but its progress through the rungs is severely delayed.
 
-In `asynchronous successive halving (ASHA) <https://arxiv.org/abs/1810.05934>`_,
+In `asynchronous successive halving (ASHA) <https://arxiv.org/abs/1810.05934>`__,
 the aim is to promote promising configurations as early as possible. There are
 two different variants of ASHA, and we will begin with the (arguably) simpler
 one. Whenever a worker becomes available, a new configuration is sampled at
@@ -35,14 +35,14 @@ decisions. While asynchronous decision-making can be much more efficient at
 running good configurations to the end, it runs the risk of making bad
 decisions based on too little data.
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs the stopping
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs the stopping
 variant of ASHA if ``method="ASHA-STOP"``.
 
 Asynchronous Successive Halving: Promotion Variant
 --------------------------------------------------
 
 In fact, the algorithm originally proposed as
-`ASHA <https://arxiv.org/abs/1810.05934>`_ is slightly different to what has
+`ASHA <https://arxiv.org/abs/1810.05934>`__ is slightly different to what has
 been detailed above. Instead of starting a trial once and rely on early
 stopping, this *promotion variant* is of the *pause-and-resume* type. Namely,
 whenever a trial reaches a rung, it is paused there. Whenever a worker becomes
@@ -50,7 +50,7 @@ available, all rungs are scanned top to bottom. If a paused trial is found
 which lies in the top :math:`1 / \eta` of all rung entries, it is *promoted*:
 it may resume and train until the next rung level. If no promotable paused
 trial is found, a new trial is started from scratch. Our
-`launcher script <mf_setup.html#the-launcher-script>`_ runs the stopping
+`launcher script <mf_setup.html#the-launcher-script>`__ runs the stopping
 variant of ASHA if ``method="ASHA-PROM"``.
 
 If these two variants (stopping and promotion) are compared under ideal
@@ -67,7 +67,7 @@ promotion type can be more attractive. In this context, it is important to
 understand the relevance of passing ``max_resource_attr`` to the scheduler
 (and, in our case, also to the
 :class:`~syne_tune.blackbox_repository.simulated_tabular_backend.BlackboxRepositoryBackend`).
-Recall the discussion `here <mf_setup.html#the-launcher-script>`_. If the
+Recall the discussion `here <mf_setup.html#the-launcher-script>`__. If the
 configuration space contains an entry with the maximum resource, whose key is
 passed to the scheduler as ``max_resource_attr``, the latter can modify this
 value when calling the backend to start or resume a trial. For example, if a
@@ -76,14 +76,14 @@ passes a configuration to the backend with ``{max_resource_attr: 9}``. This
 means that the training code knows how long it has to run, it does not have to
 be stopped by the backend.
 
-ASHA can be significantly accelerated by using `PASHA <https://openreview.net/forum?id=syfgJE6nFRW>`_
+ASHA can be significantly accelerated by using `PASHA <https://openreview.net/forum?id=syfgJE6nFRW>`__
 (Progressive ASHA) that dynamically allocates maximum resources for the tuning
 procedure depending on the need. PASHA starts with a small initial amount of
 maximum resources and progressively increases them if the ranking of the
 configurations in the top two rungs has not stabilized. In practice PASHA
 leads to e.g. 3x speedup compared to ASHA, but this can be even higher
 for large datasets with millions of examples. A tutorial about PASHA is
-`here <../pasha/pasha.html>`_.
+`here <../pasha/pasha.html>`__.
 
 Asynchronous Hyperband
 ----------------------
@@ -92,13 +92,13 @@ Finally, ASHA can also be extended to use multiple brackets. Namely, whenever
 a new trial is started, its bracket (or, equivalently, its :math:`r_{min}`
 value) is sampled randomly from a distribution. In Syne Tune, this distribution
 is proportional to the rung sizes in synchronous Hyperband. In our example
-with 6 brackets (see details `here <mf_syncsh.html#synchronous-hyperband>`_),
+with 6 brackets (see details `here <mf_syncsh.html#synchronous-hyperband>`__),
 this distribution is :math:`P(r_{min}) = [1:243/415, 3:98/415, 9:41/415,
 27:18/415, 81:9/415, 200:6/415]`. Our `launcher script
-<mf_setup.html#the-launcher-script>`_ runs asynchronous Hyperband with 6
+<mf_setup.html#the-launcher-script>`__ runs asynchronous Hyperband with 6
 brackets if ``method="ASHA6-STOP"``.
 
-As also noted in `ASHA <https://arxiv.org/abs/1810.05934>`_, the algorithm
+As also noted in `ASHA <https://arxiv.org/abs/1810.05934>`__, the algorithm
 often works best with a single bracket, so that ``brackets=1`` is the default
 in Syne Tune. However, we will see further below that model-based variants of
 ASHA with multiple brackets can outperform the single-bracket version if the

--- a/docs/source/tutorials/multifidelity/mf_async_model.rst
+++ b/docs/source/tutorials/multifidelity/mf_async_model.rst
@@ -13,7 +13,7 @@ will use the promotion mode here (i.e., pause-and-resume scheduling).
 Surrogate Models of Learning Curves
 -----------------------------------
 
-`Recall <mf_syncsh.html#early-stopping-hyperparameter-configurations>`_
+`Recall <mf_syncsh.html#early-stopping-hyperparameter-configurations>`__
 that validation error after :math:`r` epochs is denoted by
 :math:`f(\mathbf{x}, r)`, with :math:`\mathbf{x}` the configuration. Here,
 :math:`r\mapsto f(\mathbf{x}, r)` is called learning curve. A learning curve
@@ -23,7 +23,7 @@ are much more abundant at smaller resource levels :math:`r`, while predictions
 are more valuable at larger :math:`r`.
 
 In the context of Gaussian process based
-`Bayesian optimization <../basics/basics_bayesopt.html>`_, Syne Tune supports
+`Bayesian optimization <../basics/basics_bayesopt.html>`__, Syne Tune supports
 a number of different learning curve surrogate models. The type of model is
 selected upon construction of the scheduler:
 
@@ -80,8 +80,8 @@ represents :math:`f(\mathbf{x}, r)` directly, with mean function
 ``"freeze-thaw"``, ``"matern52"``, ``"matern52-res-warp"``,
 ``"cross-validation"``. The default choice is ``"exp-decay-sum"``, which is
 inspired by the exponential decay model proposed
-`here <https://arxiv.org/abs/1406.3896>`_. Details about these different
-models are given `here <https://openreview.net/forum?id=a2rFihIU7i>`_ and in
+`here <https://arxiv.org/abs/1406.3896>`__. Details about these different
+models are given `here <https://openreview.net/forum?id=a2rFihIU7i>`__ and in
 the source code.
 
 Decision-making is somewhat more expensive with ``"gp_multitask"`` than with
@@ -96,7 +96,7 @@ Additive Gaussian Models
 Two additional models are selected by
 ``search_options["model"] = "gp_expdecay"`` and
 ``search_options["model"] = "gp_issm"``. The former is the exponential
-decay model proposed `here <https://arxiv.org/abs/1406.3896>`_, the latter is
+decay model proposed `here <https://arxiv.org/abs/1406.3896>`__, the latter is
 a variant thereof. These additive Gaussian models represent dependencies across
 :math:`r` in a cheaper way than in ``"gp_multitask"``, and they can be fit to
 all observed data, not just at rung levels. Also, joint sampling is cheap.
@@ -108,7 +108,7 @@ Hyper-Tune.
 Asynchronous MOBSTER
 --------------------
 
-`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`_ combines ASHA and
+`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`__ combines ASHA and
 asynchronous Hyperband with GP-based Bayesian optimization. A Gaussian process
 learning curve surrogate model is fit to the data at all rung levels, and
 posterior predictive distributions are used in order to compute acquisition
@@ -116,14 +116,14 @@ function values and decide on which configuration to start next. We distinguish
 between MOBSTER-JOINT with a GP multi-task model (``"gp_multitask"``) and
 MOBSTER-INDEP with an independent GP model (``"gp_independent"``), as detailed
 above. The acquisition function is expected improvement (EI) at the rung level
-:math:`r_{acq}` also used by `BOHB <mf_sync_model.html#synchronous-bohb>`_.
+:math:`r_{acq}` also used by `BOHB <mf_sync_model.html#synchronous-bohb>`__.
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs (asynchronous)
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs (asynchronous)
 MOBSTER-JOINT if ``method="MOBSTER-JOINT"``. The searcher can be configured
 with ``search_options``, but MOBSTER-JOINT with the ``"exp-decay-sum"``
 covariance model is the default
 
-As shown `below <mf_comparison.html>`_, MOBSTER can outperform ASHA
+As shown `below <mf_comparison.html>`__, MOBSTER can outperform ASHA
 significantly. This is achieved by starting many less trials that stop very
 early (after 1 epoch) due to poor performance. Essentially, MOBSTER rapidly
 learns some important properties about the NASBench-201 problem and avoids
@@ -153,7 +153,7 @@ not tend to make a difference, so the default ``searcher_data="rungs"`` is
 recommended.
 
 Finally, we can also combine ASHA with
-`BOHB <mf_sync_model.html#synchronous-bohb>`_ decision-making, by choosing
+`BOHB <mf_sync_model.html#synchronous-bohb>`__ decision-making, by choosing
 ``searcher="kde"`` in
 :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`. This is an
 asynchronous version of BOHB.
@@ -161,7 +161,7 @@ asynchronous version of BOHB.
 MOBSTER-INDEP
 ~~~~~~~~~~~~~
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs
 (asynchronous) MOBSTER-INDEP if ``method="MOBSTER-INDEP"``. The independent
 GPs model is selected by ``search_options["model"] = "gp_independent"``.
 MOBSTER tends to perform slightly better with a joint multi-task GP model than
@@ -172,7 +172,7 @@ marginal impact.
 MOBSTER and Hyperband
 ~~~~~~~~~~~~~~~~~~~~~
 
-Just like `ASHA can be run with multiple brackets <mf_asha.html#asynchronous-hyperband>`_,
+Just like `ASHA can be run with multiple brackets <mf_asha.html#asynchronous-hyperband>`__,
 so can MOBSTER, simply by selecting ``brackets`` when creating
 :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`. In our experience so
 far, just like with ASHA, MOBSTER tends to work best with a single bracket.
@@ -206,13 +206,13 @@ number of observations. The amount of computation spent by MOBSTER can be contro
   surrogate model, the most expensive computation by far is refitting its own
   parameters, such as kernel parameters. The frequency of this computation can
   be regulated, as detailed
-  `here <../basics/basics_bayesopt.html#speeding-up-decision-making>`_.
+  `here <../basics/basics_bayesopt.html#speeding-up-decision-making>`__.
 
 
 Hyper-Tune
 ----------
 
-`Hyper-Tune <https://arxiv.org/abs/2201.06834>`_ is a model-based extension of
+`Hyper-Tune <https://arxiv.org/abs/2201.06834>`__ is a model-based extension of
 ASHA with some additional features compared to MOBSTER. It can be seen as
 extending MOBSTER-INDEP (with the ``"gp_independent"`` surrogate model) in two
 ways. First, it uses an acquisition function based on an ensemble predictive
@@ -224,7 +224,7 @@ is used to weight rung levels according to their reliability for making
 decisions (namely, which configuration :math:`\mathbf{x}` and bracket
 :math:`r_{min}` to associate with a new trial).
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs Hyper-Tune
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs Hyper-Tune
 if ``method="HYPERTUNE-INDEP"``. The searcher can be configured with
 ``search_options``, but the independent GPs model ``"gp_independent"`` is the
 default. In this example, Hyper-Tune is using a single bracket, so the
@@ -234,11 +234,11 @@ the acquisition function.
 Syne Tune also implements Hyper-Tune with the GP multi-task surrogate models
 used in MOBSTER. In result plots for this tutorial, original Hyper-Tune is
 called HYPERTUNE-INDEP, while this latter variant is called HYPERTUNE-JOINT.
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs this variant
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs this variant
 if ``method="HYPERTUNE-JOINT"``.
 
 Finally, computations of Hyper-Tune can be
-`controlled in the same way as in MOBSTER <#controlling-mobster-computations>`_.
+`controlled in the same way as in MOBSTER <#controlling-mobster-computations>`__.
 
 Hyper-Tune with Multiple Brackets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -248,7 +248,7 @@ simply by using the ``brackets`` argument of
 :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`. If ``brackets > 1``,
 Hyper-Tune samples the bracket for a new trial from an adaptive distribution
 closely related to the ensemble distribution used for acquisitions. Our
-`launcher script <mf_setup.html#the-launcher-script>`_ runs Hyper-Tune with 4
+`launcher script <mf_setup.html#the-launcher-script>`__ runs Hyper-Tune with 4
 brackets if ``method="HYPERTUNE4-INDEP"``.
 
 Recall that both ASHA and MOBSTER tend to work better for one than for multiple
@@ -290,7 +290,7 @@ compute loss values :math:`l_{r, s}` for :math:`(r, r_{*})` over all
 :math:`[\theta_r]` is obtained as normalized sum of these indicators over
 :math:`s=1,\dots, S`. We also need to compute loss values :math:`l_{r_{*}, s}`,
 this is done using a cross-validation approximation, see
-`here <https://arxiv.org/abs/2201.06834>`_ or the code in
+`here <https://arxiv.org/abs/2201.06834>`__ or the code in
 :mod:`syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune`
 for details. In the beginning, with too little data at the second rung level,
 we use :math:`\theta_{r_{min}} = 1` and 0 elsewhere.
@@ -307,7 +307,7 @@ experiments so far, this adaptive weighting can outperform the
 :math:`r_{acq}` heuristic used in BOHB and MOBSTER.
 
 Note that our implementation generalizes
-`Hyper-Tune <https://arxiv.org/abs/2201.06834>`_ in that ranking losses and
+`Hyper-Tune <https://arxiv.org/abs/2201.06834>`__ in that ranking losses and
 :math:`[\theta_r]` are estimated once :math:`r_{*} > r_{min}` (i.e., once
 :math:`r_{*}` is equal to the second rung level). In the original work, one has
 to wait until :math:`r_{*} = r_{max}`, i.e. the maximum rung level is
@@ -325,7 +325,7 @@ to determine a distribution :math:`P(r)` over all rung levels which feature as
 :math:`r_{min}` in a bracket. In our NASBench-201 example, if Hyper-Tune is run
 with 5 brackets, the support of :math:`P(r)` would be :math:`\mathcal{S} =
 \{1, 3, 9, 27, 81\}`. Also, denote the
-`default distribution <mf_asha.html#asynchronous-hyperband>`_ used in ASHA
+`default distribution <mf_asha.html#asynchronous-hyperband>`__ used in ASHA
 and MOBSTER by :math:`P_0(r)`. Let
 :math:`r_0 = \text{min}(r_{*}, \text{max}(\mathcal{S}))`. For
 :math:`r\in\mathcal{S}`, we define :math:`P(r) = M \theta_r / r` for
@@ -333,13 +333,13 @@ and MOBSTER by :math:`P_0(r)`. Let
 :math:`M = \sum_{r\in\mathcal{S}, r\le r_0} P_0(r)`. In other words, we use
 :math:`\theta_r / r` for rung levels supported by data, and the default
 :math:`P_0(r)` elsewhere. Once more, this slightly generalizes
-`Hyper-Tune <https://arxiv.org/abs/2201.06834>`_.
+`Hyper-Tune <https://arxiv.org/abs/2201.06834>`__.
 
 
 DyHPO
 -----
 
-`DyHPO <https://arxiv.org/abs/2202.09774>`_ is another recent model-based
+`DyHPO <https://arxiv.org/abs/2202.09774>`__ is another recent model-based
 multi-fidelity method. It is a promotion-based scheduler like the ones below
 with ``type="promotion"``, but differs from MOBSTER and Hyper-Tune in that
 promotion decisions are done based on the surrogate model, not on the
@@ -366,7 +366,7 @@ quantile-based rule of successive halving. In a nutshell:
 Our implementation of DyHPO differs from the published work in a number of
 important points:
 
-* `DyHPO <https://arxiv.org/abs/2202.09774>`_ uses an advanced surrogate model
+* `DyHPO <https://arxiv.org/abs/2202.09774>`__ uses an advanced surrogate model
   based on a neural network covariance kernel which is fitted to the current
   data. Our implementation supports DyHPO with the GP surrogate models
   detailed above, except for ``"gp_independent"``.
@@ -383,6 +383,6 @@ important points:
   before promoting any paused ones.
 * Since in DyHPO, the surrogate model is used more frequently than in MOBSTER,
   it is important to control surrogate model computations, as detailed
-  `above <#controlling-mobster-computations>`_. Apart from the default for
+  `above <#controlling-mobster-computations>`__. Apart from the default for
   ``max_size_data_for_model``, we also use ``opt_skip_period = 3`` as default
   for DyHPO.

--- a/docs/source/tutorials/multifidelity/mf_introduction.rst
+++ b/docs/source/tutorials/multifidelity/mf_introduction.rst
@@ -120,7 +120,7 @@ How to implement such scheduling decisions? In general, we need to compare a
 number of trials with each other on the basis of observations at a certain
 resource level :math:`r` (or, more generally, on values up to :math:`r`). In
 this tutorial, and in Syne Tune more generally, we use terminology defined in
-the `ASHA <https://arxiv.org/abs/1810.05934>`_ publication. A *rung* is a list
+the `ASHA <https://arxiv.org/abs/1810.05934>`__ publication. A *rung* is a list
 of trials :math:`\mathbf{x}_j` and observations :math:`f(\mathbf{x}_j, r)` at a
 certain resource level :math:`r`. This resource is also called *rung level*. In
 general, a decision on what to do with one or several trials in the rung is
@@ -135,7 +135,7 @@ remarks at this point, which will be substantiated with examples:
 * Modern successive halving methods innovated over earlier proposals by
   suggesting a geometric spacing of rung levels, and by calibrating the
   thresholds in scheduling decisions according to this spacing. For example,
-  the `median stopping rule <https://research.google/pubs/pub46180/>`_
+  the `median stopping rule <https://research.google/pubs/pub46180/>`__
   predates successive halving, but is typically outperformed by ASHA (while MSR
   is implemented in Syne Tune, it is not discussed in this tutorial).
 * Scheduling decisions can either be made synchronously or asynchronously. In
@@ -148,5 +148,5 @@ remarks at this point, which will be substantiated with examples:
   next rung level and paused there. When a worker becomes available, it may be
   used to resume any of the paused trials, in case they compare well against
   peers at the same rung. These modalities place `different requirements
-  <mf_asha.html#asynchronous-successive-halving-promotion-variant>`_ on the
+  <mf_asha.html#asynchronous-successive-halving-promotion-variant>`__ on the
   training script and the execution backend.

--- a/docs/source/tutorials/multifidelity/mf_setup.rst
+++ b/docs/source/tutorials/multifidelity/mf_setup.rst
@@ -2,7 +2,7 @@ Setting up the Problem
 ======================
 
 If you have not done this before, it is recommended you first work through the
-`Basics of Syne Tune <../basics/README.html>`_ tutorial, in order to become
+`Basics of Syne Tune <../basics/README.html>`__ tutorial, in order to become
 familiar with concepts such as *configuration*, *configuration space*,
 *backend*, *scheduler*.
 
@@ -10,7 +10,7 @@ Running Example
 ---------------
 
 For most of this tutorial, we will be concerned with one running example: the
-`NASBench-201 benchmark <https://arxiv.org/abs/2001.00326>`_. NASBench-201 is
+`NASBench-201 benchmark <https://arxiv.org/abs/2001.00326>`__. NASBench-201 is
 a frequently used neural architecture search benchmark with a configuration
 space of six categorical parameters, with five values each. The authors
 trained networks under all these configurations and provide metrics, such as
@@ -245,7 +245,7 @@ script.
 Let us have a walk through this script, assuming it is called with the default
 ``--method ASHA-STOP``:
 
-* If you worked through `Basics of Syne Tune <../basics/README.html>`_, you
+* If you worked through `Basics of Syne Tune <../basics/README.html>`__, you
   probably miss the training scripts. Since we use the simulator backend with a
   blackbox (NASBench-201), a training script is not required, since the backend
   is directly linked to the blackbox repository and obtains evaluation data from
@@ -279,7 +279,7 @@ Let us have a walk through this script, assuming it is called with the default
   finite configuration space, we can ignore this extra complexity in this
   tutorial. However, choosing a suitable configuration space and specifying a
   surrogate can be important for model-based HPO methods. Some more informations
-  are given `here <../../search_space.html>`_.
+  are given `here <../../search_space.html>`__.
 * [2] We can determine ``resource_attr`` (name of resource attribute) from the
   blackbox as ``blackbox.fidelity_name()``. Next, if ``max_resource_attr`` is
   specified, we attach the information about the largest resource level to the
@@ -291,7 +291,7 @@ Let us have a walk through this script, assuming it is called with the default
   the maximum resource information to the configuration space is that
   pause-and-resume schedulers can use it to signal the training script how long
   to really run for. This is explained in more detail
-  `when we come to these schedulers <mf_asha.html#asynchronous-successive-halving-promotion-variant>`_.
+  `when we come to these schedulers <mf_asha.html#asynchronous-successive-halving-promotion-variant>`__.
   In short, we strongly recommend to use ``max_resource_attr`` and to configure
   schedulers with it.
 * [2] If ``max_resource_attr`` is not to be used, the scheduler needs to be
@@ -301,7 +301,7 @@ Let us have a walk through this script, assuming it is called with the default
   the default case. Most supported schedulers can easily be imported from
   :mod:`syne_tune.optimizer.baselines`, using common names.
 * [4] Finally, we create a stopping criterion and a ``Tuner``. This should be
-  well known from `Basics of Syne Tune <../basics/README.html>`_. One
+  well known from `Basics of Syne Tune <../basics/README.html>`__. One
   speciality here is that we require ``sleep_time=0`` and
   ``callbacks=[SimulatorCallback()]`` for things to work out with the simulator
   backend. Namely, since time is simulated, the ``Tuner`` does not really have

--- a/docs/source/tutorials/multifidelity/mf_sync_model.rst
+++ b/docs/source/tutorials/multifidelity/mf_sync_model.rst
@@ -7,15 +7,15 @@ Bayesian optimization with multi-fidelity scheduling, where configurations are
 chosen based on performance of previously chosen ones, rather than being
 sampled at random.
 
-`Basics of Syne Tune: Bayesian Optimization <../basics/basics_bayesopt.html>`_
+`Basics of Syne Tune: Bayesian Optimization <../basics/basics_bayesopt.html>`__
 provides an introduction to Bayesian optimization in Syne Tune.
 
 Synchronous BOHB
 ----------------
 
 The first model-based method we consider is
-`BOHB <https://arxiv.org/abs/1807.01774>`_, which uses the
-`TPE <https://papers.nips.cc/paper/2011/hash/86e8f7ab32cfd12577bc2619bc635690-Abstract.html>`_
+`BOHB <https://arxiv.org/abs/1807.01774>`__, which uses the
+`TPE <https://papers.nips.cc/paper/2011/hash/86e8f7ab32cfd12577bc2619bc635690-Abstract.html>`__
 formulation of Bayesian optimization. In the latter, an approximation to the
 expected improvement (EI) acquisition function is interpreted via a ratio of
 two densities. BOHB uses kernel density estimators rather than tree Parzen
@@ -24,13 +24,13 @@ estimators (as in TPE) to model the two densities.
 BOHB uses the same scheduling mechanism (i.e., rung levels, promotion
 decisions) than synchronous Hyperband (or SH), but it uses a model fit to past
 data for suggesting the configuration of every new trial.
-`Recall <mf_syncsh.html#early-stopping-hyperparameter-configurations>`_ that
+`Recall <mf_syncsh.html#early-stopping-hyperparameter-configurations>`__ that
 validation error after :math:`r` epochs is denoted by :math:`f(\mathbf{x}, r)`,
 where :math:`\mathbf{x}` is the configuration. BOHB fits KDEs separately to the
 data obtained at each rung level. When a new configuration is to be suggested,
 it first determines the largest rung level :math:`r_{acq}` supported by enough
 data for the two densities to be properly fit. It then makes a TPE decision at
-this resource level. Our `launcher script <mf_setup.html#the-launcher-script>`_
+this resource level. Our `launcher script <mf_setup.html#the-launcher-script>`__
 runs synchronous BOHB if ``method="BOHB"``.
 
 While BOHB is often more efficient than SYNCHB, it is held back by synchronous
@@ -45,15 +45,15 @@ Synchronous MOBSTER
 -------------------
 
 Another model-based variant is synchronous
-`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`_. We will provide more
+`MOBSTER <https://openreview.net/forum?id=a2rFihIU7i>`__. We will provide more
 details on MOBSTER below, when discussing model-based asynchronous methods.
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs synchronous
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs synchronous
 MOBSTER if ``method="SYNCMOBSTER"``. Note that the default surrogate model for
 ``SyncMOBSTER`` is ``gp_independent``, where the data at each rung level
 is represented by an independent Gaussian process (more details are given
-`here <mf_async_model.html#independent-processes-at-each-rung-level>`_).
-`It turns out <mf_comparison.html>`_ that ``SyncMOBSTER`` outperforms
+`here <mf_async_model.html#independent-processes-at-each-rung-level>`__).
+`It turns out <mf_comparison.html>`__ that ``SyncMOBSTER`` outperforms
 ``SyncBOHB`` substantially on the benchmark chosen here.
 
 When running these experiments with the simulator backend, we note that
@@ -73,24 +73,24 @@ required to make decisions, as well as potential inefficiencies in scheduling
 jobs in parallel. HPO methods should always be compared with real experiment
 time on the x axis, and the any-time performance of methods should be
 visualized by plotting curves, not just quoting “final values”. Examples are
-provided `here <mf_comparison.html>`_.
+provided `here <mf_comparison.html>`__.
 
 .. note::
    Syne Tune allows to launch experiments remotely and in parallel in order
    to still obtain results rapidly, as is detailed
-   `here <../benchmarking/README.html>`_.
+   `here <../benchmarking/README.html>`__.
 
 Differential Evolution Hyperband
 --------------------------------
 
 Another recent model-based extension of synchronous Hyperband is
-`Differential Evolution Hyperband (DEHB) <https://arxiv.org/abs/2105.09821>`_.
+`Differential Evolution Hyperband (DEHB) <https://arxiv.org/abs/2105.09821>`__.
 DEHB is typically run with multiple brackets. A main difference to Hyperband
 is that configurations promoted from a rung to the next are also modified by
 an evolutionary rule, involving mutation, cross-over and selection. Since
 configurations are not just sampled once, but potentially modified at every
 rung, the hope is to find well-performing configurations faster. Our
-`launcher script <mf_setup.html#the-launcher-script>`_ runs DEHB if
+`launcher script <mf_setup.html#the-launcher-script>`__ runs DEHB if
 ``method="DEHB"``.
 
 The main feature of DEHB over synchronous Hyperband is that configurations can

--- a/docs/source/tutorials/multifidelity/mf_syncsh.rst
+++ b/docs/source/tutorials/multifidelity/mf_syncsh.rst
@@ -5,7 +5,7 @@ In this section, we will introduce some simple multi-fidelity HPO methods based
 on synchronous decision-making. Methods discussed here are not model-based,
 they suggest new configurations simply by drawing them uniformly at random from
 the configuration space, much like
-`random search <../basics/basics_randomsearch.html>`_ does.
+`random search <../basics/basics_randomsearch.html>`__ does.
 
 Early Stopping Hyperparameter Configurations
 --------------------------------------------
@@ -32,7 +32,7 @@ them to more promising ones. This speeds up the optimization process, since we
 have a higher throughput of configurations that we can try.
 
 Recall the notation of *resource* from the
-`introduction <mf_introduction.html#fidelities-and-resources>`_. In this
+`introduction <mf_introduction.html#fidelities-and-resources>`__. In this
 tutorial, resource equates to epochs trained, so :math:`r=2` refers to metric
 values evaluated at the end of the second epoch. The main objective of interest,
 validation error in our tutorial, is denoted by :math:`f(\mathbf{x}, r)`, where
@@ -46,7 +46,7 @@ Synchronous Successive Halving
 ------------------------------
 
 One of the simplest competitive multi-fidelity HPO methods is
-`synchronous successive halving <https://arxiv.org/abs/1502.07943>`_ (SH). The
+`synchronous successive halving <https://arxiv.org/abs/1502.07943>`__ (SH). The
 basic idea is to start with :math:`N` configurations randomly sampled from the
 configuration space, training each of them for :math:`r_{min}` epochs only
 (e.g., :math:`r_{min} = 1`). We then discard a fraction of the worst performing
@@ -84,7 +84,7 @@ resource :math:`r_{max}`. In our example:
 Finally, once one such round of SH is finished, we start the next round with a
 new set of initial configurations, until the total budget is spent.
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs synchronous
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs synchronous
 successive halving if ``method="SYNCSH"``. The relevant parameters are
 ``grace_period`` ( :math:`r_{min}` ) and ``reduction_factor`` ( :math:`\eta` ).
 Moreover, for SH, we need to set ``brackets=1``, since otherwise an extension
@@ -92,7 +92,7 @@ called *Hyperband* is run (to be discussed shortly). Our implementation is
 :class:`~syne_tune.optimizer.schedulers.synchronous.SynchronousHyperbandScheduler`.
 
 Synchronous SH employs *pause-and-resume scheduling* (see
-`introduction <mf_introduction.html#multi-fidelity-scheduling>`_). Once a
+`introduction <mf_introduction.html#multi-fidelity-scheduling>`__). Once a
 trial reaches a rung level, it is paused there. This is because the decision of
 which trials to promote to the next rung level can only be taken once the
 current rung level is completely filled up: only then can we determine the top
@@ -103,7 +103,7 @@ trial is resumed, the checkpoint is loaded and training can resume from there.
 Say a trial is paused at :math:`r = 9` and is later resumed towards
 :math:`r = 27`. With checkpointing, we have to train for :math:`27 - 9 = 18`
 epochs only instead of 27 epochs for training from scratch. More details are
-given `here <../../faq.html#how-can-i-enable-trial-checkpointing>`_. For
+given `here <../../faq.html#how-can-i-enable-trial-checkpointing>`__. For
 tabulated benchmarks, checkpointing is supported by default.
 
 Finally, it is important to understand in which sense the method detailed in
@@ -136,7 +136,7 @@ network might not have learned anything useful, and even the best configurations
 may be filtered out at random. If :math:`r_{min}` is too large on the other
 hand, the benefits of early stopping may be greatly diminished.
 
-`Hyperband <https://arxiv.org/abs/1603.06560>`_ is an extension of SH that
+`Hyperband <https://arxiv.org/abs/1603.06560>`__ is an extension of SH that
 mitigates the risk of setting :math:`r_{min}` too small. It runs SH as
 subroutine, where each round, called a *bracket*, balances between
 :math:`r_{min}` and the number of initial configurations :math:`N`, such that
@@ -155,7 +155,7 @@ NASBench-201 example:
 * Bracket 4: :math:`r_{min} = 81, N = 9`
 * Bracket 5: :math:`r_{min} = 200, N = 6`
 
-Our `launcher script <mf_setup.html#the-launcher-script>`_ runs synchronous
+Our `launcher script <mf_setup.html#the-launcher-script>`__ runs synchronous
 Hyperband if ``method="SYNCHB"``. Since ``brackets`` is not used when creating
 ``SyncHyperband``, the maximum value 6 is chosen. We also use the default
 values for ``grace_period`` (1) and ``reduction_factor`` (3). Our implementation

--- a/docs/source/tutorials/pasha/pasha.rst
+++ b/docs/source/tutorials/pasha/pasha.rst
@@ -16,7 +16,7 @@ resources than ASHA.
 What is PASHA?
 --------------
 
-The goal of `PASHA <https://openreview.net/forum?id=syfgJE6nFRW>`_ is to identify
+The goal of `PASHA <https://openreview.net/forum?id=syfgJE6nFRW>`__ is to identify
 well-performing configurations significantly faster than current methods,
 so that we can then retrain the model with the selected configuration
 (in practice on the combined training and validation sets). By giving preference
@@ -57,10 +57,10 @@ How well does PASHA work?
 Experimental evaluation has shown PASHA consistently leads to strong improvements in runtime,
 while achieving similar accuracies as ASHA. PASHA is e.g. three times faster than ASHA on NASBench201.
 Full experiments and further details are available in 
-`PASHA: Efficient HPO and NAS with Progressive Resource Allocation <https://openreview.net/forum?id=syfgJE6nFRW>`_.
+`PASHA: Efficient HPO and NAS with Progressive Resource Allocation <https://openreview.net/forum?id=syfgJE6nFRW>`__.
 
 We provide an example script
-`launch_pasha_nasbench201.py <../../examples.html#pasha-efficient-hpo-and-nas-with-progressive-resource-allocation>`_
+`launch_pasha_nasbench201.py <../../examples.html#pasha-efficient-hpo-and-nas-with-progressive-resource-allocation>`__
 that shows how to run an experiment with PASHA on NASBench201.
 
 Recommendations

--- a/docs/source/tutorials/transfer_learning/transfer_learning.rst
+++ b/docs/source/tutorials/transfer_learning/transfer_learning.rst
@@ -13,7 +13,7 @@ previous training data to work well on the augmented data set as well.
 
 Syne Tune includes implementations of several transfer learning schedulers; a
 list of available schedulers is given
-`here <../../getting_started.html#supported-hpo-methods>`_. In this tutorial we
+`here <../../getting_started.html#supported-hpo-methods>`__. In this tutorial we
 look at three of them:
 
 * :class:`~syne_tune.optimizer.baselines.ZeroShotTransfer`
@@ -49,7 +49,7 @@ ZeroShot, BoundingBox and Quantiles. The set of tasks is made by adjusting the
 the training data instead.
 
 The code is available
-`here <../../examples.html#transfer-learning-example>`_.
+`here <../../examples.html#transfer-learning-example>`__.
 Make sure to run it as
 `python launch_transfer_learning_example.py --generate_plots`
 if you want to generate the plots locally.

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gluon.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/gluon.py
@@ -802,7 +802,7 @@ class Block:
         Prefix acts like a name space. All children blocks created in parent block's
         :py:meth:`name_scope` will have parent block's prefix in their name.
         Please refer to
-        `naming tutorial </api/python/docs/tutorials/packages/gluon/blocks/naming.html>`_
+        `naming tutorial </api/python/docs/tutorials/packages/gluon/blocks/naming.html>`__
         for more info on prefix and naming.
     params : ParameterDict or None
         :py:class:`ParameterDict` for sharing weights with the new :py:class:`Block`. For example,
@@ -914,7 +914,7 @@ class Block:
             with self.name_scope():
                 self.dense = nn.Dense(20)
         Please refer to
-        `the naming tutorial </api/python/docs/tutorials/packages/gluon/blocks/naming.html>`_
+        `the naming tutorial </api/python/docs/tutorials/packages/gluon/blocks/naming.html>`__
         for more info on prefix and naming.
         """
         return self._scope


### PR DESCRIPTION
In rst, links `text <...>`_ (one underscore) are supposed to have unique text. It is more useful to use anonymous links, of the form `text <...>`__ (two underscores), this does not give warnings about duplicate text.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
