### PR TITLE
refactor: Move early checkpoint removal into mixin

### DIFF
--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -158,9 +158,7 @@ class ConfigDict:
     def __setattr__(self, attr, value):
         self._config[attr] = value
 
-    def check_if_all_paremeters_present(
-        self, desired_parameters: List[DictStrKey]
-    ) -> bool:
+    def check_if_all_paremeters_present(self, desired_parameters: List[DictStrKey]):
         """
         Verify that all the parameers present in desired_parameters can be found in this ConfigDict
         """
@@ -205,14 +203,7 @@ class ConfigDict:
         """
         Build the configuration dict from command line arguments
 
-        ``map_extra_args`` can be used to modify ``method_kwargs`` for constructing
-        :class:`~benchmarking.commons.baselines.MethodArguments`, depending on
-        ``args`` returned by :func:`parse_args` and the method. Its signature is
-        :code:`method_kwargs = map_extra_args(args, method, method_kwargs)`, where
-        ``method`` is the name of the baseline.
-
         :param extra_args: Extra arguments for command line parser. Optional
-        :param map_extra_args: See above, optional
         """
         parser = ArgumentParser(
             description=(
@@ -220,7 +211,10 @@ class ConfigDict:
                 "and seeds (repetitions). Use hpo_main.py to launch experiments "
                 "locally, or launch_remote.py to launch experiments remotely on AWS"
             ),
-            epilog="For more information, please visit:\nhttps://syne-tune.readthedocs.io/en/latest/tutorials/benchmarking/README.html",
+            epilog=(
+                "For more information, please visit:\n"
+                "https://syne-tune.readthedocs.io/en/latest/tutorials/benchmarking/README.html"
+            ),
         )
 
         for param in ConfigDict.__base_cl_parameters:

--- a/benchmarking/commons/hpo_main_local.py
+++ b/benchmarking/commons/hpo_main_local.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 import itertools
 from typing import Optional, Callable, Dict, Any
-
 import numpy as np
 from tqdm import tqdm
 import logging
@@ -69,6 +68,12 @@ LOCAL_BACKEND_EXTRA_PARAMETERS = [
         type=str2bool,
         default=True,
         help="Remote tuning publishes metrics to Sagemaker console?",
+    ),
+    dict(
+        name="delete_checkpoints",
+        type=str2bool,
+        default=False,
+        help="Remove checkpoints of trials once no longer needed?",
     ),
 ]
 
@@ -238,7 +243,10 @@ def start_benchmark_local_backend(
         print(
             f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}"
         )
-        trial_backend = LocalBackend(entry_point=str(benchmark.script))
+        trial_backend = LocalBackend(
+            entry_point=str(benchmark.script),
+            delete_checkpoints=configuration.delete_checkpoints,
+        )
 
         tuner_kwargs = create_objects_for_tuner(
             configuration,

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -188,6 +188,7 @@ def launch_remote_experiments(
     extra_sagemaker_hyperparameters = {
         "verbose": int(configuration.verbose),
         "remote_tuning_metrics": int(configuration.remote_tuning_metrics),
+        "delete_checkpoints": int(configuration.delete_checkpoints),
     }
     experiment_tag = _launch_experiment_remotely(
         configuration=configuration,

--- a/syne_tune/backend/simulator_backend/simulator_backend.py
+++ b/syne_tune/backend/simulator_backend/simulator_backend.py
@@ -34,8 +34,12 @@ from syne_tune.backend.simulator_backend.events import (
     StopEvent,
     OnTrialResultEvent,
 )
-from syne_tune.constants import ST_CHECKPOINT_DIR, ST_WORKER_TIMESTAMP, ST_TUNER_TIME
-from syne_tune.tuner import DEFAULT_SLEEP_TIME
+from syne_tune.constants import (
+    ST_CHECKPOINT_DIR,
+    ST_WORKER_TIMESTAMP,
+    ST_TUNER_TIME,
+    TUNER_DEFAULT_SLEEP_TIME,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +133,7 @@ class SimulatorBackend(LocalBackend):
         entry_point: str,
         elapsed_time_attr: str,
         simulator_config: Optional[SimulatorConfig] = None,
-        tuner_sleep_time: float = DEFAULT_SLEEP_TIME,
+        tuner_sleep_time: float = TUNER_DEFAULT_SLEEP_TIME,
         debug_resource_attr: Optional[str] = None,
     ):
         super().__init__(entry_point=entry_point, rotate_gpus=False)

--- a/syne_tune/backend/trial_backend.py
+++ b/syne_tune/backend/trial_backend.py
@@ -38,9 +38,11 @@ class TrialBackend:
 
     :param delete_checkpoints: If ``True``, the checkpoints written by a trial
         are deleted once the trial is stopped or is registered as
-        completed. Also, as part of :meth:`stop_all` called at the end of the
-        tuning loop, all remaining checkpoints are deleted. Defaults to
-        ``False``.
+        completed. Checkpoints of paused trials may also be removed, if the
+        scheduler supports early checkpoint removal. Also, as part of
+        :meth:`stop_all` called at the end of the tuning loop, all remaining
+        checkpoints are deleted. Defaults to ``False`` (no checkpoints are
+        removed).
     :param pass_args_as_json: Normally, the hyperparameter configuration is
         passed as command line arguments to the trial evaluation script. This
         works if all hyperparameters have elementary types. If

--- a/syne_tune/callbacks/checkpoint_removal_factory.py
+++ b/syne_tune/callbacks/checkpoint_removal_factory.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import Optional, Callable
+
+from syne_tune.callbacks.remove_checkpoints_callback import RemoveCheckpointsCallback
+from syne_tune.optimizer.scheduler import TrialScheduler
+from syne_tune.optimizer.schedulers.remove_checkpoints import (
+    RemoveCheckpointsSchedulerMixin,
+)
+from syne_tune.tuner_callback import TunerCallback
+from syne_tune.tuning_status import TuningStatus
+
+
+def early_checkpoint_removal_factory(
+    scheduler: TrialScheduler,
+    stop_criterion: Callable[[TuningStatus], bool],
+) -> Optional[TunerCallback]:
+    """
+    Early checkpoint removal is implemented by callbacks, which depend on which
+    scheduler is being used. For many schedulers, early checkpoint removal is
+    not supported.
+
+    :param scheduler: Scheduler for which early checkpoint removal is requested
+    :param stop_criterion: Stop criterion as passed to :class:`~syne_tune.Tuner`
+    :return: Callback for early checkpoint removal, or ``None`` if this is not
+        supported for the scheduler
+    """
+    callback = None
+    if isinstance(scheduler, RemoveCheckpointsSchedulerMixin):
+        callback_kwargs = scheduler.params_early_checkpoint_removal()
+    else:
+        callback_kwargs = None
+    if callback_kwargs is not None:
+        # General case: Scheduler implements ``trials_checkpoints_can_be_removed``
+        # method, and we can use the generic ``RemoveCheckpointsCallback``
+        # callback
+        assert len(callback_kwargs) == 0, (
+            "params_early_checkpoint_removal of your scheduler returns "
+            "arguments, which are not used in RemoveCheckpointsCallback"
+        )
+        callback = RemoveCheckpointsCallback()
+    return callback

--- a/syne_tune/callbacks/remove_checkpoints_callback.py
+++ b/syne_tune/callbacks/remove_checkpoints_callback.py
@@ -11,6 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 from syne_tune.tuner_callback import TunerCallback
+from syne_tune.optimizer.schedulers.remove_checkpoints import (
+    RemoveCheckpointsSchedulerMixin,
+)
 
 
 class RemoveCheckpointsCallback(TunerCallback):
@@ -24,6 +27,9 @@ class RemoveCheckpointsCallback(TunerCallback):
         self._tuner = None
 
     def on_tuning_start(self, tuner):
+        assert isinstance(
+            tuner.scheduler, RemoveCheckpointsSchedulerMixin
+        ), "tuner.scheduler must be of type RemoveCheckpointsSchedulerMixin"
         self._tuner = tuner
 
     def on_loop_end(self):

--- a/syne_tune/constants.py
+++ b/syne_tune/constants.py
@@ -87,3 +87,6 @@ ST_TUNER_DILL_FILENAME = "tuner.dill"
 
 MAX_METRICS_SUPPORTED_BY_SAGEMAKER = 40
 """Max number of metrics allowed for estimator"""  # pylint: disable=W0105
+
+TUNER_DEFAULT_SLEEP_TIME = 5.0
+"""Default value for ``sleep_time``"""  # pylint: disable=W0105

--- a/syne_tune/experiments.py
+++ b/syne_tune/experiments.py
@@ -21,6 +21,7 @@ from typing import List, Dict, Callable, Optional, Union, Any, Tuple
 import numpy as np
 import pandas as pd
 
+from syne_tune import Tuner
 from syne_tune.constants import (
     ST_TUNER_TIME,
     ST_TUNER_CREATION_TIMESTAMP,
@@ -28,8 +29,6 @@ from syne_tune.constants import (
     ST_RESULTS_DATAFRAME_FILENAME,
     ST_TUNER_DILL_FILENAME,
 )
-from syne_tune import Tuner
-from syne_tune.constants import ST_TUNER_TIME, ST_TUNER_CREATION_TIMESTAMP
 from syne_tune.optimizer.schedulers.multiobjective.utils import hypervolume_cumulative
 from syne_tune.try_import import try_import_aws_message
 from syne_tune.util import experiment_path, s3_experiment_path

--- a/syne_tune/optimizer/scheduler.py
+++ b/syne_tune/optimizer/scheduler.py
@@ -282,26 +282,6 @@ class TrialScheduler:
         else:
             raise NotImplementedError
 
-    def trials_checkpoints_can_be_removed(self) -> List[int]:
-        """
-        This (optional) method can be implemented by schedulers which pause and
-        resume trials (in that :meth:`on_trial_result` can return
-        :const:`SchedulerDecision.PAUSE`). Model checkpoints are retained for
-        paused trials, because they may get resumed later on. This can lead to
-        the disk filling up, so removing checkpoints which are not longer needed,
-        can be important.
-
-        This method returns IDs of paused trials for which checkpoints can be
-        removed. These trials either cannot be resumed anymore, or it is very
-        unlikely they will be resumed. Any trial ID needs to be returned only once,
-        not over and over. If a trial gets stopped (by returning
-        :const:`SchedulerDecision.STOP` in :meth:`on_trial_result`), its checkpoint
-        is removed anyway, so its ID does not have to be returned here.
-
-        :return: IDs of paused trials for which checkpoints can be removed
-        """
-        return []  # Default is not to participate in early checkpoint removal
-
     def metadata(self) -> Dict[str, Any]:
         """
         :return: Metadata for the scheduler

--- a/syne_tune/optimizer/schedulers/hyperband.py
+++ b/syne_tune/optimizer/schedulers/hyperband.py
@@ -13,7 +13,7 @@
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 import numpy as np
 

--- a/syne_tune/optimizer/schedulers/remove_checkpoints.py
+++ b/syne_tune/optimizer/schedulers/remove_checkpoints.py
@@ -1,0 +1,80 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import List, Optional, Dict, Any
+
+
+class RemoveCheckpointsSchedulerMixin:
+    """
+    Methods to be implemented by pause-and-resume schedulers (in that
+    :meth:`on_trial_result` can return :const:`SchedulerDecision.PAUSE`) which
+    support early removal of checkpoints. Typically, model checkpoints are
+    retained for paused trials, because they may get resumed later on. This can
+    lead to the disk filling up, so removing checkpoints which are no longer
+    needed, can be important.
+
+    Early checkpoint removal is implemented as a callback used with
+    :class:`~syne_tune.Tuner`, which is created by
+    :func:``~syne_tune.callbacks.checkpoint_removal_factory.early_checkpoint_removal_factory`.
+    There are different ways how this callback works (they differ in terms
+    of which pause-and-resume schedulers use them), all are supported here:
+
+    * General case: Scheduler reports trials for which checkpoints can be
+      removed. To this end, the scheduler implements
+      :meth:`trials_checkpoints_can_be_removed`. In this case, the callback can
+      be very simple:
+      :class:`~syne_tune.callbacks.remove_checkpoints_callback.RemoveCheckpointsCallback`.
+      For this case, :meth:`params_early_checkpoint_removal` should return an
+      empty dictionary.
+      Example:
+      :class:`~syne_tune.optimizer.scheduler.synchronous.SynchronousHyperbandScheduler`
+    * Special cases: The callback implements a more advanced logic for a specific
+      kind of scheduler. The callback is created by
+      ``early_checkpoint_removal_factory``, and
+      :meth:`params_early_checkpoint_removal` provides the constructor arguments.
+      Example:
+      :class:`~syne_tune.callbacks.hyperband_remove_checkpoints_callback.HyperbandRemoveCheckpointsCallback`.
+      Note that in this case, the scheduler may need to provide information to
+      the callback via methods not specified here.
+    """
+
+    def trials_checkpoints_can_be_removed(self) -> List[int]:
+        """
+        Supports the general case (see header comment).
+        This method returns IDs of paused trials for which checkpoints can safely
+        be removed. These trials either cannot be resumed anymore, or it is very
+        unlikely they will be resumed. Any trial ID needs to be returned only once,
+        not over and over. If a trial gets stopped (by returning
+        :const:`SchedulerDecision.STOP` in :meth:`on_trial_result`), its checkpoint
+        is removed anyway, so its ID does not have to be returned here.
+
+        :return: IDs of paused trials for which checkpoints can be removed
+        """
+        return []  # Safe default
+
+    def params_early_checkpoint_removal(self) -> Optional[Dict[str, Any]]:
+        """
+        Supports special cases, in which :meth:`trials_checkpoints_can_be_removed`
+        is not used. In such cases, the checkpoint removal callback is created by
+        :func:``~syne_tune.callbacks.checkpoint_removal_factory.early_checkpoint_removal_factory`.
+        The arguments for the callback constructor are provided here.
+
+        .. note::
+           In the general case, where :meth:`trials_checkpoints_can_be_removed`
+           is implemented, this method should return an empty dictionary.
+           If this method returns ``None``, it means that early checkpoint removal
+           should not be done.
+
+        :return: Arguments for callback constructor, or ``None`` if early
+            checkpoint removal is not supported
+        """
+        return None

--- a/syne_tune/optimizer/schedulers/synchronous/hyperband.py
+++ b/syne_tune/optimizer/schedulers/synchronous/hyperband.py
@@ -24,6 +24,9 @@ from syne_tune.optimizer.schedulers.synchronous.hyperband_rung_system import (
 from syne_tune.optimizer.scheduler import TrialSuggestion, SchedulerDecision
 from syne_tune.optimizer.schedulers.scheduler_searcher import TrialSchedulerWithSearcher
 from syne_tune.optimizer.schedulers.multi_fidelity import MultiFidelitySchedulerMixin
+from syne_tune.optimizer.schedulers.remove_checkpoints import (
+    RemoveCheckpointsSchedulerMixin,
+)
 from syne_tune.backend.trial_status import Trial
 from syne_tune.config_space import cast_config_values
 from syne_tune.optimizer.schedulers.searchers.utils.default_arguments import (
@@ -156,7 +159,9 @@ class SynchronousHyperbandCommon(
         return self._searcher_data
 
 
-class SynchronousHyperbandScheduler(SynchronousHyperbandCommon):
+class SynchronousHyperbandScheduler(
+    SynchronousHyperbandCommon, RemoveCheckpointsSchedulerMixin
+):
     """
     Synchronous Hyperband. Compared to
     :class:`~syne_tune.optimizer.schedulers.HyperbandScheduler`, this is also
@@ -433,3 +438,6 @@ class SynchronousHyperbandScheduler(SynchronousHyperbandCommon):
         result = self._trials_checkpoints_can_be_removed
         self._trials_checkpoints_can_be_removed = []
         return result
+
+    def params_early_checkpoint_removal(self) -> Optional[Dict[str, Any]]:
+        return dict()

--- a/syne_tune/results_callback.py
+++ b/syne_tune/results_callback.py
@@ -133,11 +133,12 @@ class StoreResultsCallback(TunerCallback):
         return pd.DataFrame(self.results)
 
     def on_tuning_start(self, tuner):
-        # we set the path of the csv file once the tuner is created since the path may change when the tuner is stop
-        # and resumed again on a different machine.
+        # We set the path of the csv file once the tuner is created, since the
+        # path may change when the tuner is stopped and resumed again on a
+        # different machine.
         self.csv_file = str(tuner.tuner_path / ST_RESULTS_DATAFRAME_FILENAME)
-        # we only save results every ``results_update_frequency`` seconds as this operation
-        # may be expensive on remote storage.
+        # We only save results every ``results_update_frequency`` seconds as
+        # this operation may be expensive on remote storage.
         self.save_results_at_frequency = RegularCallback(
             lambda: self.store_results(),
             call_seconds_frequency=tuner.results_update_interval,
@@ -148,6 +149,6 @@ class StoreResultsCallback(TunerCallback):
             self._tuner = tuner
 
     def on_tuning_end(self):
-        # store the results in case some results were not committed yet (since they are saved every
-        # ``results_update_interval`` seconds)
+        # Store the results in case some results were not committed yet (since
+        # they are saved every ``results_update_interval`` seconds)
         self.store_results()

--- a/syne_tune/tuner_callback.py
+++ b/syne_tune/tuner_callback.py
@@ -101,3 +101,17 @@ class TunerCallback:
         :param sleep_time: Time (in secs) for which tuner has just slept
         """
         pass
+
+    def on_start_trial(self, trial: Trial):
+        """Called just after a new trials is started
+
+        :param trial: Trial which has just been started
+        """
+        pass
+
+    def on_resume_trial(self, trial: Trial):
+        """Called just after a trial is resumed
+
+        :param trial: Trial which has just been resumed
+        """
+        pass


### PR DESCRIPTION
This is the first part of the speculative early CP removal PR. It shows how we can avoid new methods in `TrialScheduler`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
