### PR TITLE
fix: random seed initialisation limited to int32

### DIFF
--- a/syne_tune/optimizer/schedulers/random_seeds.py
+++ b/syne_tune/optimizer/schedulers/random_seeds.py
@@ -18,4 +18,4 @@ class RandomSeedGenerator:
         self._random_state = np.random.RandomState(master_seed)
 
     def __call__(self) -> int:
-        return self._random_state.randint(0, 2**32)
+        return self._random_state.randint(0, 2**31 - 1)


### PR DESCRIPTION
int32 is limited to 2**31-1. On windows this was resulting in a program crash:

```
File "C:\[...]\lib\site-packages\syne_tune\optimizer\baselines.py", line 677, in __init__
    searcher_kwargs = _create_searcher_kwargs(
  File "C:\[...]\lib\site-packages\syne_tune\optimizer\baselines.py", line 566, in _create_searcher_kwargs
    searcher_kwargs["random_seed"] = _random_seed_from_generator(random_seed)
  File "C:\[...]\lib\site-packages\syne_tune\optimizer\baselines.py", line 52, in _random_seed_from_generator
    return RandomSeedGenerator(random_seed)()
  File "C:\[...]\lib\site-packages\syne_tune\optimizer\schedulers\random_seeds.py", line 21, in __call__
    return self._random_state.randint(0, 2**32)
  File "mtrand.pyx", line 746, in numpy.random.mtrand.RandomState.randint
  File "_bounded_integers.pyx", line 1336, in numpy.random._bounded_integers._rand_int32
ValueError: high is out of bounds for int32
```


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
