### PR TITLE
chore: Moved scheduler metadata generation

### DIFF
--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -15,7 +15,12 @@ from typing import Optional, List, Dict, Any, Union
 import logging
 
 from syne_tune.backend.trial_status import Trial
-from syne_tune.config_space import non_constant_hyperparameter_keys, cast_config_values
+from syne_tune.config_space import (
+    non_constant_hyperparameter_keys,
+    cast_config_values,
+    config_space_to_json_dict,
+)
+from syne_tune.util import dump_json_with_numpy
 
 logger = logging.getLogger(__name__)
 
@@ -296,3 +301,17 @@ class TrialScheduler:
         :return: IDs of paused trials for which checkpoints can be removed
         """
         return []  # Default is not to participate in early checkpoint removal
+
+    def metadata(self) -> Dict[str, Any]:
+        """
+        :return: Metadata for the scheduler
+        """
+        config_space_json = dump_json_with_numpy(
+            config_space_to_json_dict(self.config_space)
+        )
+        return {
+            "metric_names": self.metric_names(),
+            "metric_mode": self.metric_mode(),
+            "scheduler_name": str(self.__class__.__name__),
+            "config_space": config_space_json,
+        }

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -25,9 +25,16 @@ from syne_tune.backend.trial_backend import (
 )
 from syne_tune.backend.trial_status import Status, Trial, TrialResult
 from syne_tune.callbacks.remove_checkpoints_callback import RemoveCheckpointsCallback
-from syne_tune.constants import ST_TUNER_CREATION_TIMESTAMP, ST_TUNER_START_TIMESTAMP
+from syne_tune.config_space import config_space_to_json_dict
+from syne_tune.constants import (
+    ST_TUNER_CREATION_TIMESTAMP,
+    ST_TUNER_START_TIMESTAMP,
+    ST_METADATA_FILENAME,
+    ST_TUNER_DILL_FILENAME,
+)
 from syne_tune.optimizer.scheduler import SchedulerDecision, TrialScheduler
-from syne_tune.tuner_callback import StoreResultsCallback, TunerCallback
+from syne_tune.tuner_callback import TunerCallback
+from syne_tune.results_callback import StoreResultsCallback
 from syne_tune.tuning_status import TuningStatus, print_best_metric_found
 from syne_tune.util import (
     RegularCallback,
@@ -82,7 +89,7 @@ class Tuner:
         when a result is seen. The default callback stores results every
         ``results_update_interval``.
     :param metadata: Dictionary of user-metadata that will be persisted in
-        ``{tuner_path}/metadata.json``, in addition to metadata provided by
+        ``{tuner_path}/{ST_METADATA_FILENAME}``, in addition to metadata provided by
         the user. ``SMT_TUNER_CREATION_TIMESTAMP`` is always included which
         measures the time-stamp when the tuner started to run.
     :param suffix_tuner_name: If ``True``, a timestamp is appended to the
@@ -381,14 +388,14 @@ class Tuner:
         """
         res = metadata if metadata is not None else dict()
         self._set_metadata(res, ST_TUNER_CREATION_TIMESTAMP, time.time())
-        self._set_metadata(res, "backend", str(type(self.trial_backend).__name__))
         self._set_metadata(res, "entrypoint", self.trial_backend.entrypoint_path().stem)
+        self._set_metadata(res, "backend", str(type(self.trial_backend).__name__))
         for key, value in self.scheduler.metadata().items():
             self._set_metadata(res, key, value)
         return res
 
     def _save_metadata(self):
-        dump_json_with_numpy(self.metadata, self.tuner_path / "metadata.json")
+        dump_json_with_numpy(self.metadata, self.tuner_path / ST_METADATA_FILENAME)
 
     def _stop_condition(self) -> bool:
         return (
@@ -532,9 +539,9 @@ class Tuner:
 
     def save(self, folder: Optional[str] = None):
         if folder is None:
-            tuner_serialized_path = self.tuner_path / "tuner.dill"
+            tuner_serialized_path = self.tuner_path / ST_TUNER_DILL_FILENAME
         else:
-            tuner_serialized_path = Path(folder) / "tuner.dill"
+            tuner_serialized_path = Path(folder) / ST_TUNER_DILL_FILENAME
         with open(tuner_serialized_path, "wb") as f:
             logger.debug(f"saving tuner in {tuner_serialized_path}")
             dill.dump(self, f)
@@ -542,7 +549,7 @@ class Tuner:
 
     @staticmethod
     def load(tuner_path: Optional[str]):
-        with open(Path(tuner_path) / "tuner.dill", "rb") as f:
+        with open(Path(tuner_path) / ST_TUNER_DILL_FILENAME, "rb") as f:
             tuner = dill.load(f)
             tuner.tuner_path = Path(experiment_path(tuner_name=tuner.name))
             return tuner

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -25,7 +25,6 @@ from syne_tune.backend.trial_backend import (
 )
 from syne_tune.backend.trial_status import Status, Trial, TrialResult
 from syne_tune.callbacks.remove_checkpoints_callback import RemoveCheckpointsCallback
-from syne_tune.config_space import config_space_to_json_dict
 from syne_tune.constants import (
     ST_TUNER_CREATION_TIMESTAMP,
     ST_TUNER_START_TIMESTAMP,

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -410,3 +410,10 @@ def test_schedulers_api(scheduler):
             dill.dump(scheduler, f)
         with open(Path(local_path) / "scheduler.dill", "rb") as f:
             dill.load(f)
+
+    # Check metadata, metric_names() and metric_mode() are tested above
+    meta = scheduler.metadata()
+    assert meta["metric_names"] == scheduler.metric_names()
+    assert meta["metric_mode"] == scheduler.metric_mode()
+    assert meta["scheduler_name"] == str(scheduler.__class__.__name__)
+    assert "config_space" in meta


### PR DESCRIPTION
Moved scheduler metadata generation from Tuner to the scheduler. Now different schedulers can override this metod to provide their own metadata.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
