### PR TITLE
feat: add example to optimize hyperparams of HF models on SWAG

### DIFF
--- a/benchmarking/nursery/fine_tuning_hugging_face/multiple_choice_on_swag.py
+++ b/benchmarking/nursery/fine_tuning_hugging_face/multiple_choice_on_swag.py
@@ -19,8 +19,16 @@ from typing import Optional, Union
 
 from datasets import load_dataset
 
-from transformers import AutoModelForMultipleChoice, TrainingArguments, Trainer, AutoTokenizer
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase, PaddingStrategy
+from transformers import (
+    AutoModelForMultipleChoice,
+    TrainingArguments,
+    Trainer,
+    AutoTokenizer,
+)
+from transformers.tokenization_utils_base import (
+    PreTrainedTokenizerBase,
+    PaddingStrategy,
+)
 from transformers.trainer_callback import TrainerCallback
 
 from syne_tune.report import Reporter
@@ -67,8 +75,10 @@ class DataCollatorForMultipleChoice:
         labels = [feature.pop(label_name) for feature in features]
         batch_size = len(features)
         num_choices = len(features[0]["input_ids"])
-        flattened_features = [[{k: v[i] for k, v in feature.items()} for i in range(num_choices)] for feature in
-                              features]
+        flattened_features = [
+            [{k: v[i] for k, v in feature.items()} for i in range(num_choices)]
+            for feature in features
+        ]
         flattened_features = sum(flattened_features, [])
 
         batch = self.tokenizer.pad(
@@ -98,8 +108,10 @@ def preprocess_function(examples):
     # Grab all second sentences possible for each context.
     question_headers = examples["sent2"]
     ending_names = ["ending0", "ending1", "ending2", "ending3"]
-    second_sentences = [[f"{header} {examples[end][i]}" for end in ending_names] for i, header in
-                        enumerate(question_headers)]
+    second_sentences = [
+        [f"{header} {examples[end][i]}" for end in ending_names]
+        for i, header in enumerate(question_headers)
+    ]
 
     # Flatten everything
     first_sentences = sum(first_sentences, [])
@@ -108,7 +120,10 @@ def preprocess_function(examples):
     # Tokenize
     tokenized_examples = tokenizer(first_sentences, second_sentences, truncation=True)
     # Un-flatten
-    return {k: [v[i:i + 4] for i in range(0, len(v), 4)] for k, v in tokenized_examples.items()}
+    return {
+        k: [v[i : i + 4] for i in range(0, len(v), 4)]
+        for k, v in tokenized_examples.items()
+    }
 
 
 if __name__ == "__main__":
@@ -120,7 +135,7 @@ if __name__ == "__main__":
     parser.add_argument("--train_batch_size", type=int, default=8)
     parser.add_argument("--eval_batch_size", type=int, default=8)
     parser.add_argument("--warmup_ratio", type=float, default=0.0)
-    parser.add_argument("--lr_schedule", type=str, default='linear')
+    parser.add_argument("--lr_schedule", type=str, default="linear")
     parser.add_argument("--model_name", type=str)
     parser.add_argument("--learning_rate", type=float, default=5e-5)
     parser.add_argument("--weight_decay", type=float, default=0.0)
@@ -155,7 +170,7 @@ if __name__ == "__main__":
         lr_scheduler_type=args.lr_schedule,
         warmup_ratio=args.warmup_ratio,
         fp16=True,
-        save_strategy='no',
+        save_strategy="no",
     )
 
     trainer = Trainer(

--- a/benchmarking/nursery/fine_tuning_hugging_face/multiple_choice_on_swag.py
+++ b/benchmarking/nursery/fine_tuning_hugging_face/multiple_choice_on_swag.py
@@ -1,0 +1,173 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import torch
+import argparse
+import numpy as np
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from datasets import load_dataset
+
+from transformers import AutoModelForMultipleChoice, TrainingArguments, Trainer, AutoTokenizer
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase, PaddingStrategy
+from transformers.trainer_callback import TrainerCallback
+
+from syne_tune.report import Reporter
+
+
+class ReportBackMetrics(TrainerCallback):
+    """
+    This callback is used in order to report metrics back to Syne Tune, using a
+    ``Reporter`` object.
+
+    If ``test_dataset`` is given, we also compute and report test set metrics here.
+    These are just for final evaluations. HPO must use validation metrics (in
+    ``metrics`` passed to ``on_evaluate``).
+
+    If ``additional_info`` is given, it is a static dict reported with each call.
+    """
+
+    def __init__(self, trainer):
+        self.trainer = trainer
+        self.report = Reporter()
+
+    def on_evaluate(self, args, state, control, **kwargs):
+        # Metrics on train and validation set:
+        results = kwargs["metrics"].copy()
+        results["step"] = state.global_step
+        results["epoch"] = int(state.epoch)
+        # Report results back to Syne Tune
+        self.report(**results)
+
+
+@dataclass
+class DataCollatorForMultipleChoice:
+    """
+    Data collator that will dynamically pad the inputs for multiple choice received.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+
+    def __call__(self, features):
+        label_name = "label" if "label" in features[0].keys() else "labels"
+        labels = [feature.pop(label_name) for feature in features]
+        batch_size = len(features)
+        num_choices = len(features[0]["input_ids"])
+        flattened_features = [[{k: v[i] for k, v in feature.items()} for i in range(num_choices)] for feature in
+                              features]
+        flattened_features = sum(flattened_features, [])
+
+        batch = self.tokenizer.pad(
+            flattened_features,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors="pt",
+        )
+
+        # Un-flatten
+        batch = {k: v.view(batch_size, num_choices, -1) for k, v in batch.items()}
+        # Add back labels
+        batch["labels"] = torch.tensor(labels, dtype=torch.int64)
+        return batch
+
+
+def compute_metrics(eval_predictions):
+    predictions, label_ids = eval_predictions
+    preds = np.argmax(predictions, axis=1)
+    return {"accuracy": (preds == label_ids).astype(np.float32).mean().item()}
+
+
+def preprocess_function(examples):
+    # Repeat each first sentence four times to go with the four possibilities of second sentences.
+    first_sentences = [[context] * 4 for context in examples["sent1"]]
+    # Grab all second sentences possible for each context.
+    question_headers = examples["sent2"]
+    ending_names = ["ending0", "ending1", "ending2", "ending3"]
+    second_sentences = [[f"{header} {examples[end][i]}" for end in ending_names] for i, header in
+                        enumerate(question_headers)]
+
+    # Flatten everything
+    first_sentences = sum(first_sentences, [])
+    second_sentences = sum(second_sentences, [])
+
+    # Tokenize
+    tokenized_examples = tokenizer(first_sentences, second_sentences, truncation=True)
+    # Un-flatten
+    return {k: [v[i:i + 4] for i in range(0, len(v), 4)] for k, v in tokenized_examples.items()}
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    # hyperparameters sent by the client are passed as command-line arguments to the script.
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--train_batch_size", type=int, default=8)
+    parser.add_argument("--eval_batch_size", type=int, default=8)
+    parser.add_argument("--warmup_ratio", type=float, default=0.0)
+    parser.add_argument("--lr_schedule", type=str, default='linear')
+    parser.add_argument("--model_name", type=str)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--weight_decay", type=float, default=0.0)
+    parser.add_argument("--adam_beta1", type=float, default=0.9)
+    parser.add_argument("--adam_beta2", type=float, default=0.999)
+    parser.add_argument("--adam_epsilon", type=float, default=1e-8)
+    parser.add_argument("--max_grad_norm", type=float, default=1.0)
+
+    args, _ = parser.parse_known_args()
+
+    model_checkpoint = "bert-base-uncased"
+
+    datasets = load_dataset("swag", "regular")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, use_fast=True)
+
+    encoded_datasets = datasets.map(preprocess_function, batched=True)
+
+    model = AutoModelForMultipleChoice.from_pretrained(model_checkpoint)
+    n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(model_checkpoint, n_params)
+    model_name = model_checkpoint.split("/")[-1]
+
+    training_args = TrainingArguments(
+        f"{model_name}-finetuned-swag",
+        evaluation_strategy="epoch",
+        learning_rate=args.learning_rate,
+        per_device_train_batch_size=args.train_batch_size,
+        per_device_eval_batch_size=args.eval_batch_size,
+        num_train_epochs=args.epochs,
+        weight_decay=args.weight_decay,
+        lr_scheduler_type=args.lr_schedule,
+        warmup_ratio=args.warmup_ratio,
+        fp16=True,
+        save_strategy='no',
+    )
+
+    trainer = Trainer(
+        model,
+        training_args,
+        train_dataset=encoded_datasets["train"],
+        eval_dataset=encoded_datasets["validation"],
+        tokenizer=tokenizer,
+        data_collator=DataCollatorForMultipleChoice(tokenizer),
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.add_callback(ReportBackMetrics(trainer=trainer))
+
+    trainer.train()

--- a/benchmarking/nursery/fine_tuning_hugging_face/run_hpo.py
+++ b/benchmarking/nursery/fine_tuning_hugging_face/run_hpo.py
@@ -11,12 +11,13 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 import logging
+import matplotlib.pyplot as plt
 
 from sagemaker.huggingface import HuggingFace
 
 from syne_tune import Tuner, StoppingCriterion
 from syne_tune.backend import LocalBackend, SageMakerBackend
-from syne_tune.config_space import randint, loguniform, uniform
+from syne_tune.config_space import loguniform, uniform
 from syne_tune.optimizer.baselines import BayesianOptimization
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
     get_execution_role,
@@ -26,6 +27,7 @@ from syne_tune.experiments import load_experiment
 from syne_tune.constants import ST_TUNER_TIME
 
 logging.getLogger().setLevel(logging.INFO)
+
 
 config_space = {
     "learning_rate": loguniform(1e-6, 1e-4),

--- a/benchmarking/nursery/fine_tuning_hugging_face/run_hpo.py
+++ b/benchmarking/nursery/fine_tuning_hugging_face/run_hpo.py
@@ -1,0 +1,108 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+
+from sagemaker.huggingface import HuggingFace
+
+from syne_tune import Tuner, StoppingCriterion
+from syne_tune.backend import LocalBackend, SageMakerBackend
+from syne_tune.config_space import randint, loguniform, uniform
+from syne_tune.optimizer.baselines import BayesianOptimization
+from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
+    get_execution_role,
+    default_sagemaker_session,
+)
+from syne_tune.experiments import load_experiment
+from syne_tune.constants import ST_TUNER_TIME
+
+logging.getLogger().setLevel(logging.INFO)
+
+config_space = {
+    "learning_rate": loguniform(1e-6, 1e-4),
+    "per_device_train_batch_size": 8,
+    "warmup_ratio": uniform(0, 0.5),
+    'epochs': 3,
+    'weight_decay': uniform(0, 1e-1),
+    'adam_beta1': uniform(0.0, 0.9999),
+    'adam_beta2': uniform(0.0, 0.9999),
+    'adam_epsilon': loguniform(1e-10, 1e-6),
+    'max_grad_norm': uniform(0, 2)
+}
+
+# Default hyperparameter configuration from HuggingFace as specified in TrainingArguments
+default_config = {'learning_rate': 5e-5, 'warmup_ratio': 0.0, 'weight_decay': 0.0,
+                  'adam_beta1': 0.9, 'adam_beta2': 0.999, 'adam_epsilon': 1e-8, 'max_grad_norm': 1.0}
+
+entry_point = 'multiple_choice_on_swag.py'
+run_locally = False
+
+if run_locally:
+    trial_backend=LocalBackend(entry_point=entry_point, rotate_gpus=False)
+    n_workers = 1  # if we only have a single GPU, we can also only run a single worker
+else:
+    trial_backend = SageMakerBackend(
+        sm_estimator=HuggingFace(
+            instance_type='ml.g5.xlarge',
+            instance_count=1,
+            entry_point=str(entry_point),
+            role=get_execution_role(),
+            transformers_version='4.26',
+            pytorch_version='1.13',
+            py_version='py39',
+            max_run=10 * 600,
+            sagemaker_session=default_sagemaker_session(),
+            disable_profiler=True,
+            debugger_hook_config=False,
+        ),
+        metrics_names=['eval_accuracy'],
+    )
+    n_workers = 4  # runs 4 SageMaker Training Jobs in parallel
+
+
+tuner = Tuner(
+    trial_backend=trial_backend,
+    scheduler=BayesianOptimization(
+        config_space,
+        metric='eval_accuracy',
+        mode='max',
+        points_to_evaluate=[default_config]  # let's start with the default configuration
+    ),
+    stop_criterion=StoppingCriterion(max_wallclock_time=3600 * 5),
+    n_workers=n_workers,  # how many trials are evaluated in parallel
+)
+tuner.run()
+
+
+experiment = load_experiment(tuner.name)
+results = experiment.results
+metric_name = experiment.metadata['metric_names'][0]
+
+best_config = experiment.best_config()
+
+for trial_id, df_trial in results.groupby('trial_id'):
+    if trial_id == best_config['trial_id']:
+        plt.plot(df_trial[ST_TUNER_TIME], df_trial[metric_name], marker='o',
+                 color='red', label='best', linewidth=3)
+    elif trial_id == 0:
+        plt.plot(df_trial[ST_TUNER_TIME], df_trial[metric_name], marker='o',
+                 color='blue', label='default', linewidth=3)
+    else:
+        plt.plot(df_trial[ST_TUNER_TIME], df_trial[metric_name], marker='o',
+                 color='black', alpha=0.4, linewidth=1)
+
+plt.xlabel('wall-clock time (seconds)')
+plt.ylabel(metric_name.replace('_', '-'))
+plt.title('Fine-tuning on SWAG')
+plt.grid(alpha=0.4)
+plt.legend()
+plt.show()


### PR DESCRIPTION
Adds an example how to optimize hyperparameters for fine-tuning transformer models from the HuggingFace hub on the SWAG Q/A dataset. The example also shows how to visualize the optimization process. Future PR will extend this example to include more sophisticated techniques (e.g checkpointing) to accelerate the HPO process.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
