### PR TITLE
fix: CI failing with `ModuleNotFoundError: No module named 'examples'` error

### DIFF
--- a/.github/workflows/run-syne-tune.yml
+++ b/.github/workflows/run-syne-tune.yml
@@ -48,7 +48,8 @@ jobs:
           cache: 'pip'
       - name: Install Syne Tune
         run: |
-          python -m pip install --upgrade pip wheel
+          python -m pip install wheel
+          python -m pip install --upgrade pip
           python -m pip install -e '.[extra]'
       - name: Run optional custom command
         if: ${{ inputs.additional-command != '' }}

--- a/.github/workflows/run-syne-tune.yml
+++ b/.github/workflows/run-syne-tune.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install Syne Tune
         run: |
           python -m pip install --upgrade pip
+          pip install pip==23.0.1
           python -m pip install -e '.[extra]'
       - name: Run optional custom command
         if: ${{ inputs.additional-command != '' }}

--- a/.github/workflows/run-syne-tune.yml
+++ b/.github/workflows/run-syne-tune.yml
@@ -48,8 +48,7 @@ jobs:
           cache: 'pip'
       - name: Install Syne Tune
         run: |
-          python -m pip install --upgrade pip
-          pip install pip==23.0.1
+          python -m pip install --upgrade pip wheel
           python -m pip install -e '.[extra]'
       - name: Run optional custom command
         if: ${{ inputs.additional-command != '' }}


### PR DESCRIPTION
Issue: https://github.com/pypa/pip/issues/11972

New version of pip `23.1` broke installation of the `examples` module.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
