### PR TITLE
refactor: Make all literalinclude in docs independent of line numbers

### DIFF
--- a/docs/source/benchmarking/benchmark_dehb.rst
+++ b/docs/source/benchmarking/benchmark_dehb.rst
@@ -7,19 +7,19 @@ against a number of baselines.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/baselines.py
    :caption: benchmarking/nursery/benchmark_dehb/baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/benchmark_definitions.py
    :caption: benchmarking/nursery/benchmark_dehb/benchmark_definitions.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/hpo_main.py
    :caption: benchmarking/nursery/benchmark_dehb/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/launch_remote.py
    :caption: benchmarking/nursery/benchmark_dehb/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_dehb/requirements.txt
    :caption: benchmarking/nursery/benchmark_dehb/requirements.txt

--- a/docs/source/benchmarking/benchmark_hypertune.rst
+++ b/docs/source/benchmarking/benchmark_hypertune.rst
@@ -7,19 +7,19 @@ against a number of baselines.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/baselines.py
    :caption: benchmarking/nursery/benchmark_hypertune/baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/benchmark_definitions.py
    :caption: benchmarking/nursery/benchmark_hypertune/benchmark_definitions.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/hpo_main.py
    :caption: benchmarking/nursery/benchmark_hypertune/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/launch_remote.py
    :caption: benchmarking/nursery/benchmark_hypertune/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_hypertune/requirements.txt
    :caption: benchmarking/nursery/benchmark_hypertune/requirements.txt

--- a/docs/source/benchmarking/benchmark_yahpo.rst
+++ b/docs/source/benchmarking/benchmark_yahpo.rst
@@ -6,19 +6,19 @@ simple baselines.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_yahpo/baselines.py
    :caption: benchmarking/nursery/benchmark_yahpo/baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_yahpo/benchmark_definitions.py
    :caption: benchmarking/nursery/benchmark_yahpo/benchmark_definitions.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_yahpo/hpo_main.py
    :caption: benchmarking/nursery/benchmark_yahpo/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_yahpo/launch_remote.py
    :caption: benchmarking/nursery/benchmark_yahpo/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/benchmark_yahpo/requirements.txt
    :caption: benchmarking/nursery/benchmark_yahpo/requirements.txt

--- a/docs/source/benchmarking/fine_tuning_transformer_glue.rst
+++ b/docs/source/benchmarking/fine_tuning_transformer_glue.rst
@@ -6,11 +6,11 @@ fine-tuning it to GLUE task.
 
 .. literalinclude:: ../../../benchmarking/nursery/fine_tuning_transformer_glue/hpo_main.py
    :caption: benchmarking/nursery/fine_tuning_transformer_glue/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
    :caption: benchmarking/nursery/fine_tuning_transformer_glue/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/fine_tuning_transformer_glue/run_glue_modified.py
    :caption: benchmarking/nursery/fine_tuning_transformer_glue/run_glue_modified.py

--- a/docs/source/benchmarking/launch_local.rst
+++ b/docs/source/benchmarking/launch_local.rst
@@ -6,15 +6,15 @@ Comparison of baseline methods on real benchmark, using the
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_local/baselines.py
    :caption: benchmarking/nursery/launch_local/baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_local/hpo_main.py
    :caption: benchmarking/nursery/launch_local/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_local/launch_remote.py
    :caption: benchmarking/nursery/launch_local/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_local/requirements-synetune.txt
    :caption: benchmarking/nursery/launch_local/requirements-synetune.txt

--- a/docs/source/benchmarking/launch_sagemaker.rst
+++ b/docs/source/benchmarking/launch_sagemaker.rst
@@ -6,15 +6,15 @@ Comparison of baseline methods on real benchmark, using the
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_sagemaker/baselines.py
    :caption: benchmarking/nursery/launch_sagemaker/baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_sagemaker/hpo_main.py
    :caption: benchmarking/nursery/launch_sagemaker/hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_sagemaker/launch_remote.py
    :caption: benchmarking/nursery/launch_sagemaker/launch_remote.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 .. literalinclude:: ../../../benchmarking/nursery/launch_sagemaker/requirements.txt
    :caption: benchmarking/nursery/launch_sagemaker/requirements.txt

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -3,7 +3,7 @@ Launch HPO Experiment Locally
 
 .. literalinclude:: ../../examples/launch_height_baselines.py
    :caption: examples/launch_height_baselines.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Along with several of the examples below, this launcher script is using the
 following :ref:`train_height.py <train_height_script>` training script:
@@ -11,7 +11,7 @@ following :ref:`train_height.py <train_height_script>` training script:
 .. literalinclude:: ../../examples/training_scripts/height_example/train_height.py
    :name: train_height_script
    :caption: examples/training_scripts/height_example/train_height.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 
 Fine-Tuning Hugging Face Model for Sentiment Classification
@@ -19,7 +19,7 @@ Fine-Tuning Hugging Face Model for Sentiment Classification
 
 .. literalinclude:: ../../examples/launch_huggingface_classification.py
    :caption: examples/launch_huggingface_classification.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -42,7 +42,7 @@ Launch HPO Experiment with Python Backend
 
 .. literalinclude:: ../../examples/launch_height_python_backend.py
    :caption: examples/launch_height_python_backend.py
-   :lines: 17-
+   :start-after: # permissions and limitations under the License.
 
 The Python backend does not need a separate training script.
 
@@ -52,7 +52,7 @@ Population-Based Training (PBT)
 
 .. literalinclude:: ../../examples/launch_pbt.py
    :caption: examples/launch_pbt.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This launcher script is using the following :ref:`pbt_example.py <pbt_example_script>` training
 script:
@@ -60,7 +60,7 @@ script:
 .. literalinclude:: ../../examples/training_scripts/pbt_example/pbt_example.py
    :name: pbt_example_script
    :caption: examples/training_scripts/pbt_example/pbt_example.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 For this toy example, PBT is run with a population size of 2, so only
 two parallel workers are needed. In order to use PBT competitively,
@@ -74,7 +74,7 @@ Visualize Tuning Progress with Tensorboard
 
 .. literalinclude:: ../../examples/launch_tensorboard_example.py
    :caption: examples/launch_tensorboard_example.py
-   :lines: 14-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -93,7 +93,7 @@ Launch HPO Experiment with Simulator Backend
 
 .. literalinclude:: ../../examples/launch_nasbench201_simulated.py
    :caption: examples/launch_nasbench201_simulated.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -115,7 +115,7 @@ Joint Tuning of Instance Type and Hyperparameters using MOASHA
 
 .. literalinclude:: ../../examples/launch_moasha_instance_tuning.py
    :caption: examples/launch_moasha_instance_tuning.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -143,7 +143,7 @@ Multi-objective Asynchronous Successive Halving (MOASHA)
 
 .. literalinclude:: ../../examples/launch_height_moasha.py
    :caption: examples/launch_height_moasha.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 This launcher script is using the following :ref:`mo_artificial.py <mo_artificial_script>` training
 script:
@@ -151,7 +151,7 @@ script:
 .. literalinclude:: ../../examples/training_scripts/mo_artificial/mo_artificial.py
    :name: mo_artificial_script
    :caption: examples/training_scripts/mo_artificial/mo_artificial.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 PASHA: Efficient HPO and NAS with Progressive Resource Allocation
@@ -159,7 +159,7 @@ PASHA: Efficient HPO and NAS with Progressive Resource Allocation
 
 .. literalinclude:: ../../examples/launch_pasha_nasbench201.py
    :caption: examples/launch_pasha_nasbench201.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 This script uses the simulator backend to run an experiment on NASBench-201.
 It takes only a few seconds to run, but it needs ``nasbench201`` blackbox
@@ -176,7 +176,7 @@ Constrained Bayesian Optimization
 
 .. literalinclude:: ../../examples/launch_bayesopt_constrained.py
    :caption: examples/launch_bayesopt_constrained.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 This launcher script is using the following :ref:`train_constrained_example.py <train_constrained_script>` training
 script:
@@ -184,7 +184,7 @@ script:
 .. literalinclude:: ../../examples/training_scripts/constrained_hpo/train_constrained_example.py
    :name: train_constrained_script
    :caption: examples/training_scripts/constrained_hpo/train_constrained_example.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 Restrict Scheduler to Tabulated Configurations with Simulator Backend
@@ -192,7 +192,7 @@ Restrict Scheduler to Tabulated Configurations with Simulator Backend
 
 .. literalinclude:: ../../examples/launch_lcbench_simulated.py
    :caption: examples/launch_lcbench_simulated.py
-   :lines: 18-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -221,7 +221,7 @@ Tuning Reinforcement Learning
 
 .. literalinclude:: ../../examples/launch_rl_tuning.py
    :caption: examples/launch_rl_tuning.py
-   :lines: 17-
+   :start-after: # permissions and limitations under the License.
 
 This launcher script is using the following :ref:`train_cartpole.py <rl_cartpole_script>` training
 script:
@@ -229,7 +229,7 @@ script:
 .. literalinclude:: ../../examples/training_scripts/rl_cartpole/train_cartpole.py
    :name: rl_cartpole_script
    :caption: examples/training_scripts/rl_cartpole/train_cartpole.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This training script requires the following dependencies to be
 installed:
@@ -243,7 +243,7 @@ Launch HPO Experiment with SageMaker Backend
 
 .. literalinclude:: ../../examples/launch_height_sagemaker.py
    :caption: examples/launch_height_sagemaker.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -261,7 +261,7 @@ SageMaker Backend and Checkpointing
 
 .. literalinclude:: ../../examples/launch_height_sagemaker_checkpoints.py
    :caption: examples/launch_height_sagemaker_checkpoints.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -273,7 +273,7 @@ This launcher script is using the following
 .. literalinclude:: ../../examples/training_scripts/checkpoint_example/train_height_checkpoint.py
    :name: train_height_checkpoint_script
    :caption: examples/training_scripts/checkpoint_example/train_height_checkpoint.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Note that :class:`~syne_tune.backend.SageMakerBackend` is configured to use
 SageMaker managed warm pools:
@@ -293,7 +293,7 @@ Retrieving the Best Checkpoint
 
 .. literalinclude:: ../../examples/launch_checkpoint_example.py
    :caption: examples/launch_checkpoint_example.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This launcher script is using the following
 :ref:`xgboost_checkpoint.py <xgboost_checkpoint.py>` training script:
@@ -301,7 +301,7 @@ This launcher script is using the following
 .. literalinclude:: ../../examples/training_scripts/xgboost/xgboost_checkpoint.py
    :name: xgboost_checkpoint.py
    :caption: examples/training_scripts/xgboost/xgboost_checkpoint.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 Launch with SageMaker Backend and Custom Docker Image
@@ -309,7 +309,7 @@ Launch with SageMaker Backend and Custom Docker Image
 
 .. literalinclude:: ../../examples/launch_height_sagemaker_custom_image.py
    :caption: examples/launch_height_sagemaker_custom_image.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -326,7 +326,7 @@ Launch Experiments Remotely on SageMaker
 
 .. literalinclude:: ../../examples/launch_height_sagemaker_remotely.py
    :caption: examples/launch_height_sagemaker_remotely.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -347,7 +347,7 @@ Launch HPO Experiment with Home-Made Scheduler
 
 .. literalinclude:: ../../examples/launch_height_standalone_scheduler.py
    :caption: examples/launch_height_standalone_scheduler.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 Makes use of :ref:`train_height.py <train_height_script>`.
 
@@ -361,7 +361,7 @@ Launch HPO Experiment on mlp_fashionmnist Benchmark
 
 .. literalinclude:: ../../examples/launch_fashionmnist.py
    :caption: examples/launch_fashionmnist.py
-   :lines: 16-
+   :start-after: # permissions and limitations under the License.
 
 In this example, we tune one of the built-in benchmark problems, which
 is useful in order to compare different HPO methods. More details on
@@ -374,7 +374,7 @@ Transfer Tuning on NASBench-201
 
 .. literalinclude:: ../../examples/launch_nas201_transfer_learning.py
    :caption: examples/launch_nas201_transfer_learning.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -390,11 +390,11 @@ related tasks can be used to speed up HPO.
 
 
 Transfer Learning Example
-===============================
+=========================
 
 .. literalinclude:: ../../examples/launch_transfer_learning_example.py
    :caption: examples/launch_transfer_learning_example.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -414,7 +414,7 @@ Plot Results of Tuning Experiment
 
 .. literalinclude:: ../../examples/launch_plot_results.py
    :caption: examples/launch_plot_results.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -428,7 +428,7 @@ Pass Configuration as JSON File to Training Script
 
 .. literalinclude:: ../../examples/launch_height_config_json.py
    :caption: examples/launch_height_config_json.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 **Requirements**:
 
@@ -442,7 +442,7 @@ script:
 .. literalinclude:: ../../examples/training_scripts/height_example/train_height_config_json.py
    :name: train_height_config_json_script
    :caption: examples/training_scripts/height_example/train_height_config_json.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 Launch HPO Experiment with Ray Tune Scheduler
@@ -450,7 +450,7 @@ Launch HPO Experiment with Ray Tune Scheduler
 
 .. literalinclude:: ../../examples/launch_height_ray.py
    :caption: examples/launch_height_ray.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Makes use of :ref:`train_height.py <train_height_script>`.
 
@@ -460,7 +460,7 @@ Stand-Alone Bayesian Optimization
 
 .. literalinclude:: ../../examples/launch_standalone_bayesian_optimization.py
    :caption: examples/launch_standalone_bayesian_optimization.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Syne Tune combines a scheduler (HPO algorithm) with a backend to provide a
 complete HPO solution. If you already have a system in place for job
@@ -475,7 +475,7 @@ Ask Tell Interface
 .. literalinclude:: ../../examples/launch_ask_tell_scheduler.py
    :name: launch_ask_tell_scheduler_script
    :caption: examples/launch_ask_tell_scheduler.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This is an example on how to use syne-tune in the ask-tell mode.
 In this setup the tuning loop and experiments are disentangled. The AskTell Scheduler suggests new configurations
@@ -492,7 +492,7 @@ Ask Tell interface for Hyperband
 
 .. literalinclude:: ../../examples/launch_ask_tell_scheduler_hyperband.py
    :caption: examples/launch_ask_tell_scheduler_hyperband.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This is an extension of
 :ref:`launch_ask_tell_scheduler.py <launch_ask_tell_scheduler_script>` to run

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -242,7 +242,7 @@ checkpointing enabled:
 .. literalinclude:: ../../examples/training_scripts/checkpoint_example/checkpoint_example.py
    :name: checkpoint_example_script
    :caption: examples/training_scripts/checkpoint_example/checkpoint_example.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 When using the SageMaker backend, we use the
 `SageMaker checkpoint mechanism <https://docs.aws.amazon.com/sagemaker/latest/dg/model-checkpoints.html>`__
@@ -722,7 +722,8 @@ backend:
 
 .. literalinclude:: ../../examples/launch_height_config_json.py
    :caption: examples/launch_height_config_json.py
-   :lines: 72-75
+   :start-after: if not use_sagemaker_backend:
+   :end-before: else:
 
 The trial backend stores the configuration as JSON file and passes its filename
 as command line argument. In the training script, the configuration is loaded
@@ -730,7 +731,8 @@ as follows:
 
 .. literalinclude:: ../../examples/training_scripts/height_example/train_height_config_json.py
    :caption: examples/training_scripts/height_example/train_height_config_json.py
-   :lines: 74-79
+   :start-at: parser = ArgumentParser()
+   :end-at: config = load_config_json(vars(args))
 
 The complete example is
 `here <examples.html#pass-configuration-as-json-file-to-training-script>`__.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -40,14 +40,14 @@ calling :code:`report(epoch=epoch, loss=loss)`, as shown in this example:
 
 .. literalinclude:: ../../examples/training_scripts/height_example/train_height_simple.py
    :caption: train_height_simple.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Once you have annotated your training script in this way, you can launch a
 tuning experiment as follows:
 
 .. literalinclude:: ../../examples/launch_height_simple.py
    :caption: launch_height_simple.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 This example runs `ASHA <tutorials/multifidelity/mf_asha.html>`__ with

--- a/docs/source/training_scripts.rst
+++ b/docs/source/training_scripts.rst
@@ -3,7 +3,7 @@ ResNet-18 Trained on CIFAR-10
 
 .. literalinclude:: ../../benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
    :caption: benchmarking/training_scripts/resnet_cifar10/resnet_cifar10.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 Transformer Trained on WikiText-2
@@ -11,7 +11,7 @@ Transformer Trained on WikiText-2
 
 .. literalinclude:: ../../benchmarking/training_scripts/transformer_wikitext2/training_script.py
    :caption: benchmarking/training_scripts/transformer_wikitext2/training_script.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 
 Multi-layer Perceptron Trained on Fashion MNIST
@@ -19,4 +19,4 @@ Multi-layer Perceptron Trained on Fashion MNIST
 
 .. literalinclude:: ../../benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
    :caption: benchmarking/training_scripts/mlp_on_fashion_mnist/mlp_on_fashion_mnist.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.

--- a/docs/source/tutorials/basics/basics_asha.rst
+++ b/docs/source/tutorials/basics/basics_asha.rst
@@ -137,7 +137,8 @@ used with random search and Bayesian optimization. We will replace
 
 .. literalinclude:: code/traincode_report_eachepoch.py
    :caption: traincode_report_eachepoch.py (relevant part)
-   :lines: 26-40
+   :start-at: def objective(config):
+   :end-before: if __name__ == "__main__":
 
 Instead of computing and reporting the validation error only after
 ``config['epochs']`` epochs, we do this at the end of each epoch. To

--- a/docs/source/tutorials/basics/basics_promotion.rst
+++ b/docs/source/tutorials/basics/basics_promotion.rst
@@ -29,7 +29,7 @@ has to be modified once more, by replacing ``objective`` with this code:
 
 .. literalinclude:: code/traincode_report_withcheckpointing.py
    :caption: traincode_report_withcheckpointing.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Checkpointing requires you to implement the following:
 

--- a/docs/source/tutorials/basics/basics_randomsearch.rst
+++ b/docs/source/tutorials/basics/basics_randomsearch.rst
@@ -40,7 +40,8 @@ search space:
 
 .. literalinclude:: code/hpo_main.py
    :caption: hpo_main.py: Configuration space
-   :lines: 25-37
+   :start-at: from syne_tune.config_space import randint, uniform, loguniform
+   :end-before: if __name__ == "__main__":
 
 Here, ``n_units_1`` is sampled uniformly from ``4,...,1024``, while
 ``learning_rate`` is sampled log-uniformly from ``[1e-6, 1]`` (i.e., it is
@@ -56,7 +57,7 @@ run HPO experiments.
 
 .. literalinclude:: code/hpo_main.py
    :caption: hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Random search is obtained by calling this script with ``--method RS``.
 Let us walk through the script, keeping this special case in mind:

--- a/docs/source/tutorials/basics/basics_setup.rst
+++ b/docs/source/tutorials/basics/basics_setup.rst
@@ -39,7 +39,7 @@ instead (e.g., cross-validation). Here is an example:
 
 .. literalinclude:: code/traincode_report_end.py
    :caption: traincode_report_end.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 This script imports boiler plate code from
 `mlp_on_fshionmnist.py <../../training_scripts.html#multi-layer-perceptron-trained-on-fashion-mnist>`__.
@@ -95,7 +95,8 @@ tutorial:
 
 .. literalinclude:: code/hpo_main.py
    :caption: hpo_main.py: Configuration space
-   :lines: 25-37
+   :start-at: from syne_tune.config_space import randint, uniform, loguniform
+   :end-before: if __name__ == "__main__":
 
 The configuration space is a dictionary with key names corresponding to command
 line input parameters of our training script. For each parameter you would like

--- a/docs/source/tutorials/developer/wrap_code.rst
+++ b/docs/source/tutorials/developer/wrap_code.rst
@@ -46,7 +46,8 @@ as we demonstrate here. Here is
 
 .. literalinclude:: ../../../../syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
    :caption: syne_tune/optimizer/schedulers/searchers/botorch/botorch_searcher.py
-   :lines: 119-132
+   :start-at: def _get_config(self, trial_id: str, **kwargs)
+   :end-before: def register_pending(
 
 * First, :code:`self._next_initial_config()` is called, which returns a
   configuration from ``points_to_evaluate`` if there is still one not yet

--- a/docs/source/tutorials/multifidelity/mf_setup.rst
+++ b/docs/source/tutorials/multifidelity/mf_setup.rst
@@ -43,7 +43,7 @@ script.
 
 .. literalinclude:: code/hpo_main.py
    :caption: hpo_main.py
-   :lines: 13-
+   :start-after: # permissions and limitations under the License.
 
 Let us have a walk through this script, assuming it is called with the default
 ``--method ASHA-STOP``:

--- a/docs/source/tutorials/transfer_learning/transfer_learning.rst
+++ b/docs/source/tutorials/transfer_learning/transfer_learning.rst
@@ -63,7 +63,8 @@ We do this in the `extract_transferable_evaluations` function.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to prepare evaluations from previous tasks for transfer learning.
-   :lines: 76-96
+   :start-at: def filter_completed(
+   :end-before: def run_scheduler_on_task(
 
 We start by collecting evaluations by running `BayesianOptimization` on
 the five preliminary
@@ -74,7 +75,8 @@ evaluations as `TransferLearningTaskEvaluations`.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to initialise schedulers, use it to optimise a task and collect evaluations on preliminary tasks.
-   :lines: 99-186
+   :start-at: def run_scheduler_on_task(
+   :end-before: # Collect evaluations on transfer task
 
 Then we run different schedulers to compare on our transfer task with
 `max_steps=6`. For `ZeroShotTransfer` we set `use_surrogates=True`, meaning
@@ -83,7 +85,8 @@ not have evaluations of the same configurations on all previous tasks.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to run schedulers on transfer task.
-   :lines: 188-204
+   :start-at: # Collect evaluations on transfer task
+   :end-before: # Optionally generate plots.
 
 We plot the results on the transfer task. We see that the early performance of
 the transfer schedulers is much better than standard BO. We only plot the first
@@ -93,11 +96,13 @@ in the plot below.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Plotting helper code.
-   :lines: 43-73
+   :start-at: def add_labels(
+   :end-before: def filter_completed(
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to plot results on transfer task.
-   :lines: 206-230
+   :start-at: # Optionally generate plots
+   :end-at: plt.savefig("Transfer_task.png"
 
 .. image:: Transfer_task.png
    :width: 768 px
@@ -107,7 +112,8 @@ preliminary tasks.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to plot the configurations tried for the preliminary tasks.
-   :lines: 232-246
+   :start-at: """ Plot the configs tried for the preliminary tasks """
+   :end-at: plt.savefig("Configs_explored_preliminary.png"
 
 .. image:: Configs_explored_preliminary.png
    :width: 768 px
@@ -119,7 +125,7 @@ checking the middle of the search space.
 
 .. literalinclude:: ../../../../examples/launch_transfer_learning_example.py
    :caption: Code to plot the configurations tried for the transfer task.
-   :lines: 248-
+   :start-at: """ Plot the configs tried for the transfer task """
 
 .. image:: Configs_explored_transfer.png
    :width: 768 px

--- a/examples/launch_tensorboard_example.py
+++ b/examples/launch_tensorboard_example.py
@@ -10,7 +10,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
 """
 Example showing how to visualize the HPO process of Syne Tune with Tensorboard.
 Results will be stored in ~/syne-tune/{tuner_name}/tensoboard_output. To start


### PR DESCRIPTION
Robustifies showing code snippets in the docs. Since ranges are selected not based on line numbers, but on how they start and end, this is more robust to code changes.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
