### PR TITLE
fix: GitHub Actions not publishing Syne Tune to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,7 +4,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
## Context

We recently updated how the Syne Tune release process works. Now, we use Release Drafter to draft release notes. 

## Problem 

Upon creating our new release (`v0.5.0`), the [python-publish.yml](https://github.com/awslabs/syne-tune/blob/main/.github/workflows/python-publish.yml) GitHub Actions workflow failed to trigger. 

## Solution

Use the `published` type instead of `created`. This is because the `created` type isn't triggered when the release is drafted by automation versus a human. Use the `published` type instead.

See also:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
- https://stackoverflow.com/a/61066906/1380805

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
