### PR TITLE
Make sure that checkpoints in PBT are removed once they are no longer…

### DIFF
--- a/syne_tune/callbacks/remove_checkpoints_callback.py
+++ b/syne_tune/callbacks/remove_checkpoints_callback.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from syne_tune.tuner_callback import TunerCallback
+
+
+class RemoveCheckpointsCallback(TunerCallback):
+    """
+    This implements early removal of checkpoints of paused trials. In order
+    for this to work, the scheduler needs to implement
+    :meth:`~syne_tune.optimizer.scheduler.TrialScheduler.trials_checkpoints_can_be_removed`.
+    """
+
+    def __init__(self):
+        self._tuner = None
+
+    def on_tuning_start(self, tuner):
+        self._tuner = tuner
+
+    def on_loop_end(self):
+        for trial_id in self._tuner.scheduler.trials_checkpoints_can_be_removed():
+            self._tuner.trial_backend.delete_checkpoint(trial_id)

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -276,3 +276,23 @@ class TrialScheduler:
             return self.mode
         else:
             raise NotImplementedError
+
+    def trials_checkpoints_can_be_removed(self) -> List[int]:
+        """
+        This (optional) method can be implemented by schedulers which pause and
+        resume trials (in that :meth:`on_trial_result` can return
+        :const:`SchedulerDecision.PAUSE`). Model checkpoints are retained for
+        paused trials, because they may get resumed later on. This can lead to
+        the disk filling up, so removing checkpoints which are not longer needed,
+        can be important.
+
+        This method returns IDs of paused trials for which checkpoints can be
+        removed. These trials either cannot be resumed anymore, or it is very
+        unlikely they will be resumed. Any trial ID needs to be returned only once,
+        not over and over. If a trial gets stopped (by returning
+        :const:`SchedulerDecision.STOP` in :meth:`on_trial_result`), its checkpoint
+        is removed anyway, so its ID does not have to be returned here.
+
+        :return: IDs of paused trials for which checkpoints can be removed
+        """
+        return []  # Default is not to participate in early checkpoint removal

--- a/syne_tune/optimizer/schedulers/synchronous/dehb_bracket.py
+++ b/syne_tune/optimizer/schedulers/synchronous/dehb_bracket.py
@@ -23,10 +23,10 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
     Represents a bracket in Differential Evolution Hyperband (DEHB).
 
     There are a number of differences to brackets in standard synchronous
-    Hyperband (:class:`SynchronousHyperbandBracket`):
+    Hyperband (:class:`~syne_tune.optimizer.schedulers.synchronous.hyperband_bracket.SynchronousHyperbandBracket`):
 
-    * ``on_result``: ``result.trial_id`` overwrites ``trial_id`` in rung even if
-      latter is not None.
+    * :meth:`on_result`: ``result.trial_id`` overwrites ``trial_id`` in rung
+      even if latter is not ``None``.
     * Promotions are not triggered automatically when a rung is complete
     * Some additional methods
     """
@@ -68,7 +68,7 @@ class DifferentialEvolutionHyperbandBracket(SynchronousBracket):
         previous_rung, _ = self._rungs[self.current_rung - 1]
         return get_top_list(
             rung=previous_rung, new_len=self.size_of_current_rung(), mode=self._mode
-        )
+        )[0]
 
-    def _promote_trials_at_rung_complete(self):
-        pass
+    def _promote_trials_at_rung_complete(self) -> List[int]:
+        return []

--- a/tst/schedulers/test_hyperband_sychronous.py
+++ b/tst/schedulers/test_hyperband_sychronous.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import numpy as np
 from collections import Counter
 import pytest
@@ -59,7 +59,9 @@ def _send_results(
     bracket: SynchronousHyperbandBracket,
     slots: List[SlotInRung],
     all_results: List[Tuple[int, float]],
+    trials_not_promoted: Optional[List[int]],
 ):
+    trials_n_p = None
     for slot_in_rung in slots:
         trial_id, metric_val = all_results[slot_in_rung.slot_index]
         result = SlotInRung(
@@ -69,7 +71,12 @@ def _send_results(
             trial_id=trial_id,
             metric_val=metric_val,
         )
-        bracket.on_result(result)
+        trials_n_p = bracket.on_result(result)
+    if trials_not_promoted is None:
+        assert trials_n_p is None, trials_n_p
+    else:
+        assert trials_n_p is not None
+        assert set(trials_not_promoted) == set(trials_n_p)
 
 
 def test_hyperband_bracket():
@@ -89,6 +96,7 @@ def test_hyperband_bracket():
         [(2, 3.1), (6, 3.0), (0, 2.9), (3, 3.0)],
         [(0, 1.0)],
     ]
+    trials_not_promoted = [[1, 4, 5, 7, 8], [2, 3, 6], None]
     bracket = SynchronousHyperbandBracket(rungs, mode="min")
 
     # Rung index 0
@@ -101,7 +109,13 @@ def test_hyperband_bracket():
         bracket, rung_index, level, slot_index, trial_ids=[None] * num_jobs
     )
     assert bracket.num_pending_slots() == num_jobs
-    _send_results(bracket, slots, results[rung_index])
+    all_results = results[rung_index]
+    _send_results(
+        bracket=bracket,
+        slots=slots,
+        all_results=all_results,
+        trials_not_promoted=None,
+    )
     assert bracket.num_pending_slots() == 0
     # Ask for some, but do not return all for now
     num_jobs = 3
@@ -113,12 +127,25 @@ def test_hyperband_bracket():
         assert bracket.num_pending_slots() == num_jobs + i
         slots_remaining.append(slots[0])
         slots = slots[1:]
-        _send_results(bracket, slots, results[rung_index])
+        _send_results(
+            bracket=bracket,
+            slots=slots,
+            all_results=all_results,
+            trials_not_promoted=None,
+        )
         assert bracket.num_pending_slots() == i + 1
     # At this point, there are no free slots, but some are pending
-    for slot in slots_remaining:
+    num_remaining = len(slots_remaining)
+    for i, slot in enumerate(slots_remaining):
         assert bracket.next_free_slot() is None
-        _send_results(bracket, [slot], results[rung_index])
+        _send_results(
+            bracket=bracket,
+            slots=[slot],
+            all_results=all_results,
+            trials_not_promoted=trials_not_promoted[rung_index]
+            if i == num_remaining - 1
+            else None,
+        )
     # The first rung must be fully occupied now
     assert bracket.num_pending_slots() == 0
 
@@ -132,7 +159,12 @@ def test_hyperband_bracket():
         )
         assert bracket.num_pending_slots() == num_jobs
         assert bracket.next_free_slot() is None
-        _send_results(bracket, slots, all_results)
+        _send_results(
+            bracket=bracket,
+            slots=slots,
+            all_results=all_results,
+            trials_not_promoted=trials_not_promoted[rung_index],
+        )
         assert bracket.num_pending_slots() == 0
     # Now, the bracket must be complete
     assert bracket.is_bracket_complete()

--- a/tst/test_pbt.py
+++ b/tst/test_pbt.py
@@ -90,7 +90,7 @@ def test_ptb():
 
         if i > 1:
             # all trials after the first one should be stopped and resampled
-            assert s == "PAUSE"
+            assert s == "STOP"
 
     # add better config
     trial_id = update_state(suggest, state)
@@ -105,7 +105,7 @@ def test_ptb():
     t = state[0]["trial"]
     results = {metric: 100, resource_attr: state[trial_id]["step"] + 1}
     s = pbt.on_trial_result(t, results)
-    assert s == "PAUSE"
+    assert s == "STOP"
 
     # we should now continue with config 10
     suggest = pbt.suggest(total_steps)


### PR DESCRIPTION
… needed

This should solve the issue about checkpoints not being removed. I just return STOP instead of PAUSE. See the code comment why I think this is fine.
I also implemented early checkpoint removal for the synchronous schedulers, which requires the scheduler to flag paused trials for which the checkpoint is no longer needed.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
