### PR TITLE
fix: Random seed initialisation in scheduler_searcher.py.

### DIFF
--- a/syne_tune/optimizer/schedulers/scheduler_searcher.py
+++ b/syne_tune/optimizer/schedulers/scheduler_searcher.py
@@ -42,7 +42,7 @@ class TrialSchedulerWithSearcher(TrialScheduler):
         # Generator for random seeds
         random_seed = kwargs.get("random_seed")
         if random_seed is None:
-            random_seed = np.random.randint(0, 2**32)
+            random_seed = np.random.randint(0, 2**31 - 1)
         logger.info(f"Master random_seed = {random_seed}")
         self.random_seed_generator = RandomSeedGenerator(random_seed)
 


### PR DESCRIPTION
Similar to #608 .

int32 is limited to 2**31-1. On windows this was resulting in a program crash when running `scheduler = BORE(conf_space, metric, random_seed=None)`. The problem did not occur when specifying the `random_seed`.

```
File c:\[...]\syne_tune\optimizer\schedulers\scheduler_searcher.py:45, in TrialSchedulerWithSearcher.__init__(self, config_space, **kwargs)
     43 random_seed = kwargs.get("random_seed")
     44 if random_seed is None:
---> 45     random_seed = np.random.randint(0, 2**32)
     46 logger.info(f"Master random_seed = {random_seed}")
     47 self.random_seed_generator = RandomSeedGenerator(random_seed)

File mtrand.pyx:746, in numpy.random.mtrand.RandomState.randint()

File _bounded_integers.pyx:1336, in numpy.random._bounded_integers._rand_int32()

ValueError: high is out of bounds for int32
```


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
