### PR TITLE
chore: only validate PR titles; specify list of valid prefixes

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,10 @@
+# conventional commit types: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+types:
+  - feat
+  - fix
+  - docs
+  - refactor
+  - chore
+  - revert
+
+titleOnly: true


### PR DESCRIPTION
Context: CI was failing for https://github.com/awslabs/syne-tune/pull/644, because the PR title followed the ConventionalCommits convention, but the *commit title itself* did not. The app by default requires that the PR title and at least one commit follows the convention. We do not actually need the commit itself to follow the convention, since when merging, GitHub will by default suggest that the PR title is used in the commit message. 

Fix: configure the app to only validate the PR title itself, to make it easier for people to start contributing to Syne Tune. 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
