### PR TITLE
fix: pin fastparquet version

### DIFF
--- a/benchmarking/nursery/benchmark_automl/requirements.txt
+++ b/benchmarking/nursery/benchmark_automl/requirements.txt
@@ -3,7 +3,7 @@ tqdm
 coolname
 numpy>=1.16.0, <1.24.0
 pandas
-fastparquet
+fastparquet==0.8.1
 s3fs
 scikit-learn
 h5py # note: only needed for fcnet

--- a/syne_tune/blackbox_repository/requirements.txt
+++ b/syne_tune/blackbox_repository/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.0, <1.24.0
 pandas
-fastparquet
+fastparquet==0.8.1
 s3fs
 scikit-learn
 xgboost


### PR DESCRIPTION
Closes #642 by setting fastparquet version. The library was updated and is not compatible anymore with LCBench dataset. If we want to update to more recent version, we could update the processing done to lcbench.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
