### PR TITLE
fix: Fix `ListTrainingJobs` throttling for E2E tests

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -28,6 +28,8 @@ jobs:
           role-to-assume: ${{ secrets.PROD_AWS_INTEG_TEST_ROLE_ARN }}
           role-session-name: integtestsession
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Install boto3
+        run: python -m pip install boto3
       - name: Stop all left-over training jobs
         run: |
           import boto3

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -5,9 +5,9 @@ name: End-to-end Tests
 
 on:
   workflow_dispatch:
-  pull_request: # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
-    branches:   # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
-      - main    # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+  # pull_request: # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+  #   branches:   # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+  #     - main    # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
 
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
           
               for page in paginator.paginate(StatusEquals='InProgress'):
                   in_progress_jobs.extend(page['TrainingJobSummaries'])
-                  sleep(3)
+                  sleep(2)
           
               return in_progress_jobs
           

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -50,6 +50,7 @@ jobs:
                   job_name = job['TrainingJobName']
                   print(f'Stopping training job: {job_name}')
                   sagemaker.stop_training_job(TrainingJobName=job_name)
+                  sleep(1)
           
           sagemaker = boto3.client('sagemaker')          
           in_progress_jobs = get_in_progress_training_jobs(sagemaker)

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -28,15 +28,33 @@ jobs:
           role-to-assume: ${{ secrets.PROD_AWS_INTEG_TEST_ROLE_ARN }}
           role-session-name: integtestsession
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      # - name: Stop all left-over training jobs
-      #   run: |
-      #     aws sagemaker list-training-jobs --status-equals InProgress > running_jobs.json
-      #     jq -c '.[][]["TrainingJobName"]' running_jobs.json | while read i; do
-      #       jobName=`echo $i | cut -d "\"" -f 2`
-      #       echo "stopping training job $jobName"
-      #       aws sagemaker stop-training-job --training-job-name $jobName
-      #       sleep 5
-      #     done
+      - name: Stop all left-over training jobs
+        run: |
+          import boto3
+          from time import sleep
+          
+          def get_in_progress_training_jobs(sagemaker):
+              in_progress_jobs = []
+              paginator = sagemaker.get_paginator('list_training_jobs')
+          
+              for page in paginator.paginate(StatusEquals='InProgress'):
+                  in_progress_jobs.extend(page['TrainingJobSummaries'])
+                  sleep(3)
+          
+              return in_progress_jobs
+          
+          def stop_training_jobs(sagemaker, in_progress_jobs):
+              for job in in_progress_jobs:
+                  job_name = job['TrainingJobName']
+                  print(f'Stopping training job: {job_name}')
+                  sagemaker.stop_training_job(TrainingJobName=job_name)
+          
+          sagemaker = boto3.client('sagemaker')          
+          in_progress_jobs = get_in_progress_training_jobs(sagemaker)
+          stop_training_jobs(sagemaker, in_progress_jobs)
+        
+        shell: python
+
 
 # Longer-running code in examples/, may need BB repository
 

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -5,9 +5,9 @@ name: End-to-end Tests
 
 on:
   workflow_dispatch:
-  # pull_request: # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
-  #   branches:   # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
-  #     - main    # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+  pull_request: # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+    branches:   # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
+      - main    # Uncomment if you want to manually run the end-to-end tests against a new PR that you're drafting
 
 
 permissions:
@@ -28,15 +28,15 @@ jobs:
           role-to-assume: ${{ secrets.PROD_AWS_INTEG_TEST_ROLE_ARN }}
           role-session-name: integtestsession
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: Stop all left-over training jobs
-        run: |
-          aws sagemaker list-training-jobs --status-equals InProgress > running_jobs.json
-          jq -c '.[][]["TrainingJobName"]' running_jobs.json | while read i; do
-            jobName=`echo $i | cut -d "\"" -f 2`
-            echo "stopping training job $jobName"
-            aws sagemaker stop-training-job --training-job-name $jobName
-            sleep 5
-          done
+      # - name: Stop all left-over training jobs
+      #   run: |
+      #     aws sagemaker list-training-jobs --status-equals InProgress > running_jobs.json
+      #     jq -c '.[][]["TrainingJobName"]' running_jobs.json | while read i; do
+      #       jobName=`echo $i | cut -d "\"" -f 2`
+      #       echo "stopping training job $jobName"
+      #       aws sagemaker stop-training-job --training-job-name $jobName
+      #       sleep 5
+      #     done
 
 # Longer-running code in examples/, may need BB repository
 


### PR DESCRIPTION
## Problem: 

End-to-end tests are failing with the following error:
```
An error occurred (ThrottlingException) when calling the ListTrainingJobs operation (reached max retries: 2): Rate exceeded
Error: Process completed with exit code 254.
```

This is because the aws cli command is calling the API too quickly.

## Solution: 

- Call the API more slowly, with an embedded 2-second sleep between paginated calls to avoid throttling. 
- Rewrite script in Python for readability. 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
