### PR TITLE
Keep rung levels sorted in HyperbandScheduler

### DIFF
--- a/benchmarking/nursery/benchmark_dehb/requirements.txt
+++ b/benchmarking/nursery/benchmark_dehb/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,kde,blackbox-repository,yahpo,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/benchmark_dyhpo/requirements.txt
+++ b/benchmarking/nursery/benchmark_dyhpo/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,blackbox-repository,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/benchmark_hypertune/requirements.txt
+++ b/benchmarking/nursery/benchmark_hypertune/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,kde,blackbox-repository,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/benchmark_neuralband/requirements.txt
+++ b/benchmarking/nursery/benchmark_neuralband/requirements.txt
@@ -1,3 +1,4 @@
 syne-tune[gpsearchers,kde,blackbox-repository,aws]
 tqdm
 botorch
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/benchmark_warping/requirements.txt
+++ b/benchmarking/nursery/benchmark_warping/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,blackbox-repository,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/benchmark_yahpo/requirements.txt
+++ b/benchmarking/nursery/benchmark_yahpo/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,blackbox-repository,yahpo,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/fine_tuning_transformer_glue/requirements.txt
+++ b/benchmarking/nursery/fine_tuning_transformer_glue/requirements.txt
@@ -1,3 +1,4 @@
 syne-tune[gpsearchers]
 datasets==1.8.0
 transformers
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/launch_local/requirements-synetune.txt
+++ b/benchmarking/nursery/launch_local/requirements-synetune.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/benchmarking/nursery/launch_sagemaker/requirements.txt
+++ b/benchmarking/nursery/launch_sagemaker/requirements.txt
@@ -1,2 +1,3 @@
 syne-tune[gpsearchers,aws]
 tqdm
+sortedcontainers  # Remove in version > 0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dill>=0.3.6
 pandas
 # only needed for python version lower than 3.8
 typing_extensions
+sortedcontainers

--- a/syne_tune/optimizer/schedulers/hyperband_pasha.py
+++ b/syne_tune/optimizer/schedulers/hyperband_pasha.py
@@ -81,19 +81,21 @@ class PASHARungSystem(PromotionRungSystem):
             self._rungs[-self.current_rung_idx],
             self._rungs[-self.current_rung_idx + 1],
         ]:
-            if rung.data != {}:
-                trial_ids = rung.data.keys()
-                values = []
-                for trial_id in trial_ids:
-                    values.append(rung.data[trial_id][0])
-                # order specifies where the value should be placed in the sorted list
-                values_order = np.array(values).argsort()
-                # calling argsort on the order will give us the ranking
-                values_ranking = values_order.argsort()
+            if len(rung) > 0:
+                # Note that entries in ``rung.data`` are already sorted
+                trial_ids, values = zip(
+                    *[(x.trial_id, x.metric_val) for x in rung.data]
+                )
+                # Note: To retain the exact logic of older code (which used
+                # ``numpy.argsort``, we assume the ranks for increasing metric
+                # values, which is the opposite ordering to ``rung.data`` if
+                # ``self._mode == "max"``
+                if self._mode == "min":
+                    values_ranking = list(range(len(trial_ids)))
+                else:
+                    values_ranking = list(range(len(trial_ids) - 1, -1, -1))
                 ranking = list(zip(trial_ids, values_ranking, values))
-
                 rankings.append(ranking)
-
         return rankings
 
     def _get_sorted_top_rungs(self, rankings):
@@ -111,11 +113,7 @@ class PASHARungSystem(PromotionRungSystem):
             lambda e: e[0] in top_rung_keys, rankings[1]
         )
         # if we try to maximize the objective, we need to reverse the ranking
-        if self._mode == "max":
-            reverse = True
-        else:
-            reverse = False
-
+        reverse = self._mode == "max"
         sorted_top_rung = sorted(rankings[0], key=lambda e: e[1], reverse=reverse)
         sorted_previous_rung = sorted(
             corresponding_previous_rung_trials, key=lambda e: e[1], reverse=reverse
@@ -227,18 +225,17 @@ class PASHARungSystem(PromotionRungSystem):
                 raise ValueError("Epsilon became nan")
 
     def _update_per_epoch_results(self, trial_id, result):
+        resource = result[self._resource_attr]
+        metric_val = result[self._metric]
         if trial_id not in self.per_epoch_results:
-            self.per_epoch_results[trial_id] = {}
-        self.per_epoch_results[trial_id][result[self._resource_attr]] = result[
-            self._metric
-        ]
-
-        if result[self._resource_attr] not in self.epoch_to_trials:
-            self.epoch_to_trials[result[self._resource_attr]] = set()
-        self.epoch_to_trials[result[self._resource_attr]].add(trial_id)
-
-        if result[self._resource_attr] > self.current_max_epoch:
-            self.current_max_epoch = result[self._resource_attr]
+            self.per_epoch_results[trial_id] = {resource: metric_val}
+        else:
+            self.per_epoch_results[trial_id][resource] = metric_val
+        if resource not in self.epoch_to_trials:
+            self.epoch_to_trials[resource] = {trial_id}
+        else:
+            self.epoch_to_trials[resource].add(trial_id)
+        self.current_max_epoch = max(self.current_max_epoch, resource)
 
     def _decide_resource_increase(self, rankings) -> bool:
         """

--- a/syne_tune/optimizer/schedulers/hyperband_rush.py
+++ b/syne_tune/optimizer/schedulers/hyperband_rush.py
@@ -13,8 +13,14 @@
 import logging
 from typing import Optional, List, Dict, Any
 
-from syne_tune.optimizer.schedulers.hyperband_promotion import PromotionRungSystem
-from syne_tune.optimizer.schedulers.hyperband_stopping import StoppingRungSystem
+from syne_tune.optimizer.schedulers.hyperband_promotion import (
+    PromotionRungEntry,
+    PromotionRungSystem,
+)
+from syne_tune.optimizer.schedulers.hyperband_stopping import (
+    Rung,
+    StoppingRungSystem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +54,16 @@ class RUSHDecider:
         )  # thresholds at different resource levels that must be met
 
     def task_continues(
-        self, task_continues: bool, trial_id: str, metric_value: float, resource: int
+        self, task_continues: bool, trial_id: str, metric_val: float, resource: int
     ) -> bool:
         if not task_continues:
             return False
         if self._is_in_points_to_evaluate(trial_id):
             self._thresholds[resource] = self._return_better(
-                self._thresholds.get(resource), metric_value
+                self._thresholds.get(resource), metric_val
             )
             return True
-        return self._meets_threshold(metric_value, resource)
+        return self._meets_threshold(metric_val, resource)
 
     def _is_in_points_to_evaluate(self, trial_id: str) -> bool:
         return int(trial_id) < self._num_threshold_candidates
@@ -75,10 +81,10 @@ class RUSHDecider:
             )
         return better_val
 
-    def _meets_threshold(self, metric_value: float, resource: int) -> bool:
+    def _meets_threshold(self, metric_val: float, resource: int) -> bool:
         return (
-            self._return_better(self._thresholds.get(resource), metric_value)
-            == metric_value
+            self._return_better(self._thresholds.get(resource), metric_val)
+            == metric_val
         )
 
 
@@ -109,17 +115,13 @@ class RUSHStoppingRungSystem(StoppingRungSystem):
 
     def _task_continues(
         self,
-        metric_value: float,
-        recorded: Dict[str, Any],
-        prom_quant: float,
         trial_id: str,
-        resource: int,
+        metric_val: float,
+        rung: Rung,
     ) -> bool:
-        task_continues = super()._task_continues(
-            metric_value, recorded, prom_quant, trial_id, resource
-        )
+        task_continues = super()._task_continues(trial_id, metric_val, rung)
         return self._decider.task_continues(
-            task_continues, trial_id, metric_value, resource
+            task_continues, trial_id, metric_val, rung.level
         )
 
 
@@ -148,12 +150,8 @@ class RUSHPromotionRungSystem(PromotionRungSystem):
         )
         self._decider = RUSHDecider(num_threshold_candidates, mode)
 
-    def _is_promotable_trial(
-        self, trial_id: str, metric_value: float, is_paused: bool, resource: int
-    ) -> bool:
-        task_continues = super()._is_promotable_trial(
-            trial_id, metric_value, is_paused, resource
-        )
+    def _is_promotable_trial(self, entry: PromotionRungEntry, resource: int) -> bool:
+        task_continues = super()._is_promotable_trial(entry, resource)
         return self._decider.task_continues(
-            task_continues, trial_id, metric_value, resource
+            task_continues, entry.trial_id, entry.metric_val, resource
         )

--- a/syne_tune/optimizer/schedulers/hyperband_stopping.py
+++ b/syne_tune/optimizer/schedulers/hyperband_stopping.py
@@ -11,33 +11,101 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 import logging
-from dataclasses import dataclass
-from typing import List, Tuple, Dict, Any
-
-import numpy as np
+from typing import List, Tuple, Dict, Any, Optional
+from sortedcontainers import SortedList
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
 class RungEntry:
     """
-    :param level: Rung level :math:`r_j`
-    :param prom_quant: romotion quantile :math:`q_j`
-    :param data: Data of all previous jobs reaching the level
+    Represents entry in a rung. This class is extended by rung level systems
+    which need to maintain more information per entry.
+
+    :param trial_id: ID of trial
+    :param metric_val: Metric value
     """
 
-    level: int
-    prom_quant: float
-    data: Dict[str, Any]
+    def __init__(self, trial_id: str, metric_val: float):
+        self.trial_id = trial_id
+        self.metric_val = metric_val
 
 
-def quantile_cutoff(values, prom_quant, mode):
-    if len(values) < 2:
-        # Cannot determine cutoff from one value
-        return None
-    q = prom_quant if mode == "min" else (1 - prom_quant)
-    return np.quantile(values, q)
+class Rung:
+    """
+    :param level: Rung level :math:`r_j`
+    :param prom_quant: promotion quantile :math:`q_j`
+    :param data: Data of all previous jobs reaching the level. This list is
+        kept sorted w.r.t. ``metric_val``, so that best values come first
+    """
+
+    def __init__(
+        self,
+        level: int,
+        prom_quant: float,
+        mode: str,
+        data: Optional[List[RungEntry]] = None,
+    ):
+        self.level = level
+        assert 0 < prom_quant < 1
+        self.prom_quant = prom_quant
+        assert mode in ["min", "max"]
+        self._is_min = mode == "min"
+        # ``SortedList`` supports insertion in :math:`O(log n)`
+        if data is None:
+            data = []
+        sign = 1 if self._is_min else -1
+        self.data = SortedList(iterable=data, key=lambda x: sign * x.metric_val)
+        # We need to test whether ``trial_id`` is in the rung, but not at which
+        # position it is
+        self._trial_ids = {entry.trial_id for entry in data}
+
+    def add(self, entry: RungEntry):
+        self.data.add(entry)
+        self._trial_ids.add(entry.trial_id)
+
+    def pop(self, pos: int) -> RungEntry:
+        entry = self.data.pop(pos)
+        self._trial_ids.remove(entry.trial_id)
+        return entry
+
+    def __contains__(self, trial_id: str):
+        return trial_id in self._trial_ids
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def quantile(self) -> Optional[float]:
+        """
+        Returns same value as ``numpy.quantile(metric_vals, q)``, where
+        ``metric_vals`` are the metric values in ``data``, and
+        ``q = prom_quant`` if ``mode == "min"``, ``q = ``1 - prom_quant``
+        otherwise. If ``len(data) < 2``, we return ``None``.
+
+        See `here <https://numpy.org/doc/stable/reference/generated/numpy.quantile.html>`__.
+        The default for ``numpy.quantile`` is ``method="linear"``.
+
+        :return: See above
+        """
+        len_data = len(self.data)
+        if len_data < 2:
+            return None
+        # In ``numpy.quantile``, values are sorted in increasing order. This is
+        # the case for ``self.data`` for "min" mode, otherwise ``self.data`` is
+        # sorted in decreasing order, so we need to use it in reverse
+        q = self.prom_quant if self._is_min else 1 - self.prom_quant
+        virt_index = (len_data - 1) * q + 1
+        index = int(virt_index)  # i in ``numpy.quantile`` docs
+        assert 1 <= index < len_data  # Sanity check
+        frac_part = virt_index - index  # g in ``numpy.quantile`` docs
+        if self._is_min:
+            left_pos = index - 1
+            g = frac_part
+        else:
+            left_pos = len_data - index - 1
+            g = 1 - frac_part
+        values = [x.metric_val for x in self.data.islice(left_pos, left_pos + 2)]
+        return g * values[1] + (1 - g) * values[0]
 
 
 class RungSystem:
@@ -75,11 +143,8 @@ class RungSystem:
         self._mode = mode
         self._resource_attr = resource_attr
         self._max_t = max_t
-        # The data entry in ``_rungs`` is a dict with key trial_id. The
-        # value type depends on the subclass, but it contains the
-        # metric value
         self._rungs = [
-            RungEntry(level=x, prom_quant=y, data=dict())
+            Rung(level=x, prom_quant=y, mode=mode)
             for x, y in reversed(list(zip(rung_levels, promote_quantiles)))
         ]
 
@@ -158,7 +223,7 @@ class RungSystem:
             else self._max_t
         )
 
-    def _milestone_rungs(self, skip_rungs: int) -> List[RungEntry]:
+    def _milestone_rungs(self, skip_rungs: int) -> List[Rung]:
         if skip_rungs > 0:
             return self._rungs[:(-skip_rungs)]
         else:
@@ -174,7 +239,7 @@ class RungSystem:
         milestone_rungs = self._milestone_rungs(skip_rungs)
         return [x.level for x in milestone_rungs]
 
-    def snapshot_rungs(self, skip_rungs: int) -> List[Tuple[int, dict]]:
+    def snapshot_rungs(self, skip_rungs: int) -> List[Tuple[int, List[RungEntry]]]:
         """
         A snapshot is a list of rung levels with entries ``(level, data)``,
         ordered from top to bottom (largest rung first).
@@ -184,7 +249,7 @@ class RungSystem:
         :return: Snapshot (see above)
         """
         milestone_rungs = self._milestone_rungs(skip_rungs)
-        return [(x.level, x.data) for x in milestone_rungs]
+        return [(x.level, list(x.data)) for x in milestone_rungs]
 
     @staticmethod
     def does_pause_resume() -> bool:
@@ -210,32 +275,23 @@ class StoppingRungSystem(RungSystem):
     in case ``mode == "min"``. See also :meth:`_task_continues`.
     """
 
-    def _cutoff(self, recorded, prom_quant):
-        values = list(recorded.values())
-        return quantile_cutoff(values, prom_quant, self._mode)
-
     def _task_continues(
         self,
-        metric_value: float,
-        recorded: Dict[str, Any],
-        prom_quant: float,
         trial_id: str,
-        resource: int,
+        metric_val: float,
+        rung: Rung,
     ) -> bool:
         r"""
-        :param metric_value: :math:`f(\mathbf{x}, r)` for trial
-            :math:`\mathbf{x}` at rung :math:`r`
-        :param recorded: Data for rung :math:`r` (including
-            :math:`r(\mathbf{x}, r)`)
-        :param prom_quant: Quantile threshold (for mode 'min')
         :param trial_id: ID of trial
-        :param resource: Rung level
+        :param metric_val: :math:`f(\mathbf{x}, r)` for trial
+            :math:`\mathbf{x}` at rung :math:`r`
+        :param rung: Rung where new entry has just been inserted
         :return: Continue trial? Stop otherwise
         """
-        cutoff = self._cutoff(recorded, prom_quant)
+        cutoff = rung.quantile()
         if cutoff is None:
             return True
-        return metric_value <= cutoff if self._mode == "min" else metric_value >= cutoff
+        return metric_val <= cutoff if self._mode == "min" else metric_val >= cutoff
 
     def on_task_schedule(self, new_trial_id: str) -> Dict[str, Any]:
         return dict()
@@ -244,7 +300,7 @@ class StoppingRungSystem(RungSystem):
         self, trial_id: str, result: Dict[str, Any], skip_rungs: int
     ) -> Dict[str, Any]:
         resource = result[self._resource_attr]
-        metric_value = result[self._metric]
+        metric_val = result[self._metric]
         if resource == self._max_t:
             task_continues = False
             milestone_reached = True
@@ -253,12 +309,9 @@ class StoppingRungSystem(RungSystem):
             task_continues = True
             milestone_reached = False
             next_milestone = self._max_t
-            milestone_rungs = self._milestone_rungs(skip_rungs)
-            for rung in milestone_rungs:
+            for rung in self._milestone_rungs(skip_rungs):
                 milestone = rung.level
-                prom_quant = rung.prom_quant
-                recorded = rung.data
-                if not (resource < milestone or trial_id in recorded):
+                if not (resource < milestone or trial_id in rung):
                     # Note: It is important for model-based searchers that
                     # milestones are reached exactly, not jumped over. In
                     # particular, if a future milestone is reported via
@@ -273,13 +326,11 @@ class StoppingRungSystem(RungSystem):
                     else:
                         milestone_reached = True
                         # Enter new metric value before checking condition
-                        recorded[trial_id] = metric_value
+                        rung.add(RungEntry(trial_id=trial_id, metric_val=metric_val))
                         task_continues = self._task_continues(
-                            metric_value=metric_value,
-                            recorded=recorded,
-                            prom_quant=prom_quant,
                             trial_id=trial_id,
-                            resource=resource,
+                            metric_val=metric_val,
+                            rung=rung,
                         )
                     break
                 next_milestone = milestone

--- a/tst/schedulers/test_hyperband.py
+++ b/tst/schedulers/test_hyperband.py
@@ -13,13 +13,18 @@
 from datetime import datetime
 from typing import Optional, Dict, Tuple, Any
 import pytest
+import numpy as np
 
 from syne_tune.optimizer.schedulers.hyperband import HyperbandScheduler
 from syne_tune.config_space import randint, uniform
 from syne_tune.backend.trial_status import Trial
 from syne_tune.optimizer.scheduler import SchedulerDecision
 from syne_tune.optimizer.schedulers.searchers import RandomSearcher
-from syne_tune.optimizer.schedulers.hyperband_stopping import StoppingRungSystem
+from syne_tune.optimizer.schedulers.hyperband_stopping import (
+    RungEntry,
+    Rung,
+    StoppingRungSystem,
+)
 from syne_tune.optimizer.schedulers.hyperband_promotion import PromotionRungSystem
 from syne_tune.optimizer.schedulers.hyperband_pasha import PASHARungSystem
 from syne_tune.optimizer.schedulers.hyperband_rush import (
@@ -226,3 +231,23 @@ def test_hyperband_scheduler_type(scheduler_type, terminator_cls, does_pause_res
     )
     assert isinstance(myscheduler.terminator._rung_systems[0], terminator_cls)
     assert myscheduler.does_pause_resume() == does_pause_resume
+
+
+def test_quantile_hyperband_stopping():
+    num_runs = 100
+    random_seed = 31415938
+    random_state = np.random.RandomState(random_seed)
+    for num_run in range(num_runs):
+        len_data = 2 if num_run == 0 else random_state.randint(low=2, high=200)
+        prom_quant = random_state.uniform(low=0.01, high=0.5)
+        mode = "min" if random_state.uniform() <= 0.5 else "max"
+        metric_vals = random_state.normal(loc=0, scale=1, size=len_data)
+        data = [
+            RungEntry(trial_id, metric_val)
+            for trial_id, metric_val in zip(range(len_data), metric_vals)
+        ]
+        rung = Rung(level=1, prom_quant=prom_quant, mode=mode, data=data)
+        quantile = rung.quantile()
+        q = prom_quant if mode == "min" else 1 - prom_quant
+        quantile_test = np.quantile(metric_vals, q=q, method="linear")
+        np.testing.assert_almost_equal(quantile, quantile_test)

--- a/tst/schedulers/transfer_learning/test_rush.py
+++ b/tst/schedulers/transfer_learning/test_rush.py
@@ -213,7 +213,7 @@ def test_given_hyperband_indicates_to_discontinue_return_discontinue(
     assert not decider.task_continues(
         task_continues=False,
         trial_id=num_threshold_candidates - 1,
-        metric_value=-1,
+        metric_val=-1,
         resource=1,
     )
 
@@ -228,7 +228,7 @@ def test_given_metric_better_than_threshold_update_threshold_if_threshold_config
             decider.task_continues(
                 task_continues=True,
                 trial_id=trial_id,
-                metric_value=loss,
+                metric_val=loss,
                 resource=rung_level,
             )
             if trial_id == num_threshold_candidates:
@@ -247,7 +247,7 @@ def test_given_metric_worse_than_threshold_return_discontinue_if_standard_trial(
         assert not decider.task_continues(
             task_continues=True,
             trial_id=num_threshold_candidates,
-            metric_value=0.1,
+            metric_val=0.1,
             resource=rung_level,
         )
 
@@ -260,7 +260,7 @@ def test_given_metric_worse_than_threshold_return_hyperband_decision_if_init_tri
         decider.task_continues(
             task_continues=hyperband_decision,
             trial_id=num_threshold_candidates - 1,
-            metric_value=1,
+            metric_val=1,
             resource=1,
         )
         is hyperband_decision


### PR DESCRIPTION
The current code recomputes the quantile for every inserting into a rung. This means that n insertions cost `O(n^2 log n)`, which can be a problem for large n. The new code keeps rung enntries sorted, using a data structure where insertions are `O(log n)`, so n insertions cost `O(n log n)`.

The PR also cleans things up. This is needed for another idea for clever checkpoint removal.

Closes #377

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
