### PR TITLE
feat: Allow to skip initial jobs in remote launching

### DIFF
--- a/benchmarking/commons/launch_remote_common.py
+++ b/benchmarking/commons/launch_remote_common.py
@@ -16,6 +16,7 @@ from typing import Optional, Dict, Any
 import benchmarking
 import syne_tune
 from benchmarking.commons.benchmark_definitions.common import BenchmarkDefinition
+from benchmarking.commons.hpo_main_common import ExtraArgsType
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
     get_execution_role,
 )
@@ -67,3 +68,18 @@ def sagemaker_estimator_args(
         if benchmark.estimator_kwargs is not None:
             sm_args.update(benchmark.estimator_kwargs)
     return sm_args
+
+
+def append_extra_arguments_launch_remote(
+    extra_args: Optional[ExtraArgsType],
+) -> ExtraArgsType:
+    if extra_args is None:
+        extra_args = []
+    return extra_args + [
+        dict(
+            name="skip_initial_jobs",
+            type=int,
+            default=0,
+            help="Skip this number of initial jobs which would be launched",
+        )
+    ]

--- a/benchmarking/commons/launch_remote_common.py
+++ b/benchmarking/commons/launch_remote_common.py
@@ -16,7 +16,6 @@ from typing import Optional, Dict, Any
 import benchmarking
 import syne_tune
 from benchmarking.commons.benchmark_definitions.common import BenchmarkDefinition
-from benchmarking.commons.hpo_main_common import ExtraArgsType
 from syne_tune.backend.sagemaker_backend.sagemaker_utils import (
     get_execution_role,
 )

--- a/benchmarking/commons/launch_remote_common.py
+++ b/benchmarking/commons/launch_remote_common.py
@@ -70,16 +70,11 @@ def sagemaker_estimator_args(
     return sm_args
 
 
-def append_extra_arguments_launch_remote(
-    extra_args: Optional[ExtraArgsType],
-) -> ExtraArgsType:
-    if extra_args is None:
-        extra_args = []
-    return extra_args + [
-        dict(
-            name="skip_initial_jobs",
-            type=int,
-            default=0,
-            help="Skip this number of initial jobs which would be launched",
-        )
-    ]
+REMOTE_LAUNCHING_EXTRA_PARAMETERS = [
+    dict(
+        name="skip_initial_jobs",
+        type=int,
+        default=0,
+        help="Skip this number of initial jobs which would be launched",
+    )
+]

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -34,7 +34,7 @@ from benchmarking.commons.hpo_main_local import (
 )
 from benchmarking.commons.launch_remote_common import (
     sagemaker_estimator_args,
-    append_extra_arguments_launch_remote,
+    REMOTE_LAUNCHING_EXTRA_PARAMETERS,
 )
 from benchmarking.commons.utils import (
     filter_none,
@@ -136,8 +136,9 @@ def launch_remote(
     :param extra_args: Extra arguments for command line parser, optional
     """
     configuration = config_from_argparse(
-        extra_args=append_extra_arguments_launch_remote(extra_args),
-        benchmark_specific_args=LOCAL_BACKEND_EXTRA_PARAMETERS,
+        extra_args=extra_args,
+        benchmark_specific_args=LOCAL_BACKEND_EXTRA_PARAMETERS
+        + REMOTE_LAUNCHING_EXTRA_PARAMETERS,
     )
     launch_remote_experiments(
         configuration, entry_point, methods, benchmark_definitions

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -41,9 +41,7 @@ from benchmarking.commons.utils import (
 from syne_tune.remote.estimators import (
     basic_cpu_instance_sagemaker_estimator,
 )
-from benchmarking.commons.launch_remote_common import (
-    append_extra_arguments_launch_remote,
-)
+from benchmarking.commons.launch_remote_common import REMOTE_LAUNCHING_EXTRA_PARAMETERS
 from benchmarking.commons.launch_remote_local import _launch_experiment_remotely
 from benchmarking.commons.baselines import MethodDefinitions
 
@@ -67,8 +65,9 @@ def launch_remote(
     :param extra_args: Extra arguments for command line parser, optional
     """
     configuration = config_from_argparse(
-        extra_args=append_extra_arguments_launch_remote(extra_args),
-        benchmark_specific_args=SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
+        extra_args=extra_args,
+        benchmark_specific_args=SAGEMAKER_BACKEND_EXTRA_PARAMETERS
+        + REMOTE_LAUNCHING_EXTRA_PARAMETERS,
     )
     launch_remote_experiments_sagemaker(
         configuration, entry_point, methods, benchmark_definitions

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -41,6 +41,9 @@ from benchmarking.commons.utils import (
 from syne_tune.remote.estimators import (
     basic_cpu_instance_sagemaker_estimator,
 )
+from benchmarking.commons.launch_remote_common import (
+    append_extra_arguments_launch_remote,
+)
 from benchmarking.commons.launch_remote_local import _launch_experiment_remotely
 from benchmarking.commons.baselines import MethodDefinitions
 
@@ -63,7 +66,10 @@ def launch_remote(
         command line arguments
     :param extra_args: Extra arguments for command line parser, optional
     """
-    configuration = config_from_argparse(extra_args, SAGEMAKER_BACKEND_EXTRA_PARAMETERS)
+    configuration = config_from_argparse(
+        extra_args=append_extra_arguments_launch_remote(extra_args),
+        benchmark_specific_args=SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
+    )
     launch_remote_experiments_sagemaker(
         configuration, entry_point, methods, benchmark_definitions
     )

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -31,7 +31,7 @@ from benchmarking.commons.hpo_main_simulator import (
 )
 from benchmarking.commons.launch_remote_common import (
     sagemaker_estimator_args,
-    append_extra_arguments_launch_remote,
+    REMOTE_LAUNCHING_EXTRA_PARAMETERS,
 )
 from benchmarking.commons.utils import (
     filter_none,
@@ -130,8 +130,9 @@ def launch_remote(
     if is_dict_of_dict(benchmark_definitions):
         simulated_backend_extra_parameters.append(BENCHMARK_KEY_EXTRA_PARAMETER)
     configuration = config_from_argparse(
-        extra_args=append_extra_arguments_launch_remote(extra_args),
-        benchmark_specific_args=simulated_backend_extra_parameters,
+        extra_args=extra_args,
+        benchmark_specific_args=simulated_backend_extra_parameters
+        + REMOTE_LAUNCHING_EXTRA_PARAMETERS,
     )
     launch_remote_experiments_simulator(
         configuration, entry_point, methods, benchmark_definitions, is_expensive_method

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -29,7 +29,10 @@ from benchmarking.commons.hpo_main_simulator import (
     SIMULATED_BACKEND_EXTRA_PARAMETERS,
     BENCHMARK_KEY_EXTRA_PARAMETER,
 )
-from benchmarking.commons.launch_remote_common import sagemaker_estimator_args
+from benchmarking.commons.launch_remote_common import (
+    sagemaker_estimator_args,
+    append_extra_arguments_launch_remote,
+)
 from benchmarking.commons.utils import (
     filter_none,
     message_sync_from_s3,
@@ -126,7 +129,10 @@ def launch_remote(
     simulated_backend_extra_parameters = SIMULATED_BACKEND_EXTRA_PARAMETERS.copy()
     if is_dict_of_dict(benchmark_definitions):
         simulated_backend_extra_parameters.append(BENCHMARK_KEY_EXTRA_PARAMETER)
-    configuration = config_from_argparse(extra_args, simulated_backend_extra_parameters)
+    configuration = config_from_argparse(
+        extra_args=append_extra_arguments_launch_remote(extra_args),
+        benchmark_specific_args=simulated_backend_extra_parameters,
+    )
     launch_remote_experiments_simulator(
         configuration, entry_point, methods, benchmark_definitions, is_expensive_method
     )
@@ -200,8 +206,14 @@ def launch_remote_experiments_simulator(
         combinations = list(itertools.product(combinations, benchmark_keys))
     else:
         combinations = [(x, None) for x in combinations]
+    if configuration.skip_initial_jobs > 0:
+        print(
+            f"The first {configuration.skip_initial_jobs} tuning jobs will be skipped"
+        )
 
-    for (method, seed), benchmark_key in tqdm(combinations):
+    for job_no, ((method, seed), benchmark_key) in enumerate(tqdm(combinations)):
+        if job_no < configuration.skip_initial_jobs:
+            continue  # Skip initial number of jobs
         tuner_name = method
         if seed is not None:
             tuner_name += f"-{seed}"
@@ -230,7 +242,7 @@ def launch_remote_experiments_simulator(
             hyperparameters["benchmark_key"] = benchmark_key
         sm_args["hyperparameters"] = hyperparameters
         print(
-            f"{experiment_tag}-{tuner_name}\n"
+            f"Launch tuning job {job_no}: {experiment_tag}-{tuner_name}\n"
             f"hyperparameters = {hyperparameters}\n"
             f"Results written to {sm_args['checkpoint_s3_uri']}"
         )

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -172,6 +172,9 @@ local backend. Instances of this type have 4 GPUs, so we can use ``n_workers``
 up to 4 (the default being 4). Results are written to S3, using paths such as
 ``syne-tune/{experiment_tag}/ASHA-3/`` for method ``ASHA`` and seed 3.
 
+You can use ``--skip_initial_jobs`` to skip initial jobs, as is explained
+`here <bm_simulator.html#skipping-initial-jobs>`__.
+
 Finally, some readers may be puzzled why Syne Tune dependencies are defined in
 ``benchmarking/nursery/launch_local/requirements-synetune.txt``, and not in
 ``requirements.txt`` instead. The reason is that dependencies of the SageMaker

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -106,6 +106,9 @@ metrics are published to the SageMaker training job console (this feature can
 be switched off with ``--remote_tuning_metrics 0``). This is detailed
 `here <bm_local.html#visualizing-tuning-metrics-in-the-sagemaker-training-job-console>`_.
 
+You can use ``--skip_initial_jobs`` to skip initial jobs, as is explained
+`here <bm_simulator.html#skipping-initial-jobs>`__.
+
 Using SageMaker Managed Warm Pools
 ----------------------------------
 

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -273,6 +273,25 @@ In this case, experiments are sliced along the axis
 ``("nas201", "fcnet", "lcbench")`` to be run in parallel in different SageMaker
 training jobs.
 
+Skipping Initial Jobs
+~~~~~~~~~~~~~~~~~~~~~
+
+When running a remote launching command which starts many SageMaker training
+jobs, it can happen that the loop breaks after a certain number of jobs have
+been started. In this case, you can restart the command, asking it to skip the
+jobs which have already been launched. To this end, you need to know the number
+of the last recent job which was launched successfully. Look for outputs of
+the form
+
+.. code:: python
+
+   f"Launch tuning job {job_no}: {experiment_tag}-{tuner_name}"
+
+Add one to this number to obtain ``num_jobs_launched``. Then, run the command
+again, appending the option ``--skip_initial_jobs <num_jobs_launched>``. For
+example, if the last recent job successfully launched is 4, append
+``skip_initial_jobs 5``.
+
 Pitfalls of Experiments from Tabulated Blackboxes
 -------------------------------------------------
 


### PR DESCRIPTION
Simple change to allow a launch command to be re-run if it failed after having launched a number of jobs already.
Together with Jacek's forthcoming PR, this will improve remote launching for customers.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
