### PR TITLE
refactor: Changes to benchmarking formalism

### DIFF
--- a/benchmarking/commons/hpo_main_local.py
+++ b/benchmarking/commons/hpo_main_local.py
@@ -134,9 +134,6 @@ def create_objects_for_tuner(
             },
         }
 
-    if map_method_args is not None:
-        method_kwargs = map_method_args(configuration, method, method_kwargs)
-
     method_kwargs.update(
         dict(
             config_space=benchmark.config_space,
@@ -147,6 +144,8 @@ def create_objects_for_tuner(
             verbose=verbose,
         )
     )
+    if map_method_args is not None:
+        method_kwargs = map_method_args(configuration, method, method_kwargs)
     scheduler = methods[method](MethodArguments(**method_kwargs))
 
     stop_criterion = StoppingCriterion(
@@ -277,7 +276,7 @@ def main(
     methods: MethodDefinitions,
     benchmark_definitions: RealBenchmarkDefinitions,
     extra_args: Optional[ExtraArgsType] = None,
-    map_extra_args: Optional[MapMethodArgsType] = None,
+    map_method_args: Optional[MapMethodArgsType] = None,
     extra_results: Optional[ExtraResultsComposer] = None,
 ):
     """
@@ -285,17 +284,19 @@ def main(
     over methods selected from ``methods`` and repetitions, both controlled by
     command line arguments.
 
-    ``map_extra_args`` can be used to modify ``method_kwargs`` for constructing
+    ``map_method_args`` can be used to modify ``method_kwargs`` for constructing
     :class:`~benchmarking.commons.baselines.MethodArguments`, depending on
-    ``configuration`` returned by :func:`parse_args` and the method. Its signature is
-    :code:`method_kwargs = map_extra_args(configuration, method, method_kwargs)`, where
-    ``method`` is the name of the baseline.
+    ``configuration`` returned by :func:`parse_args` and the method. Its
+    signature is
+    :code:`method_kwargs = map_method_args(configuration, method, method_kwargs)`,
+    where ``method`` is the name of the baseline. It is called just before the
+    method is created.
 
     :param methods: Dictionary with method constructors
     :param benchmark_definitions: Definitions of benchmarks; one is selected from
         command line arguments
     :param extra_args: Extra arguments for command line parser. Optional
-    :param map_extra_args: See above, optional
+    :param map_method_args: See above, optional
     :param extra_results: If given, this is used to append extra information to the
         results dataframe
     """
@@ -308,14 +309,14 @@ def main(
     methods = {mname: methods[mname] for mname in method_names}
     if extra_args is not None:
         assert (
-            map_extra_args is not None
-        ), "map_extra_args must be specified if extra_args is used"
+            map_method_args is not None
+        ), "map_method_args must be specified if extra_args is used"
 
     start_benchmark_local_backend(
         configuration,
         methods=methods,
         benchmark_definitions=benchmark_definitions,
-        map_method_args=map_extra_args,
+        map_method_args=map_method_args,
         extra_results=extra_results,
         extra_tuning_job_metadata=None
         if extra_args is None

--- a/benchmarking/commons/hpo_main_sagemaker.py
+++ b/benchmarking/commons/hpo_main_sagemaker.py
@@ -204,7 +204,7 @@ def main(
     methods: MethodDefinitions,
     benchmark_definitions: RealBenchmarkDefinitions,
     extra_args: Optional[ExtraArgsType] = None,
-    map_extra_args: Optional[MapMethodArgsType] = None,
+    map_method_args: Optional[MapMethodArgsType] = None,
     extra_results: Optional[ExtraResultsComposer] = None,
 ):
     """
@@ -215,12 +215,19 @@ def main(
     with ``seed=4``, or ``--method ASHA --num_seeds 1`` starts experiment with
     ``seed=0``. Here, ``ASHA`` must be key in ``methods``.
 
+    ``map_method_args`` can be used to modify ``method_kwargs`` for constructing
+    :class:`~benchmarking.commons.baselines.MethodArguments`, depending on
+    ``configuration`` returned by :func:`parse_args` and the method. Its
+    signature is
+    :code:`method_kwargs = map_method_args(configuration, method, method_kwargs)`,
+    where ``method`` is the name of the baseline. It is called just before the
+    method is created.
+
     :param methods: Dictionary with method constructors
     :param benchmark_definitions: Definitions of benchmark; one is selected from
         command line arguments
     :param extra_args: Extra arguments for command line parser. Optional
-    :param map_extra_args: Maps ``args`` returned by :func:`parse_args` to dictionary
-        for extra argument values. Needed if ``extra_args`` is given
+    :param map_method_args: See above. Needed if ``extra_args`` is given
     :param extra_results: If given, this is used to append extra information to the
         results dataframe
     """
@@ -233,14 +240,14 @@ def main(
     methods = {mname: methods[mname] for mname in method_names}
     if extra_args is not None:
         assert (
-            map_extra_args is not None
-        ), "map_extra_args must be specified if extra_args is used"
+            map_method_args is not None
+        ), "map_method_args must be specified if extra_args is used"
 
     start_benchmark_sagemaker_backend(
         configuration,
         methods=methods,
         benchmark_definitions=benchmark_definitions,
-        map_method_args=map_extra_args,
+        map_method_args=map_method_args,
         extra_results=extra_results,
         extra_tuning_job_metadata=None
         if extra_args is None

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -309,8 +309,6 @@ def start_benchmark_simulated_backend(
         if search_options:
             method_kwargs["scheduler_kwargs"] = {"search_options": search_options}
 
-        if map_method_args is not None:
-            method_kwargs = map_method_args(configuration, method, method_kwargs)
         method_kwargs.update(
             dict(
                 config_space=config_space,
@@ -321,6 +319,8 @@ def start_benchmark_simulated_backend(
                 verbose=configuration.verbose,
             )
         )
+        if map_method_args is not None:
+            method_kwargs = map_method_args(configuration, method, method_kwargs)
         scheduler = methods[method](MethodArguments(**method_kwargs))
 
         stop_criterion = StoppingCriterion(
@@ -365,7 +365,7 @@ def main(
     methods: MethodDefinitions,
     benchmark_definitions: SurrogateBenchmarkDefinitions,
     extra_args: Optional[ExtraArgsType] = None,
-    map_extra_args: Optional[MapMethodArgsType] = None,
+    map_method_args: Optional[MapMethodArgsType] = None,
     extra_results: Optional[ExtraResultsComposer] = None,
     use_transfer_learning: bool = False,
 ):
@@ -377,15 +377,16 @@ def main(
 
     ``map_method_args`` can be used to modify ``method_kwargs`` for constructing
     :class:`~benchmarking.commons.baselines.MethodArguments`, depending on
-    ``configuration`` and the method. This allows for extra flexibility to specify specific arguments for chosen methods
-    Its signature is :code:`method_kwargs = map_method_args(configuration, method, method_kwargs)`,
-    where ``method`` is the name of the baseline.
+    ``configuration`` returned by :func:`parse_args` and the method. Its
+    signature is
+    :code:`method_kwargs = map_method_args(configuration, method, method_kwargs)`,
+    where ``method`` is the name of the baseline. It is called just before the
+    method is created.
 
     :param methods: Dictionary with method constructors
     :param benchmark_definitions: Definitions of benchmarks
     :param extra_args: Extra arguments for command line parser. Optional
-    :param map_extra_args: Maps ``args`` returned by :func:`parse_args` to dictionary
-        for extra argument values. Needed if ``extra_args`` given
+    :param map_method_args: See above. Needed if ``extra_args`` given
     :param extra_results: If given, this is used to append extra information to the
         results dataframe
     :param use_transfer_learning: If True, we use transfer tuning. Defaults to
@@ -404,14 +405,14 @@ def main(
     methods = {mname: methods[mname] for mname in method_names}
     if extra_args is not None:
         assert (
-            map_extra_args is not None
-        ), "map_extra_args must be specified if extra_args is used"
+            map_method_args is not None
+        ), "map_method_args must be specified if extra_args is used"
 
     start_benchmark_simulated_backend(
         configuration,
         methods=methods,
         benchmark_definitions=benchmark_definitions,
-        map_method_args=map_extra_args,
+        map_method_args=map_method_args,
         extra_results=extra_results,
         extra_tuning_job_metadata=None
         if extra_args is None

--- a/benchmarking/nursery/benchmark_dehb/hpo_main.py
+++ b/benchmarking/nursery/benchmark_dehb/hpo_main.py
@@ -28,7 +28,7 @@ extra_args = [
 ]
 
 
-def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if args.num_brackets is not None:
         new_dict = {
             "scheduler_kwargs": {"brackets": args.num_brackets},
@@ -38,4 +38,4 @@ def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str
 
 
 if __name__ == "__main__":
-    main(methods, benchmark_definitions, extra_args, map_extra_args)
+    main(methods, benchmark_definitions, extra_args, map_method_args)

--- a/benchmarking/nursery/benchmark_dyhpo/hpo_main.py
+++ b/benchmarking/nursery/benchmark_dyhpo/hpo_main.py
@@ -50,7 +50,7 @@ extra_args = [
 ]
 
 
-def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     scheduler_kwargs = dict()
     if method.startswith("DYHPO"):
         if args.rung_increment is not None:
@@ -88,4 +88,4 @@ class DyHPOExtraResults(ExtraResultsComposer):
 
 if __name__ == "__main__":
     extra_results = DyHPOExtraResults()
-    main(methods, benchmark_definitions, extra_args, map_extra_args, extra_results)
+    main(methods, benchmark_definitions, extra_args, map_method_args, extra_results)

--- a/benchmarking/nursery/benchmark_hypertune/hpo_main.py
+++ b/benchmarking/nursery/benchmark_hypertune/hpo_main.py
@@ -34,7 +34,7 @@ extra_args = [
 ]
 
 
-def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if method.startswith("HYPERTUNE"):
         scheduler_kwargs = {
             "search_options": {"hypertune_distribution_num_samples": args.num_samples},
@@ -51,4 +51,4 @@ def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str
 
 
 if __name__ == "__main__":
-    main(methods, benchmark_definitions, extra_args, map_extra_args)
+    main(methods, benchmark_definitions, extra_args, map_method_args)

--- a/benchmarking/nursery/benchmark_neuralband/hpo_main.py
+++ b/benchmarking/nursery/benchmark_neuralband/hpo_main.py
@@ -28,7 +28,7 @@ extra_args = [
 ]
 
 
-def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def map_method_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if args.num_brackets is not None:
         new_dict = {
             "scheduler_kwargs": {"brackets": args.num_brackets},
@@ -38,4 +38,4 @@ def map_extra_args(args, method: str, method_kwargs: Dict[str, Any]) -> Dict[str
 
 
 if __name__ == "__main__":
-    main(methods, benchmark_definitions, extra_args, map_extra_args)
+    main(methods, benchmark_definitions, extra_args, map_method_args)

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -40,7 +40,7 @@ Let us look at the scripts in order, and how you can adapt them to your needs:
   training script may have additional dependencies, and they are combined with
   the ones here automatically, as detailed below.
 
-Extra arguments can be specified by ``extra_args``, ``map_extra_args``, and
+Extra arguments can be specified by ``extra_args``, ``map_method_args``, and
 extra results can be written using ``extra_results``, as is explained
 `here <bm_simulator.html#specifying-extra-arguments>`__.
 

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -43,7 +43,7 @@ per instance). This is because for the local backend to support ``n_workers=4``,
 the instance needs to have at least 4 GPUs, but for the SageMaker backend, each
 worker uses its own instance, so a cheaper instance type can be used.
 
-Extra arguments can be specified by ``extra_args``, ``map_extra_args``, and
+Extra arguments can be specified by ``extra_args``, ``map_method_args``, and
 extra results can be written using ``extra_results``, as is explained
 `here <bm_simulator.html#specifying-extra-arguments>`__.
 


### PR DESCRIPTION
This is mainly renaming `map_extra_args` to `map_method_args`, and also makes sure this mapping is executed just before the creation of the scheduler, which allows the mapping function to modify all arguments (for example, also the config space).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
