### PR TITLE
docs: Alternative of 1-NN surrogate to restrict_configurations

### DIFF
--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -336,6 +336,24 @@ drawbacks:
   may perform better than they should, just because they nearly sample the
   space exhaustively
 
+In general, ``--restrict_configurations 1`` is supported for schedulers which
+select the next configuration from a finite set. In contrast, methods like
+``DEHB`` or ``BOHB`` (or Bayesian optimization with local acquisition function
+optimization) optimize over encoded vectors, then round the solution back to a
+configuration. In order to use a tabulated benchmark like ``lcbench`` with these
+methods, you need to specify a surrogate. Maybe the least intrusive surrogate
+is nearest neighbor. Here is the benchmark definition for ``lcbench``:
+
+.. literalinclude:: ../../../../benchmarking/commons/benchmark_definitions/lcbench.py
+   :caption: benchmarking/commons/benchmark_definitions/lcbench.py
+   :start-at: def lcbench_benchmark(dataset_name: str, datasets=None) -> SurrogateBenchmarkDefinition:
+   :end-before: lcbench_datasets = [
+
+The 1-NN surrogate is selected by ``surrogate="KNeighborsRegressor"`` and setting
+the number of nearest neighbors to 1. For each configuration, the surrogate finds
+the nearest neighbor in the table (w.r.t. Euclidean distance between encoded
+vectors) and returns its metric values.
+
 Selecting Benchmarks from benchmark_definitions
 -----------------------------------------------
 


### PR DESCRIPTION
Points out alternative to `restrict_configurations`, namely to use 1-NN surrogates.

Closes #505 .

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
