### PR TITLE
refactor: SurrogateModel -> Predictor; ModelFactory -> Estimator; Simplify bayesopt code

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/learncurve/posterior_state.py
@@ -184,12 +184,12 @@ class GaussProcAdditivePosteriorState(PosteriorState):
         std_data: float,
     ) -> np.ndarray:
         """
-        Implements SurrogateModel.backward_gradient, see comments there.
-        This is for a single posterior state. If the SurrogateModel uses
+        Implements Predictor.backward_gradient, see comments there.
+        This is for a single posterior state. If the Predictor uses
         MCMC, have to call this for every sample.
 
         :param input: Single input point x, shape (d,)
-        :param head_gradients: See SurrogateModel.backward_gradient
+        :param head_gradients: See Predictor.backward_gradient
         :param mean_data: Mean used to normalize targets
         :param std_data: Stddev used to normalize targets
         :return:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/gpautograd/posterior_state.py
@@ -92,12 +92,12 @@ class PosteriorState:
         std_data: float,
     ) -> np.ndarray:
         """
-        Implements SurrogateModel.backward_gradient, see comments there.
-        This is for a single posterior state. If the SurrogateModel uses
+        Implements Predictor.backward_gradient, see comments there.
+        This is for a single posterior state. If the Predictor uses
         MCMC, have to call this for every sample.
 
         :param input: Single input point x, shape (d,)
-        :param head_gradients: See SurrogateModel.backward_gradient
+        :param head_gradients: See Predictor.backward_gradient
         :param mean_data: Mean used to normalize targets
         :param std_data: Stddev used to normalize targets
         :return:
@@ -244,8 +244,8 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         std_data: float,
     ) -> np.ndarray:
         """
-        Implements SurrogateModel.backward_gradient, see comments there.
-        This is for a single posterior state. If the SurrogateModel uses
+        Implements Predictor.backward_gradient, see comments there.
+        This is for a single posterior state. If the Predictor uses
         MCMC, have to call this for every sample.
 
         The posterior represented here is based on normalized data, while
@@ -253,7 +253,7 @@ class GaussProcPosteriorState(PosteriorStateWithSampleJoint):
         distribution, which is why we need 'mean_data', 'std_data' here.
 
         :param input: Single input point x, shape (d,)
-        :param head_gradients: See SurrogateModel.backward_gradient
+        :param head_gradients: See Predictor.backward_gradient
         :param mean_data: Mean used to normalize targets
         :param std_data: Stddev used to normalize targets
         :return:
@@ -294,8 +294,8 @@ def backward_gradient_given_predict(
     std_data: float,
 ) -> np.ndarray:
     """
-    Implements SurrogateModel.backward_gradient, see comments there.
-    This is for a single posterior state. If the SurrogateModel uses
+    Implements Predictor.backward_gradient, see comments there.
+    This is for a single posterior state. If the Predictor uses
     MCMC, have to call this for every sample.
 
     The posterior represented here is based on normalized data, while
@@ -304,7 +304,7 @@ def backward_gradient_given_predict(
 
     :param predict_func: Function mapping input x to mean, variance
     :param input: Single input point x, shape (d,)
-    :param head_gradients: See SurrogateModel.backward_gradient
+    :param head_gradients: See Predictor.backward_gradient
     :param mean_data: Mean used to normalize targets
     :param std_data: Stddev used to normalize targets
     :return:

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/cost_fifo_model.py
@@ -14,11 +14,9 @@ from typing import Dict, List, Set
 import numpy as np
 import logging
 
-from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer import (
-    TransformerModelFactory,
-)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import Estimator
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_base import (
-    BaseSurrogateModel,
+    BasePredictor,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.cost.cost_model import (
     CostModel,
@@ -27,13 +25,13 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
     TuningJobState,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
-    SurrogateModel,
+    Predictor,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class CostFixedResourceSurrogateModel(BaseSurrogateModel):
+class CostFixedResourcePredictor(BasePredictor):
     """
     Wraps cost model :math:`c(x, r)` of :class:`CostModel` to be used as
     surrogate model, where predictions are done at r = ``fixed_resource``.
@@ -115,7 +113,7 @@ class CostFixedResourceSurrogateModel(BaseSurrogateModel):
         raise NotImplementedError()
 
 
-class CostSurrogateModelFactory(TransformerModelFactory):
+class CostEstimator(Estimator):
     """
     The name of the cost metric is ``model.cost_metric_name``.
 
@@ -145,14 +143,14 @@ class CostSurrogateModelFactory(TransformerModelFactory):
         assert resource >= 1, "Must be positive integer"
         self._fixed_resource = resource
 
-    def model(self, state: TuningJobState, fit_params: bool) -> SurrogateModel:
+    def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:
         """
         Models of type :class:`CostModel` do not have hyperparameters to be
-        fit, so ``fit_params`` is ignored here (TODO?).
+        fit, so ``update_params`` is ignored here.
 
         """
         self._model.update(state)
-        return CostFixedResourceSurrogateModel(
+        return CostFixedResourcePredictor(
             state=state,
             model=self._model,
             fixed_resource=self._fixed_resource,

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/estimator.py
@@ -1,0 +1,204 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, Union
+
+import numpy as np
+
+from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
+    FantasizedPendingEvaluation,
+    INTERNAL_METRIC_NAME,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
+    TuningJobState,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
+    Predictor,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
+    DebugLogPrinter,
+)
+
+
+class Estimator:
+    """
+    Interface for surrogate models used in :class:`ModelStateTransformer`.
+
+    In general, a surrogate model is probabilistic (or Bayesian), in that
+    predictions are driven by a posterior distribution, represented in a
+    posterior state of type
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes.Predictor`.
+    The model may also come with tunable (hyper)parameters, such as for example
+    covariance function parameters for a Gaussian process model. These parameters
+    can be accessed with :meth:`get_params`, :meth:`set_params`.
+    """
+
+    def get_params(self) -> Dict[str, Any]:
+        """
+        :return: Current tunable model parameters
+        """
+        raise NotImplementedError()
+
+    def set_params(self, param_dict: Dict[str, Any]):
+        """
+        :param param_dict: New model parameters
+        """
+        raise NotImplementedError()
+
+    def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:
+        """
+        Creates a
+        :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes.Predictor`
+        object based on data in ``state``. For a Bayesian model, this involves
+        computing the posterior state, which is wrapped in the ``Predictor``
+        object.
+
+        If the model also has (hyper)parameters, these are learned iff
+        ``update_params == True``. Otherwise, these parameters are not changed,
+        but only the posterior state is computed. The idea is that in general,
+        model fitting is much more expensive than just creating the final posterior
+        state (or predictor). It then makes sense to partly work with stale model
+        parameters.
+
+        If your surrogate model is not Bayesian, or does not have hyperparameters,
+        you can ignore the ``update_params`` argument,
+
+        :param state: Current data model parameters are to be fit on, and the
+            posterior state is to be computed from
+        :param update_params: See above
+        :return: Predictor, wrapping the posterior state
+        """
+        raise NotImplementedError()
+
+    @property
+    def debug_log(self) -> Optional[DebugLogPrinter]:
+        return None
+
+    def configure_scheduler(self, scheduler):
+        """
+        Called by :meth:`configure_scheduler` of searchers which make use of an
+        class:``Estimator``. Allows the estimator to depend on
+        parameters of the scheduler.
+
+        :param scheduler: Scheduler object
+        """
+        pass
+
+
+# Convenience type allowing for multi-output HPO. These are used for methods
+# that work both in the standard case of a single output model and in the
+# multi-output case
+
+OutputEstimator = Union[Estimator, Dict[str, Estimator]]
+
+
+@dataclass
+class TransformedData:
+    features: np.ndarray
+    targets: np.ndarray
+    mean: float
+    std: float
+
+
+def transform_state_to_data(
+    state: TuningJobState,
+    active_metric: Optional[str] = None,
+    normalize_targets: bool = True,
+    num_fantasy_samples: int = 1,
+) -> TransformedData:
+    """
+    Transforms
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state.TuningJobState`
+    object ``state`` to features and targets. The former are encoded vectors from
+    ``state.hp_ranges``. The latter are normalized to zero mean, unit variance if
+    ``normalize_targets == True``, in which case the original mean and stddev is
+    also returned.
+
+    If ``state.pending_evaluations`` is not empty, it must contain entries
+    of type
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common.FantasizedPendingEvaluation`,
+    which contain the fantasy samples. This is the case only for internal states.
+
+    :param state: ``TuningJobState`` to transform
+    :param active_metric: Name of target metric (optional)
+    :param normalize_targets: Normalize targets? Defaults to ``True``
+    :param num_fantasy_samples: Number of fantasy samples. Defaults to 1
+    :return: Transformed data
+    """
+    if active_metric is None:
+        active_metric = INTERNAL_METRIC_NAME
+    candidates, evaluation_values = state.observed_data_for_metric(
+        metric_name=active_metric
+    )
+    hp_ranges = state.hp_ranges
+    features = hp_ranges.to_ndarray_matrix(candidates)
+    # Normalize
+    # Note: The fantasy values in state.pending_evaluations are sampled
+    # from the model fit to normalized targets, so they are already
+    # normalized
+    targets = np.vstack(evaluation_values).reshape((-1, 1))
+    mean = 0.0
+    std = 1.0
+    if normalize_targets:
+        std = max(np.std(targets).item(), 1e-9)
+        mean = np.mean(targets).item()
+        targets = (targets - mean) / std
+    if state.pending_evaluations:
+        # In this case, y becomes a matrix, where the observed values are
+        # broadcast
+        cand_lst = [
+            hp_ranges.to_ndarray(config) for config in state.pending_configurations()
+        ]
+        fanta_lst = []
+        for pending_eval in state.pending_evaluations:
+            assert isinstance(
+                pending_eval, FantasizedPendingEvaluation
+            ), "state.pending_evaluations has to contain FantasizedPendingEvaluation"
+            fantasies = pending_eval.fantasies[active_metric]
+            assert (
+                fantasies.size == num_fantasy_samples
+            ), "All state.pending_evaluations entries must have length {}".format(
+                num_fantasy_samples
+            )
+            fanta_lst.append(fantasies.reshape((1, -1)))
+        targets = np.vstack([targets * np.ones((1, num_fantasy_samples))] + fanta_lst)
+        features = np.vstack([features] + cand_lst)
+    return TransformedData(features, targets, mean, std)
+
+
+class EstimatorFromTransformedData(Estimator):
+    def _fit(self, data: TransformedData, update_params: bool) -> Predictor:
+        """
+        Implements :meth:`fit_from_state`, given transformed data.
+
+        :param data: Transformed data (features, targets)
+        :param update_params: Should model (hyper)parameters be updated?
+        :return: Predictor, wrapping the posterior state
+        """
+        raise NotImplementedError()
+
+    @property
+    def normalize_targets(self) -> bool:
+        """
+        :return: Should targets in ``state`` be normalized before calling
+            :meth:`_fit`?
+        """
+        raise NotImplementedError()
+
+    def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:
+        return self._fit(
+            data=transform_state_to_data(
+                state=state, normalize_targets=self.normalize_targets
+            ),
+            update_params=update_params,
+        )

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_mcmc_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_mcmc_model.py
@@ -20,7 +20,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges import (
     HyperparameterRanges,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    GaussProcModelFactory,
+    GaussProcEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
     DebugLogPrinter,
@@ -33,7 +33,7 @@ from syne_tune.optimizer.schedulers.searchers.utils.common import ConfigurationF
 logger = logging.getLogger(__name__)
 
 
-class GaussProcMCMCModelFactory(GaussProcModelFactory):
+class GaussProcMCMCEstimator(GaussProcEstimator):
     """
     We support pending evaluations via fantasizing. Note that state does
     not contain the fantasy values, but just the pending configs. Fantasy

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/gp_model.py
@@ -13,13 +13,13 @@
 from typing import Dict, List, Optional, Union
 import numpy as np
 import logging
-from dataclasses import dataclass
 
-from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_transformer import (
-    TransformerModelFactory,
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import (
+    Estimator,
+    transform_state_to_data,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.model_base import (
-    BaseSurrogateModel,
+    BasePredictor,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
     FantasizedPendingEvaluation,
@@ -49,7 +49,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.posterior_stat
     PosteriorState,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
-    SurrogateModel,
+    Predictor,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.debug_log import (
     DebugLogPrinter,
@@ -67,7 +67,7 @@ GPModel = Union[
 ]
 
 
-class GaussProcSurrogateModel(BaseSurrogateModel):
+class GaussProcPredictor(BasePredictor):
     """
     Gaussian process surrogate model, where model parameters are either fit by
     marginal likelihood maximization
@@ -147,7 +147,12 @@ class GaussProcSurrogateModel(BaseSurrogateModel):
             len(poster_states), len(head_gradients)
         )
         return [
-            poster_state.backward_gradient(input, head_gradient, self.mean, self.std)
+            poster_state.backward_gradient(
+                input=input,
+                head_gradients=head_gradient,
+                mean_data=self.mean,
+                std_data=self.std,
+            )
             for poster_state, head_gradient in zip(poster_states, head_gradients)
         ]
 
@@ -171,63 +176,7 @@ class GaussProcSurrogateModel(BaseSurrogateModel):
         return candidates
 
 
-@dataclass
-class InternalCandidateEvaluations:
-    features: np.ndarray
-    targets: np.ndarray
-    mean: float
-    std: float
-
-
-# Note: If state.pending_evaluations is not empty, it must contain entries
-# of type FantasizedPendingEvaluation, which contain the fantasy samples. This
-# is the case only for internal states.
-def get_internal_candidate_evaluations(
-    state: TuningJobState,
-    active_metric: str,
-    normalize_targets: bool,
-    num_fantasy_samples: int,
-) -> InternalCandidateEvaluations:
-    candidates, evaluation_values = state.observed_data_for_metric(
-        metric_name=active_metric
-    )
-    hp_ranges = state.hp_ranges
-    features = hp_ranges.to_ndarray_matrix(candidates)
-    # Normalize
-    # Note: The fantasy values in state.pending_evaluations are sampled
-    # from the model fit to normalized targets, so they are already
-    # normalized
-    targets = np.vstack(evaluation_values).reshape((-1, 1))
-    mean = 0.0
-    std = 1.0
-    if normalize_targets:
-        std = max(np.std(targets).item(), 1e-9)
-        mean = np.mean(targets).item()
-        targets = (targets - mean) / std
-    if state.pending_evaluations:
-        # In this case, y becomes a matrix, where the observed values are
-        # broadcast
-        cand_lst = [
-            hp_ranges.to_ndarray(config) for config in state.pending_configurations()
-        ]
-        fanta_lst = []
-        for pending_eval in state.pending_evaluations:
-            assert isinstance(
-                pending_eval, FantasizedPendingEvaluation
-            ), "state.pending_evaluations has to contain FantasizedPendingEvaluation"
-            fantasies = pending_eval.fantasies[active_metric]
-            assert (
-                fantasies.size == num_fantasy_samples
-            ), "All state.pending_evaluations entries must have length {}".format(
-                num_fantasy_samples
-            )
-            fanta_lst.append(fantasies.reshape((1, -1)))
-        targets = np.vstack([targets * np.ones((1, num_fantasy_samples))] + fanta_lst)
-        features = np.vstack([features] + cand_lst)
-    return InternalCandidateEvaluations(features, targets, mean, std)
-
-
-class GaussProcModelFactory(TransformerModelFactory):
+class GaussProcEstimator(Estimator):
     """
     We support pending evaluations via fantasizing. Note that state does
     not contain the fantasy values, but just the pending configs. Fantasy
@@ -241,7 +190,7 @@ class GaussProcModelFactory(TransformerModelFactory):
         computing incumbent
     :param no_fantasizing: If True, pending evaluations in the state are
         simply ignored, fantasizing is not done (not recommended)
-    :param hp_ranges_for_prediction: If given, :class:`GaussProcSurrogateModel`
+    :param hp_ranges_for_prediction: If given, :class:`GaussProcPredictor`
         should use this instead of ``state.hp_ranges``
     """
 
@@ -273,12 +222,12 @@ class GaussProcModelFactory(TransformerModelFactory):
     def gpmodel(self) -> GPModel:
         return self._gpmodel
 
-    def model(self, state: TuningJobState, fit_params: bool) -> SurrogateModel:
+    def fit_from_state(self, state: TuningJobState, update_params: bool) -> Predictor:
         """
-        Parameters of ``self._gpmodel`` are optimized iff ``fit_params``. This
+        Parameters of ``self._gpmodel`` are optimized iff ``update_params``. This
         requires ``state`` to contain labeled examples.
 
-        If self.state.pending_evaluations is not empty, we proceed as follows:
+        If ``self.state.pending_evaluations`` is not empty, we proceed as follows:
 
         * Compute posterior for state without pending evals
         * Draw fantasy values for pending evals
@@ -296,16 +245,16 @@ class GaussProcModelFactory(TransformerModelFactory):
                 trials_evaluations=state.trials_evaluations,
                 failed_trials=state.failed_trials,
             )
-        self._posterior_for_state(no_pending_state, fit_params=fit_params)
+        self._posterior_for_state(no_pending_state, update_params=update_params)
         if state.pending_evaluations and not self._no_fantasizing:
             # Sample fantasy values for pending evaluations
             state_with_fantasies = self._draw_fantasy_values(state)
             # Compute posterior for state with pending evals
-            self._posterior_for_state(state_with_fantasies, fit_params=False)
+            self._posterior_for_state(state_with_fantasies, update_params=False)
             fantasy_samples = state_with_fantasies.pending_evaluations
         else:
             fantasy_samples = []
-        return GaussProcSurrogateModel(
+        return GaussProcPredictor(
             state=state,
             active_metric=self.active_metric,
             gpmodel=self._gpmodel,
@@ -322,7 +271,7 @@ class GaussProcModelFactory(TransformerModelFactory):
     def _posterior_for_state(
         self,
         state: TuningJobState,
-        fit_params: bool,
+        update_params: bool,
     ):
         """
         Computes posterior for state.
@@ -336,7 +285,7 @@ class GaussProcModelFactory(TransformerModelFactory):
             "Cannot compute posterior: state has no labeled datapoints "
             + f"for metric {self.active_metric}"
         )
-        internal_candidate_evaluations = get_internal_candidate_evaluations(
+        internal_candidate_evaluations = transform_state_to_data(
             state,
             self.active_metric,
             self.normalize_targets,
@@ -348,9 +297,9 @@ class GaussProcModelFactory(TransformerModelFactory):
         self._mean = internal_candidate_evaluations.mean
         self._std = internal_candidate_evaluations.std
 
-        fit_params = fit_params and (not state.pending_evaluations)
+        update_params = update_params and (not state.pending_evaluations)
         data = {"features": features, "targets": targets}
-        if not fit_params:
+        if not update_params:
             if self._debug_log is not None:
                 logger.info("Recomputing posterior state")
             self._gpmodel.recompute_states(data)
@@ -442,7 +391,7 @@ class GaussProcModelFactory(TransformerModelFactory):
             self._gpmodel.create_likelihood(rung_levels)
 
 
-class GaussProcEmpiricalBayesModelFactory(GaussProcModelFactory):
+class GaussProcEmpiricalBayesEstimator(GaussProcEstimator):
     """
     We support pending evaluations via fantasizing. Note that state does
     not contain the fantasy values, but just the pending configs. Fantasy

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_base.py
@@ -18,17 +18,17 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
     TuningJobState,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
-    SurrogateModel,
+    Predictor,
 )
 from syne_tune.optimizer.schedulers.searchers.utils.common import ConfigurationFilter
 
 logger = logging.getLogger(__name__)
 
 
-class BaseSurrogateModel(SurrogateModel):
+class BasePredictor(Predictor):
     """
     Base class for (most)
-    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes.SurrogateModel`
+    :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes.Predictor`
     implementations, provides common code.
     """
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/utils/comparison_gpy.py
@@ -27,8 +27,8 @@ from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_state import (
     TuningJobState,
 )
-from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    get_internal_candidate_evaluations,
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import (
+    transform_state_to_data,
 )
 
 
@@ -145,7 +145,7 @@ def expand_data(data: Dict[str, Any]) -> Dict[str, Any]:
     if "state" not in data:
         data = copy.copy(data)
         state = data_to_state(data)
-        data_internal = get_internal_candidate_evaluations(
+        data_internal = transform_state_to_data(
             state,
             active_metric=INTERNAL_METRIC_NAME,
             normalize_targets=True,

--- a/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/constrained/constrained_gp_fifo_searcher.py
@@ -102,11 +102,11 @@ class ConstrainedGPFIFOSearcher(MultiModelGPFIFOSearcher):
         # Create clone with mutable state taken from 'state'
         init_state = decode_state(state["state"], self._hp_ranges_in_state())
         output_skip_optimization = state["skip_optimization"]
-        output_model_factory = self.state_transformer.model_factory
+        output_estimator = self.state_transformer.estimator
         # Call internal constructor
         new_searcher = ConstrainedGPFIFOSearcher(
             **self._new_searcher_kwargs_for_clone(),
-            output_model_factory=output_model_factory,
+            output_estimator=output_estimator,
             init_state=init_state,
             output_skip_optimization=output_skip_optimization,
             constraint_attr=self._constraint_attr,

--- a/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/cost_aware/cost_aware_gp_fifo_searcher.py
@@ -44,15 +44,15 @@ class MultiModelGPFIFOSearcher(GPFIFOSearcher):
     """
 
     def _call_create_internal(self, kwargs_int):
-        output_model_factory = kwargs_int.pop("output_model_factory")
+        output_estimator = kwargs_int.pop("output_estimator")
         output_skip_optimization = kwargs_int.pop("output_skip_optimization")
-        kwargs_int["model_factory"] = output_model_factory[INTERNAL_METRIC_NAME]
+        kwargs_int["estimator"] = output_estimator[INTERNAL_METRIC_NAME]
         kwargs_int["skip_optimization"] = output_skip_optimization[INTERNAL_METRIC_NAME]
         self._create_internal(**kwargs_int)
         # Replace ``state_transformer``
         init_state = self.state_transformer.state
         self.state_transformer = ModelStateTransformer(
-            model_factory=output_model_factory,
+            estimator=output_estimator,
             init_state=init_state,
             skip_optimization=output_skip_optimization,
         )
@@ -140,11 +140,11 @@ class CostAwareGPFIFOSearcher(MultiModelGPFIFOSearcher):
         # Create clone with mutable state taken from 'state'
         init_state = decode_state(state["state"], self._hp_ranges_in_state())
         output_skip_optimization = state["skip_optimization"]
-        output_model_factory = self.state_transformer.model_factory
+        output_estimator = self.state_transformer.estimator
         # Call internal constructor
         new_searcher = CostAwareGPFIFOSearcher(
             **self._new_searcher_kwargs_for_clone(),
-            output_model_factory=output_model_factory,
+            output_estimator=output_estimator,
             init_state=init_state,
             output_skip_optimization=output_skip_optimization,
         )

--- a/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_fifo_searcher.py
@@ -282,11 +282,11 @@ class GPFIFOSearcher(BayesianOptimizationSearcher):
         # Create clone with mutable state taken from 'state'
         init_state = decode_state(state["state"], self._hp_ranges_in_state())
         skip_optimization = state["skip_optimization"]
-        model_factory = self.state_transformer.model_factory
+        estimator = self.state_transformer.estimator
         # Call internal constructor
         new_searcher = GPFIFOSearcher(
             **self._new_searcher_kwargs_for_clone(),
-            model_factory=model_factory,
+            estimator=estimator,
             init_state=init_state,
             skip_optimization=skip_optimization,
         )

--- a/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/gp_multifidelity_searcher.py
@@ -270,11 +270,11 @@ class GPMultiFidelitySearcher(GPFIFOSearcher):
         # Create clone with mutable state taken from 'state'
         init_state = decode_state(state["state"], self._hp_ranges_in_state())
         skip_optimization = state["skip_optimization"]
-        model_factory = self.state_transformer.model_factory
+        estimator = self.state_transformer.estimator
         # Call internal constructor
         new_searcher = GPMultiFidelitySearcher(
             **self._new_searcher_kwargs_for_clone(),
-            model_factory=model_factory,
+            estimator=estimator,
             init_state=init_state,
             skip_optimization=skip_optimization,
             config_space_ext=self.config_space_ext,

--- a/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_bracket_distribution.py
+++ b/syne_tune/optimizer/schedulers/searchers/hypertune/hypertune_bracket_distribution.py
@@ -13,7 +13,7 @@ import numpy as np
 import logging
 
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    GaussProcModelFactory,
+    GaussProcEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.hypertune.gp_model import (
     HyperTuneIndependentGPModel,
@@ -56,14 +56,14 @@ class HyperTuneBracketDistribution(DefaultHyperbandBracketDistribution):
 
     def __call__(self) -> np.ndarray:
         distribution = super().__call__()
-        model_factory = self._searcher.state_transformer.model_factory
+        estimator = self._searcher.state_transformer.estimator
         err_msg = (
-            "Hyper-Tune requires GaussProcModelFactory model factory with "
+            "Hyper-Tune requires GaussProcEstimator estimator with "
             "HyperTuneIndependentGPModel or HyperTuneJointGPModel model. Use "
             "searcher = 'hypertune'"
         )
-        assert isinstance(model_factory, GaussProcModelFactory), err_msg
-        gpmodel = model_factory.gpmodel
+        assert isinstance(estimator, GaussProcEstimator), err_msg
+        gpmodel = estimator.gpmodel
         assert isinstance(
             gpmodel, (HyperTuneIndependentGPModel, HyperTuneJointGPModel)
         ), err_msg

--- a/tst/schedulers/bayesopt/gpautograd/test_comparison_gpy.py
+++ b/tst/schedulers/bayesopt/gpautograd/test_comparison_gpy.py
@@ -21,7 +21,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
     INTERNAL_METRIC_NAME,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    GaussProcEmpiricalBayesModelFactory,
+    GaussProcEmpiricalBayesEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.gpautograd.gp_regression import (
     GaussianProcessRegression,
@@ -110,11 +110,11 @@ def fit_predict_ours(
         optimization_config=optimization_config,
         random_seed=random_seed,
     )
-    model_factory = GaussProcEmpiricalBayesModelFactory(
+    estimator = GaussProcEmpiricalBayesEstimator(
         active_metric=INTERNAL_METRIC_NAME, gpmodel=_gpmodel, num_fantasy_samples=20
     )
-    model = model_factory.model(data["state"], fit_params=True)
-    model_params = model_factory.get_params()
+    model = estimator.fit_from_state(data["state"], update_params=True)
+    model_params = estimator.get_params()
     print("Hyperparameters: {}".format(model_params))
     # Prediction
     predictions = model.predict(data["test_inputs"])[0]

--- a/tst/schedulers/bayesopt/test_bayesopt_ei.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_ei.py
@@ -33,11 +33,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc im
     ActiveMetricCurrentBestProvider,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    GaussProcSurrogateModel,
-    GaussProcEmpiricalBayesModelFactory,
+    GaussProcPredictor,
+    GaussProcEmpiricalBayesEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_mcmc_model import (
-    GaussProcMCMCModelFactory,
+    GaussProcMCMCEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.bo_algorithm_components import (
     LBFGSOptimizeAcquisition,
@@ -71,7 +71,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import
 #
 # In fact, if EI is optimized starting at a point outside [0, 0.1]^2, the optimizer
 # returns with the starting point, and test_optimization_improves fails.
-def default_models(do_mcmc=True) -> List[GaussProcSurrogateModel]:
+def default_models(do_mcmc=True) -> List[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
@@ -82,18 +82,18 @@ def default_models(do_mcmc=True) -> List[GaussProcSurrogateModel]:
     gpmodel = default_gpmodel(
         state, random_seed=random_seed, optimization_config=DEFAULT_OPTIMIZATION_CONFIG
     )
-    model_factory = GaussProcEmpiricalBayesModelFactory(
+    estimator = GaussProcEmpiricalBayesEstimator(
         active_metric=INTERNAL_METRIC_NAME, gpmodel=gpmodel, num_fantasy_samples=20
     )
-    result = [model_factory.model(state, fit_params=True)]
+    result = [estimator.fit_from_state(state, update_params=True)]
     if do_mcmc:
         gpmodel_mcmc = default_gpmodel_mcmc(
             state, random_seed=random_seed, mcmc_config=DEFAULT_MCMC_CONFIG
         )
-        model_factory = GaussProcMCMCModelFactory(
+        estimator = GaussProcMCMCEstimator(
             active_metric=INTERNAL_METRIC_NAME, gpmodel=gpmodel_mcmc
         )
-        result.append(model_factory.model(state, fit_params=True))
+        result.append(estimator.fit_from_state(state, update_params=True))
     return result
 
 

--- a/tst/schedulers/bayesopt/test_bayesopt_eipu.py
+++ b/tst/schedulers/bayesopt/test_bayesopt_eipu.py
@@ -33,11 +33,11 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.models.meanstd_acqfunc im
     ActiveMetricCurrentBestProvider,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    GaussProcSurrogateModel,
-    GaussProcEmpiricalBayesModelFactory,
+    GaussProcPredictor,
+    GaussProcEmpiricalBayesEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_mcmc_model import (
-    GaussProcMCMCModelFactory,
+    GaussProcMCMCEstimator,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.bo_algorithm_components import (
     LBFGSOptimizeAcquisition,
@@ -54,7 +54,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import
 COST_METRIC_NAME = "cost_metric"
 
 
-def default_models(metric, do_mcmc=True) -> List[GaussProcSurrogateModel]:
+def default_models(metric, do_mcmc=True) -> List[GaussProcPredictor]:
     config_space = {"x": uniform(0.0, 1.0), "y": uniform(0.0, 1.0)}
     hp_ranges = make_hyperparameter_ranges(config_space)
     X = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
@@ -71,18 +71,16 @@ def default_models(metric, do_mcmc=True) -> List[GaussProcSurrogateModel]:
     gpmodel = default_gpmodel(
         state, random_seed=random_seed, optimization_config=DEFAULT_OPTIMIZATION_CONFIG
     )
-    model_factory = GaussProcEmpiricalBayesModelFactory(
+    estimator = GaussProcEmpiricalBayesEstimator(
         active_metric=metric, gpmodel=gpmodel, num_fantasy_samples=2
     )
-    result = [model_factory.model(state, fit_params=True)]
+    result = [estimator.fit_from_state(state, update_params=True)]
     if do_mcmc:
         gpmodel_mcmc = default_gpmodel_mcmc(
             state, random_seed=random_seed, mcmc_config=DEFAULT_MCMC_CONFIG
         )
-        model_factory = GaussProcMCMCModelFactory(
-            active_metric=metric, gpmodel=gpmodel_mcmc
-        )
-        result.append(model_factory.model(state, fit_params=True))
+        estimator = GaussProcMCMCEstimator(active_metric=metric, gpmodel=gpmodel_mcmc)
+        result.append(estimator.fit_from_state(state, update_params=True))
     return result
 
 

--- a/tst/schedulers/bayesopt/test_bo_algorithm_functions.py
+++ b/tst/schedulers/bayesopt/test_bo_algorithm_functions.py
@@ -99,7 +99,7 @@ def test_lazily_locally_optimize():
         candidates=original_candidates,
         local_optimizer=NoOptimization(None, None, None),
         hp_ranges=hp_ranges,
-        model=None,
+        predictor=None,
     ):
         # no optimization is applied ot the candidates
         assert candidate[0] == original_candidates[i]
@@ -114,7 +114,7 @@ def test_lazily_locally_optimize():
                     candidates=[],
                     local_optimizer=NoOptimization(None, None, None),
                     hp_ranges=hp_ranges,
-                    model=None,
+                    predictor=None,
                 )
             )
         )

--- a/tst/schedulers/bayesopt/test_gp_components.py
+++ b/tst/schedulers/bayesopt/test_gp_components.py
@@ -12,8 +12,8 @@
 # permissions and limitations under the License.
 import numpy as np
 
-from syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model import (
-    get_internal_candidate_evaluations,
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import (
+    transform_state_to_data,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
     dictionarize_objective,
@@ -47,7 +47,7 @@ def test_get_internal_candidate_evaluations():
     )
     state.failed_trials.append("0")  # First trial with observation also failed
 
-    result = get_internal_candidate_evaluations(
+    result = transform_state_to_data(
         state, INTERNAL_METRIC_NAME, normalize_targets=True, num_fantasy_samples=20
     )
 

--- a/tst/schedulers/bayesopt/test_transferlearning.py
+++ b/tst/schedulers/bayesopt/test_transferlearning.py
@@ -78,7 +78,7 @@ def test_create_transfer_learning():
     expected_mat = np.array([[x[i] for x in expected_ndarray_bounds] for i in range(2)])
     np.testing.assert_almost_equal(mat, expected_mat)
 
-    kernel = kwargs_int["model_factory"]._gpmodel.likelihood.kernel
+    kernel = kwargs_int["estimator"]._gpmodel.likelihood.kernel
     assert isinstance(kernel, ProductKernelFunction)
     kernel1 = kernel.kernel1
     assert isinstance(kernel1, Matern52)


### PR DESCRIPTION
This is doing a substantial amount of refactoring (mostly renaming), in line with what Jacek is proposing.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
