### PR TITLE
feat: simple linear scalarization scheduler

### DIFF
--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -132,6 +132,13 @@ class LinearScalarizedScheduler(TrialScheduler):
         """
         return self.base_scheduler.on_trial_remove(trial)
 
+    def trials_checkpoints_can_be_removed(self) -> List[int]:
+        """
+        See the docstring of the chosen base_scheduler for details
+        :return: IDs of paused trials for which checkpoints can be removed
+        """
+        return self.base_scheduler.trials_checkpoints_can_be_removed()
+
     def metric_names(self) -> List[str]:
         """
         :return: List of metric names.

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -113,11 +113,11 @@ class LinearScalarizedScheduler(TrialScheduler):
         mo_results = np.array([result[item] for item in self.metric_names()])
         return np.sum(np.multiply(mo_results, self.scalarization_weights))
 
-    def suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
-        """Returns a suggestion for a new trial, or one to be resumed
+    def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        """Implements ``suggest``, except for basic postprocessing of config.
         See the docstring of the chosen base_scheduler for details
         """
-        return self.base_scheduler.suggest(trial_id)
+        return self.base_scheduler._suggest(trial_id)
 
     def on_trial_add(self, trial: Trial):
         """Called when a new trial is added to the trial runner.

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -13,13 +13,13 @@
 import logging
 from collections.abc import Iterable
 from itertools import groupby
-from typing import Dict, Any, List, Union
+from typing import Dict, Any, List, Union, Callable, Optional
 
 import numpy as np
 
 from syne_tune.backend.trial_status import Trial
-from syne_tune.optimizer.schedulers import FIFOScheduler
-from syne_tune.optimizer.schedulers.fifo import _to_list
+from syne_tune.optimizer.scheduler import TrialScheduler, TrialSuggestion
+from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -33,91 +33,128 @@ def _all_equal(iterable: Iterable) -> bool:
     return next(g, True) and not next(g, False)
 
 
-class LinearScalarizedFIFOScheduler(FIFOScheduler):
+class LinearScalarizedScheduler(TrialScheduler):
     """Scheduler with a Linear Scalarization of multiple objectives.
     This method optimizes a single objective equal to the linear scalarization of given two objectives.
     The scalarized single objective is named: 'scalarized_<metric1>_<metric2>_..._<metricN>'
 
-    See :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`
-    for ``kwargs["search_options"]`` parameters.
 
+    :param base_scheduler: Class for the single-objective scheduler to be used on the scalarized objective.
+        It will be initialized inside this Scheduler
     :param config_space: Configuration space for evaluation function
     :param metric: Names of metrics to optimize
     :param mode: Modes of metrics to optimize (min or max). All must be matching.
     :param scalarization_weights: Weights used to scalarize objectives, if None an array of 1s is used
-    :param searcher_name: Name of the Single objective Searcher used for optimizing the linearized objective
-    :param kwargs: Additional arguments to
-        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
+    :param kwargs: Additional arguments to base_scheduler
     """
 
     scalarization_weights: np.ndarray
-    multi_objective_metrics: List[str]
+    single_objective_metric: str
+    base_scheduler: TrialScheduler
 
     def __init__(
         self,
         config_space: Dict[str, Any],
         metric: List[str],
-        scalarization_weights: Union[np.ndarray, List[float]] = None,
         mode: Union[List[str], str] = "min",
-        searcher="bayesopt",
+        scalarization_weights: Union[np.ndarray, List[float]] = None,
+        base_scheduler: Callable[[...], TrialScheduler] = FIFOScheduler,
         **kwargs,
     ):
-        self.multi_objective_metrics = metric
+        super(LinearScalarizedScheduler, self).__init__(config_space)
         if scalarization_weights is None:
             scalarization_weights = np.ones(shape=len(metric))
         self.scalarization_weights = np.asarray(scalarization_weights)
 
+        self.metric = metric
+        self.mode = mode
+
+        self.single_objective_metric = f"scalarized_{'_'.join(metric)}"
         assert len(mode) >= 1, "At least one mode must be provided"
         if isinstance(mode, Iterable):
             assert _all_equal(
                 mode
             ), "Modes must be the same, use positive/negative scalarization_weights to change relative signs"
-            mode = next(x for x in mode)
+            single_objective_mode = next(x for x in mode)
 
-        metric = f"scalarized_{'_'.join(metric)}"
-        super(LinearScalarizedFIFOScheduler, self).__init__(
+        self.base_scheduler = base_scheduler(
             config_space=config_space,
-            metric=metric,
-            searcher=searcher,
-            mode=mode,
+            metric=self.single_objective_metric,
+            mode=single_objective_mode,
             **kwargs,
         )
 
-    def multi_objective_metric_names(self) -> List[str]:
-        return _to_list(self.multi_objective_metrics)
-
-    def _multi_objective_check_result(self, result: Dict[str, Any]):
-        self._check_keys_of_result(result, self.multi_objective_metric_names())
-
     def _scalarized_metric(self, result: Dict[str, Any]) -> float:
-        self._multi_objective_check_result(result)
-        mo_results = np.array(
-            [result[item] for item in self.multi_objective_metric_names()]
-        )
+        if isinstance(self.base_scheduler, FIFOScheduler):
+            FIFOScheduler._check_keys_of_result(result, self.metric_names())
+
+        mo_results = np.array([result[item] for item in self.metric_names()])
         logger.debug(
-            f"Scalarizing {self.multi_objective_metric_names()} into {self.metric} using linear combination"
+            f"Scalarizing {self.metric_names()} into {self.single_objective_metric} using linear combination"
         )
         return np.sum(np.multiply(mo_results, self.scalarization_weights))
 
+    def suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        """Returns a suggestion for a new trial, or one to be resumed
+        See the docstring of the chosen base_scheduler for details
+        """
+        return self.base_scheduler.suggest(trial_id)
+
+    def on_trial_add(self, trial: Trial):
+        """Called when a new trial is added to the trial runner.
+        See the docstring of the chosen base_scheduler for details
+        """
+        return self.base_scheduler.on_trial_add(trial)
+
+    def on_trial_error(self, trial: Trial):
+        """Called when a trial has failed.
+        See the docstring of the chosen base_scheduler for details
+        """
+        return self.base_scheduler.on_trial_error(trial)
+
     def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+        """Called on each intermediate result reported by a trial.
+        See the docstring of the chosen base_scheduler for details
         """
-        We simply relay ``result`` to the searcher. Other decisions are done
-        in ``on_trial_complete``.
-        """
-        result[self.metric] = self._scalarized_metric(result)
-        return super(LinearScalarizedFIFOScheduler, self).on_trial_result(trial, result)
+        result[self.single_objective_metric] = self._scalarized_metric(result)
+        return self.base_scheduler.on_trial_result(trial, result)
 
     def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
-        result[self.metric] = self._scalarized_metric(result)
-        return super(LinearScalarizedFIFOScheduler, self).on_trial_complete(
-            trial, result
-        )
+        """Notification for the completion of trial.
+        See the docstring of the chosen base_scheduler for details
+        """
+        result[self.single_objective_metric] = self._scalarized_metric(result)
+        return self.base_scheduler.on_trial_complete(trial, result)
+
+    def on_trial_remove(self, trial: Trial):
+        """Called to remove trial.
+        See the docstring of the chosen base_scheduler for details
+        """
+        return self.base_scheduler.on_trial_remove(trial)
+
+    def metric_names(self) -> List[str]:
+        """
+        :return: List of metric names.
+        """
+        return self.metric
+
+    def metric_mode(self) -> Union[str, List[str]]:
+        """
+        :return: "min" if target metric is minimized, otherwise "max".
+        """
+        return self.mode
 
     def metadata(self) -> Dict[str, Any]:
         """
         :return: Metadata of the scheduler
         """
         return {
-            **super(LinearScalarizedFIFOScheduler, self).metadata(),
-            "multi_objective_metric": self.multi_objective_metric_names(),
+            **super(LinearScalarizedScheduler, self).metadata(),
+            "scalarized_metric": self.single_objective_metric,
         }
+
+    def is_multiobjective_scheduler(self) -> bool:
+        """
+        Return True if a scheduler is multi-objective.
+        """
+        return True

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -18,7 +18,6 @@ from typing import Dict, Any, List, Union
 import numpy as np
 
 from syne_tune.backend.trial_status import Trial
-from syne_tune.optimizer.baselines import _assert_searcher_must_be
 from syne_tune.optimizer.schedulers import FIFOScheduler
 from syne_tune.optimizer.schedulers.fifo import _to_list
 

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -58,7 +58,7 @@ class LinearScalarizedScheduler(TrialScheduler):
         metric: List[str],
         mode: Union[List[str], str] = "min",
         scalarization_weights: Union[np.ndarray, List[float]] = None,
-        base_scheduler: Callable[[...], TrialScheduler] = FIFOScheduler,
+        base_scheduler: Callable[[Any], TrialScheduler] = FIFOScheduler,
         **kwargs,
     ):
         super(LinearScalarizedScheduler, self).__init__(config_space)

--- a/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/linear_scalarizer.py
@@ -1,0 +1,124 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+from collections.abc import Iterable
+from itertools import groupby
+from typing import Dict, Any, List, Union
+
+import numpy as np
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.optimizer.baselines import _assert_searcher_must_be
+from syne_tune.optimizer.schedulers import FIFOScheduler
+from syne_tune.optimizer.schedulers.fifo import _to_list
+
+logger = logging.getLogger(__name__)
+
+
+def _all_equal(iterable: Iterable) -> bool:
+    """
+    Check if all elements of an iterable are the same
+    https://stackoverflow.com/questions/3844801/check-if-all-elements-in-a-list-are-identical
+    """
+    g = groupby(iterable)
+    return next(g, True) and not next(g, False)
+
+
+class LinearScalarizedFIFOScheduler(FIFOScheduler):
+    """Scheduler with a Linear Scalarization of multiple objectives.
+    This method optimizes a single objective equal to the linear scalarization of given two objectives.
+    The scalarized single objective is named: 'scalarized_<metric1>_<metric2>_..._<metricN>'
+
+    See :class:`~syne_tune.optimizer.schedulers.searchers.GPFIFOSearcher`
+    for ``kwargs["search_options"]`` parameters.
+
+    :param config_space: Configuration space for evaluation function
+    :param metric: Names of metrics to optimize
+    :param mode: Modes of metrics to optimize (min or max). All must be matching.
+    :param scalarization_weights: Weights used to scalarize objectives, if None an array of 1s is used
+    :param searcher_name: Name of the Single objective Searcher used for optimizing the linearized objective
+    :param kwargs: Additional arguments to
+        :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`
+    """
+
+    scalarization_weights: np.ndarray
+    multi_objective_metrics: List[str]
+
+    def __init__(
+        self,
+        config_space: Dict[str, Any],
+        metric: List[str],
+        scalarization_weights: Union[np.ndarray, List[float]] = None,
+        mode: Union[List[str], str] = "min",
+        searcher="bayesopt",
+        **kwargs,
+    ):
+        self.multi_objective_metrics = metric
+        if scalarization_weights is None:
+            scalarization_weights = np.ones(shape=len(metric))
+        self.scalarization_weights = np.asarray(scalarization_weights)
+
+        assert len(mode) >= 1, "At least one mode must be provided"
+        if isinstance(mode, Iterable):
+            assert _all_equal(
+                mode
+            ), "Modes must be the same, use positive/negative scalarization_weights to change relative signs"
+            mode = next(x for x in mode)
+
+        metric = f"scalarized_{'_'.join(metric)}"
+        super(LinearScalarizedFIFOScheduler, self).__init__(
+            config_space=config_space,
+            metric=metric,
+            searcher=searcher,
+            mode=mode,
+            **kwargs,
+        )
+
+    def multi_objective_metric_names(self) -> List[str]:
+        return _to_list(self.multi_objective_metrics)
+
+    def _multi_objective_check_result(self, result: Dict[str, Any]):
+        self._check_keys_of_result(result, self.multi_objective_metric_names())
+
+    def _scalarized_metric(self, result: Dict[str, Any]) -> float:
+        self._multi_objective_check_result(result)
+        mo_results = np.array(
+            [result[item] for item in self.multi_objective_metric_names()]
+        )
+        logger.debug(
+            f"Scalarizing {self.multi_objective_metric_names()} into {self.metric} using linear combination"
+        )
+        return np.sum(np.multiply(mo_results, self.scalarization_weights))
+
+    def on_trial_result(self, trial: Trial, result: Dict[str, Any]) -> str:
+        """
+        We simply relay ``result`` to the searcher. Other decisions are done
+        in ``on_trial_complete``.
+        """
+        result[self.metric] = self._scalarized_metric(result)
+        return super(LinearScalarizedFIFOScheduler, self).on_trial_result(trial, result)
+
+    def on_trial_complete(self, trial: Trial, result: Dict[str, Any]):
+        result[self.metric] = self._scalarized_metric(result)
+        return super(LinearScalarizedFIFOScheduler, self).on_trial_complete(
+            trial, result
+        )
+
+    def metadata(self) -> Dict[str, Any]:
+        """
+        :return: Metadata of the scheduler
+        """
+        return {
+            **super(LinearScalarizedFIFOScheduler, self).metadata(),
+            "multi_objective_metric": self.multi_objective_metric_names(),
+        }

--- a/tst/schedulers/multiobjective/test_simple_scalarizer.py
+++ b/tst/schedulers/multiobjective/test_simple_scalarizer.py
@@ -1,0 +1,103 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import datetime
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.config_space import randint, uniform, choice
+from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
+    LinearScalarizedFIFOScheduler,
+)
+from syne_tune.optimizer.schedulers.multiobjective.utils import (
+    hypervolume,
+    hypervolume_cumulative,
+)
+
+
+@pytest.fixture
+def config_space():
+    return {
+        "steps": 100,
+        "x": randint(0, 20),
+        "y": uniform(0, 1),
+        "z": choice(["a", "b", "c"]),
+    }
+
+
+@pytest.fixture
+def metric1():
+    return "objective1"
+
+
+@pytest.fixture
+def metric2():
+    return "objective2"
+
+
+@pytest.fixture
+def resource_attr():
+    return "step"
+
+
+@pytest.fixture
+def max_t():
+    return 10
+
+
+@pytest.fixture
+def mode():
+    return "max"
+
+
+@pytest.fixture
+def make_metric(metric1, metric2):
+    return lambda x: {metric1: x, metric2: -x}
+
+
+@pytest.fixture
+def scheduler(config_space, metric1, metric2, mode):
+    return LinearScalarizedFIFOScheduler(
+        config_space=config_space,
+        metric=[metric1, metric2],
+        mode=[mode, mode],
+        scalarization_weights=[1, 1],
+        searcher="kde",
+    )
+
+
+def test_scalarization(scheduler: LinearScalarizedFIFOScheduler, make_metric: Callable):
+    results = make_metric(321)
+    scalarized = scheduler._scalarized_metric(results)
+    assert scalarized == 321 - 321
+
+
+def test_resukls_gathering(
+    scheduler: LinearScalarizedFIFOScheduler, make_metric: Callable
+):
+    trialid = 123
+    trial = Trial(
+        trial_id=trialid,
+        config=scheduler.suggest(trialid).config,
+        creation_time=datetime.datetime.now(),
+    )
+    results = make_metric(321)
+    scheduler.on_trial_complete(trial, results)
+
+    observed_metric = scheduler.searcher.y[0]
+    assert observed_metric == 0.0
+
+    observed_trial = scheduler.searcher._from_feature(scheduler.searcher.X[0])
+    assert observed_trial == trial.config

--- a/tst/schedulers/multiobjective/test_simple_scalarizer.py
+++ b/tst/schedulers/multiobjective/test_simple_scalarizer.py
@@ -13,17 +13,12 @@
 import datetime
 from typing import Callable
 
-import numpy as np
 import pytest
 
 from syne_tune.backend.trial_status import Trial
 from syne_tune.config_space import randint, uniform, choice
 from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
     LinearScalarizedFIFOScheduler,
-)
-from syne_tune.optimizer.schedulers.multiobjective.utils import (
-    hypervolume,
-    hypervolume_cumulative,
 )
 
 

--- a/tst/schedulers/multiobjective/test_simple_scalarizer.py
+++ b/tst/schedulers/multiobjective/test_simple_scalarizer.py
@@ -70,7 +70,7 @@ def scheduler(config_space, metric1, metric2, mode):
         metric=[metric1, metric2],
         mode=[mode, mode],
         scalarization_weights=[1, 1],
-        base_scheduler=FIFOScheduler,
+        base_scheduler_factory=FIFOScheduler,
         searcher="kde",
     )
 

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -50,6 +50,9 @@ from syne_tune.optimizer.schedulers import (
     RayTuneScheduler,
 )
 from syne_tune.optimizer.schedulers.multiobjective import MOASHA
+from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
+    LinearScalarizedFIFOScheduler,
+)
 from syne_tune.optimizer.schedulers.transfer_learning import (
     TransferLearningTaskEvaluations,
     BoundingBox,
@@ -351,6 +354,19 @@ list_schedulers_to_test = [
     #     max_t=max_t,
     #     resource_attr=resource_attr,
     # ),
+    LinearScalarizedFIFOScheduler(
+        config_space=config_space,
+        metric=[metric1, metric2],
+        mode=[mode, mode],
+        scalarization_weights=[1, 1],
+    ),
+    LinearScalarizedFIFOScheduler(
+        config_space=config_space,
+        metric=[metric1, metric2],
+        mode=[mode, mode],
+        scalarization_weights=[1, 1],
+        searcher="random",
+    ),
 ]
 if sys.version_info >= (3, 8):
     # BoTorch scheduler requires Python 3.8 or later
@@ -371,6 +387,8 @@ def test_schedulers_api(scheduler):
 
     if scheduler.is_multiobjective_scheduler():
         assert scheduler.metric_names() == [metric1, metric2]
+    elif isinstance(scheduler, LinearScalarizedFIFOScheduler):
+        assert scheduler.metric_names() == [f"scalarized_{metric1}_{metric2}"]
     else:
         assert scheduler.metric_names() == [metric1]
 

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -51,7 +51,7 @@ from syne_tune.optimizer.schedulers import (
 )
 from syne_tune.optimizer.schedulers.multiobjective import MOASHA
 from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
-    LinearScalarizedFIFOScheduler,
+    LinearScalarizedScheduler,
 )
 from syne_tune.optimizer.schedulers.transfer_learning import (
     TransferLearningTaskEvaluations,
@@ -354,17 +354,19 @@ list_schedulers_to_test = [
     #     max_t=max_t,
     #     resource_attr=resource_attr,
     # ),
-    LinearScalarizedFIFOScheduler(
+    LinearScalarizedScheduler(
         config_space=config_space,
         metric=[metric1, metric2],
         mode=[mode, mode],
         scalarization_weights=[1, 1],
+        base_scheduler=FIFOScheduler,
     ),
-    LinearScalarizedFIFOScheduler(
+    LinearScalarizedScheduler(
         config_space=config_space,
         metric=[metric1, metric2],
         mode=[mode, mode],
         scalarization_weights=[1, 1],
+        base_scheduler=FIFOScheduler,
         searcher="random",
     ),
 ]
@@ -387,8 +389,6 @@ def test_schedulers_api(scheduler):
 
     if scheduler.is_multiobjective_scheduler():
         assert scheduler.metric_names() == [metric1, metric2]
-    elif isinstance(scheduler, LinearScalarizedFIFOScheduler):
-        assert scheduler.metric_names() == [f"scalarized_{metric1}_{metric2}"]
     else:
         assert scheduler.metric_names() == [metric1]
 

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -359,14 +359,14 @@ list_schedulers_to_test = [
         metric=[metric1, metric2],
         mode=[mode, mode],
         scalarization_weights=[1, 1],
-        base_scheduler=FIFOScheduler,
+        base_scheduler_factory=FIFOScheduler,
     ),
     LinearScalarizedScheduler(
         config_space=config_space,
         metric=[metric1, metric2],
         mode=[mode, mode],
         scalarization_weights=[1, 1],
-        base_scheduler=FIFOScheduler,
+        base_scheduler_factory=FIFOScheduler,
         searcher="random",
     ),
 ]


### PR DESCRIPTION
Added a simple linear scalarization scheduler that combines multiple objectives into one using weighted mean and optimizes the resulting metric with any singe-objective FIFO optimizer.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
