### PR TITLE
chore: run two additional examples as tests

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -158,6 +158,14 @@ jobs:
       requires-aws-credentials: true
     secrets: inherit
 
+  launch_lcbench_simulated:
+    needs: stop_all_training_jobs
+    uses: ./.github/workflows/run-syne-tune.yml
+    with:
+      script-path: examples/launch_lcbench_simulated.py
+      requires-aws-credentials: true
+    secrets: inherit
+
 # Code in docs/source/tutorials/basics/code
 
   launch_basics_tutorial_rs:

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -120,3 +120,8 @@ jobs:
     uses: ./.github/workflows/run-syne-tune.yml
     with:
       script-path: examples/launch_height_extra_results.py
+
+  example_automatic_termination_criterion:
+    uses: ./.github/workflows/run-syne-tune.yml
+    with:
+      script-path: examples/example_automatic_termination_criterion.py


### PR DESCRIPTION
Related to https://github.com/awslabs/syne-tune/pull/647. Runs two missing examples as tests.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
