### PR TITLE
fix: Fixes to benchmarking with simulator backend

### DIFF
--- a/benchmarking/commons/benchmark_definitions/fcnet.py
+++ b/benchmarking/commons/benchmark_definitions/fcnet.py
@@ -17,7 +17,7 @@ from benchmarking.commons.benchmark_definitions.common import (
 
 def fcnet_benchmark(dataset_name):
     return SurrogateBenchmarkDefinition(
-        max_wallclock_time=1200,
+        max_wallclock_time=3600,
         n_workers=4,
         elapsed_time_attr="metric_elapsed_time",
         metric="metric_valid_loss",

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -45,13 +45,13 @@ from syne_tune.stopping_criterion import StoppingCriterion
 from syne_tune.tuner import Tuner
 from syne_tune.util import sanitize_sagemaker_name
 
+
 SIMULATED_BACKEND_EXTRA_PARAMETERS = [
     dict(
         name="benchmark",
         type=str,
         help="Benchmark to run from benchmark_definitions",
         default=None,
-        required=True,
     ),
     dict(
         name="verbose",
@@ -79,13 +79,17 @@ SIMULATED_BACKEND_EXTRA_PARAMETERS = [
         help="If 1, scheduler only suggests configs contained in tabulated benchmark",
     ),
 ]
+
+
 BENCHMARK_KEY_EXTRA_PARAMETER = dict(
     name="benchmark_key",
     type=str,
-    help="Key for benchmarks, needs to bespecified if benchmarks definitions are nested.",
+    help="Key for benchmarks, needs to be specified if benchmarks definitions are nested.",
     default=None,
     required=True,
 )
+
+
 SurrogateBenchmarkDefinitions = Union[
     Dict[str, SurrogateBenchmarkDefinition],
     Dict[str, Dict[str, SurrogateBenchmarkDefinition]],
@@ -340,7 +344,7 @@ def start_benchmark_simulated_backend(
             )
         tuner_name = experiment_tag
         if configuration.use_long_tuner_name_prefix:
-            tuner_name += f"-{sanitize_sagemaker_name(configuration.benchmark)}-{seed}"
+            tuner_name += f"-{sanitize_sagemaker_name(benchmark_name)}-{seed}"
         tuner = Tuner(
             trial_backend=trial_backend,
             scheduler=scheduler,
@@ -413,7 +417,7 @@ def main(
         map_method_args=map_extra_args,
         post_processing=post_processing,
         extra_tuning_job_metadata=None
-        if len(extra_args) == 0
+        if extra_args is None
         else extra_metadata(configuration, extra_args),
         use_transfer_learning=use_transfer_learning,
     )

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -1177,6 +1177,10 @@ class HyperbandBracketManager:
         is returned. This information is passed to ``get_config`` of the
         searcher.
 
+        Note: ``extra_kwargs`` can return information also if ``trial_id = None``
+        is returned. This information is passed to ``get_config`` of the
+        searcher.
+
         :param new_trial_id: ID for new trial as passed to :meth:`_suggest`
         :return: ``(trial_id, extra_kwargs)``
         """

--- a/syne_tune/optimizer/schedulers/hyperband_stopping.py
+++ b/syne_tune/optimizer/schedulers/hyperband_stopping.py
@@ -98,6 +98,13 @@ class RungSystem:
         The default is to return an empty dictionary, but some special subclasses
         can use this to return information in case a trial is not promoted.
 
+        If no trial can be promoted, or if the rung system is not
+        promotion-based, the returned dictionary must not contain the
+        "trial_id" key. It is nevertheless passed back via ``extra_kwargs`` in
+        :meth:`~syne_tune.optimizer.schedulers.hyperband.HyperbandBracketManager.on_task_schedule`.
+        The default is to return an empty dictionary, but some special subclasses
+        can use this to return information in case a trial is not promoted.
+
         :param new_trial_id: ID for new trial as passed to :meth:`_suggest`.
             Only needed by specific subclasses
         :return: See above

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/hypertune/gp_model.py
@@ -148,9 +148,9 @@ class HyperTuneIndependentGPModel(IndependentGPPerResourceModel, HyperTuneModelM
     Variant of :class:`IndependentGPPerResourceModel` which implements additional
     features of the Hyper-Tune algorithm, see
 
-        Yang Li et al
-        Hyper-Tune: Towards Efficient Hyper-parameter Tuning at Scale
-        VLDB 2022
+        | Yang Li et al
+        | Hyper-Tune: Towards Efficient Hyper-parameter Tuning at Scale
+        | VLDB 2022
 
     Our implementation differs from the Hyper-Tune paper in a number of ways.
     Most importantly, their method requires a sufficient number of observed

--- a/tst/schedulers/bayesopt/gpautograd/test_warping.py
+++ b/tst/schedulers/bayesopt/gpautograd/test_warping.py
@@ -10,7 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-import numpy
 import autograd.numpy as anp
 import numpy as np
 import pytest
@@ -48,12 +47,12 @@ def test_warping_default_parameters():
     warping.collect_params().initialize()
 
     warping_a = warping.encoding.get(warping.power_a_internal.data())
-    numpy.testing.assert_almost_equal(warping_a, anp.ones(3))
+    np.testing.assert_almost_equal(warping_a, anp.ones(3))
 
     expected = anp.array([NUMERICAL_JITTER, 0.5, 1.0 - NUMERICAL_JITTER]).reshape(
         (1, -1)
     )
-    numpy.testing.assert_almost_equal(warping(x), expected)
+    np.testing.assert_almost_equal(warping(x), expected)
 
 
 def test_warping_with_arbitrary_parameters():
@@ -63,7 +62,7 @@ def test_warping_with_arbitrary_parameters():
     warping.encoding.set(warping.power_a_internal, [2.0, 2.0, 2.0])
     warping.encoding.set(warping.power_b_internal, [0.5, 0.5, 0.5])
     warping_a = warping.encoding.get(warping.power_a_internal.data())
-    numpy.testing.assert_almost_equal(warping_a, [2.0, 2.0, 2.0])
+    np.testing.assert_almost_equal(warping_a, [2.0, 2.0, 2.0])
     # In that case (with parameters [2., 0.5]), the warping is given by x => 1. - sqrt(1. - x^2)
     def expected_warping(x):
         return 1.0 - anp.sqrt(1.0 - x * x)
@@ -71,7 +70,7 @@ def test_warping_with_arbitrary_parameters():
     expected = expected_warping(
         anp.array([NUMERICAL_JITTER, 0.5, 1.0 - NUMERICAL_JITTER]).reshape((1, -1))
     )
-    numpy.testing.assert_almost_equal(warping(x), expected)
+    np.testing.assert_almost_equal(warping(x), expected)
 
 
 def test_warping_with_multidimension_and_arbitrary_parameters():
@@ -89,7 +88,7 @@ def test_warping_with_multidimension_and_arbitrary_parameters():
 
     # The parameters of w2 should be the default ones (as there was no set operations)
     w2_params = warping2.get_params()
-    numpy.testing.assert_almost_equal(
+    np.testing.assert_almost_equal(
         [w2_params["power_a"], w2_params["power_b"]], [1.0, 1.0]
     )
 
@@ -105,7 +104,7 @@ def test_warping_with_multidimension_and_arbitrary_parameters():
         [NUMERICAL_JITTER, 0.5, 1.0 - NUMERICAL_JITTER]
     ).reshape((-1, 1))
 
-    numpy.testing.assert_almost_equal(
+    np.testing.assert_almost_equal(
         warping0(warping2(X)),
         anp.hstack([expected_column0, expected_column1, expected_column2]),
     )


### PR DESCRIPTION
Without this fix, benchmarking does not work properly for simulator backend.

Also some fixes of docstrings, and extended default `max_wallclock_time` for `fcnet` benchmark.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
