### PR TITLE
Upgrade to Sphinx 6

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxcontrib.bibtex",
     "myst_parser",
+    "sphinxcontrib.jquery",  # can be removed as soon as the theme no longer depends on jQuery
 ]
 
 myst_heading_anchors = 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ sphinx-autodoc-typehints
 myst-parser
 sphinx_copybutton
 sphinxcontrib-bibtex
+sphinxcontrib.jquery


### PR DESCRIPTION
Theme still requires jQuery (https://github.com/readthedocs/sphinx_rtd_theme/issues/1253) but Sphinx already dropped it. Therefore, it is now added via extension.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
