### PR TITLE
chore: add initial multiobjective benchmarking logic

### DIFF
--- a/benchmarking/commons/default_baselines.py
+++ b/benchmarking/commons/default_baselines.py
@@ -36,6 +36,10 @@ from syne_tune.optimizer.baselines import (
     SyncBOHB as _SyncBOHB,
     DEHB as _DEHB,
     SyncMOBSTER as _SyncMOBSTER,
+    MOREA as _MOREA,
+)
+from syne_tune.optimizer.schedulers.multiobjective.linear_scalarizer import (
+    LinearScalarizedScheduler as _LinearScalarizedScheduler,
 )
 from syne_tune.util import recursive_merge
 
@@ -133,3 +137,11 @@ def DEHB(method_arguments: MethodArguments, **kwargs):
 
 def SyncMOBSTER(method_arguments: MethodArguments, **kwargs):
     return _SyncMOBSTER(**_baseline_kwargs(method_arguments, kwargs, is_multifid=True))
+
+
+def MOREABench(method_arguments: MethodArguments, **kwargs):
+    return _MOREA(**_baseline_kwargs(method_arguments, kwargs))
+
+
+def LSOBOBench(method_arguments: MethodArguments, **kwargs):
+    return _LinearScalarizedScheduler(**_baseline_kwargs(method_arguments, kwargs))

--- a/benchmarking/nursery/benchmark_multiobjective/README.md
+++ b/benchmarking/nursery/benchmark_multiobjective/README.md
@@ -1,0 +1,18 @@
+# Benchmark Multiobjective Methods in Syne Tune
+
+This folder shows one way to run quick experiments running different scheduler on different benchmarks and plot
+ results once they are done.
+
+To run all experiments, you can run the following:
+
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-moo.txt
+python benchmarking/nursery/benchmark_multiobjective/hpo_main.py --experiment_tag "my-new-experiment" --num_seeds 2
+```
+
+Which will run all combinations of methods/benchmark/seeds on your local computer for 2 seeds.
+
+You can also run only one scheduler by doing `python benchmarking/nursery/benchmark_multiobjective/hpo_main.py --method RS`, see
+`benchmark_main.py` to see all options supported.

--- a/benchmarking/nursery/benchmark_multiobjective/__init__.py
+++ b/benchmarking/nursery/benchmark_multiobjective/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/benchmarking/nursery/benchmark_multiobjective/baselines.py
+++ b/benchmarking/nursery/benchmark_multiobjective/baselines.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from benchmarking.commons.default_baselines import (
+    RandomSearch,
+    MOREABench,
+    LSOBOBench,
+)
+
+
+class Methods:
+    RS = "RS"
+    MOREA = "MOREA"
+    LSOBO = "LSOBO"
+
+
+methods = {
+    Methods.RS: lambda method_arguments: RandomSearch(method_arguments),
+    Methods.MOREA: lambda method_arguments: MOREABench(method_arguments),
+    Methods.LSOBO: lambda method_arguments: LSOBOBench(method_arguments),
+}

--- a/benchmarking/nursery/benchmark_multiobjective/benchmark_definitions.py
+++ b/benchmarking/nursery/benchmark_multiobjective/benchmark_definitions.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from benchmarking.commons.benchmark_definitions import (
+    SurrogateBenchmarkDefinition,
+)
+
+
+def nas201_mo_benchmark(dataset_name):
+    return SurrogateBenchmarkDefinition(
+        max_wallclock_time=6 * 3600,
+        n_workers=4,
+        elapsed_time_attr="metric_elapsed_time",
+        metric=["metric_valid_error", "metric_params"],
+        mode=["min", "min"],
+        blackbox_name="nasbench201",
+        dataset_name=dataset_name,
+        max_resource_attr="epochs",
+    )
+
+
+nas201_mo_benchmark_definitions = {
+    "nas201-mo-cifar10": nas201_mo_benchmark("cifar10"),
+    "nas201-mo-cifar100": nas201_mo_benchmark("cifar100"),
+    "nas201-mo-ImageNet16-120": nas201_mo_benchmark("ImageNet16-120"),
+}
+
+
+benchmark_definitions = {
+    **nas201_mo_benchmark_definitions,
+}

--- a/benchmarking/nursery/benchmark_multiobjective/hpo_main.py
+++ b/benchmarking/nursery/benchmark_multiobjective/hpo_main.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from benchmarking.commons.hpo_main_simulator import main
+from benchmarking.nursery.benchmark_multiobjective.baselines import methods
+from benchmarking.nursery.benchmark_multiobjective.benchmark_definitions import (
+    benchmark_definitions,
+)
+
+if __name__ == "__main__":
+    main(methods, benchmark_definitions)

--- a/benchmarking/nursery/benchmark_multiobjective/launch_remote.py
+++ b/benchmarking/nursery/benchmark_multiobjective/launch_remote.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from pathlib import Path
+
+from benchmarking.commons.launch_remote_simulator import launch_remote
+from benchmarking.nursery.benchmark_multiobjective.benchmark_definitions import (
+    benchmark_definitions,
+)
+from benchmarking.nursery.benchmark_multiobjective.baselines import (
+    methods,
+)
+
+if __name__ == "__main__":
+
+    entry_point = Path(__file__).parent / "hpo_main.py"
+    launch_remote(
+        entry_point=entry_point,
+        methods=methods,
+        benchmark_definitions=benchmark_definitions,
+    )

--- a/docs/source/tutorials/multifidelity/mf_setup.rst
+++ b/docs/source/tutorials/multifidelity/mf_setup.rst
@@ -98,7 +98,7 @@ Let us have a walk through this script, assuming it is called with the default
   In short, we strongly recommend to use ``max_resource_attr`` and to configure
   schedulers with it.
 * [2] If ``max_resource_attr`` is not to be used, the scheduler needs to be
-  passed the maximum resource value explicitly. For ``ASHA-STOP`, this is the
+  passed the maximum resource value explicitly. For ``ASHA-STOP``, this is the
   ``max_t`` attribute. This is not recommended, and not shown here.
 * [3] At this point, we create the multi-fidelity scheduler, which is ASHA in
   the default case. Most supported schedulers can easily be imported from

--- a/tst/benchmarking/benchmark_commons/test_hpo_main_local.py
+++ b/tst/benchmarking/benchmark_commons/test_hpo_main_local.py
@@ -67,7 +67,7 @@ class HPOMainLocalTests(unittest.TestCase):
                 "use_long_tuner_name_prefix": True,
                 "launched_remotely": False,
                 "benchmark": None,
-                "verbose": 0,
+                "verbose": False,
                 "support_checkpointing": 1,
                 "fcnet_ordinal": "nn-log",
                 "restrict_configurations": 0,

--- a/tst/benchmarking/benchmark_commons/test_hpo_main_local.py
+++ b/tst/benchmarking/benchmark_commons/test_hpo_main_local.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import unittest
+from unittest.mock import MagicMock, patch
+from benchmarking.commons.default_baselines import RandomSearch
+from benchmarking.commons.hpo_main_common import ConfigDict
+from benchmarking.nursery.benchmark_multiobjective.baselines import (
+    Methods,
+    MOREABench,
+    LSOBOBench,
+)
+from benchmarking.nursery.benchmark_multiobjective.benchmark_definitions import (
+    nas201_mo_benchmark,
+)
+from benchmarking.nursery.benchmark_multiobjective.hpo_main import main
+
+
+class HPOMainLocalTests(unittest.TestCase):
+    @patch(
+        "benchmarking.commons.hpo_main_simulator.config_from_argparse",
+        new_callable=MagicMock,
+    )
+    @patch("benchmarking.commons.hpo_main_simulator.Tuner", new_callable=MagicMock)
+    @patch(
+        "benchmarking.commons.hpo_main_simulator.BlackboxRepositoryBackend",
+        new_callable=MagicMock,
+    )
+    def test_tuner_is_run_the_expected_number_of_times(
+        self, mock_blackbox_repository_backend, mock_tuner, mock_config_from_argparse
+    ):
+        methods = {
+            Methods.RS: lambda method_arguments: RandomSearch(method_arguments),
+            Methods.MOREA: lambda method_arguments: MOREABench(method_arguments),
+            Methods.LSOBO: lambda method_arguments: LSOBOBench(method_arguments),
+        }
+
+        benchmark_definitions = {
+            "nas201-cifar10": nas201_mo_benchmark("cifar10"),
+            "nas201-cifar100": nas201_mo_benchmark("cifar100"),
+            "nas201-ImageNet16-120": nas201_mo_benchmark("ImageNet16-120"),
+        }
+
+        seeds = [1, 2]
+
+        mock_config_from_argparse.return_value = ConfigDict.from_dict(
+            {
+                "experiment_tag": "my-new-experiment",
+                "num_seeds": len(seeds),
+                "start_seed": 0,
+                "method": None,
+                "save_tuner": 0,
+                "n_workers": None,
+                "max_wallclock_time": None,
+                "random_seed": None,
+                "max_size_data_for_model": None,
+                "scale_max_wallclock_time": 0,
+                "use_long_tuner_name_prefix": True,
+                "launched_remotely": False,
+                "benchmark": None,
+                "verbose": 0,
+                "support_checkpointing": 1,
+                "fcnet_ordinal": "nn-log",
+                "restrict_configurations": 0,
+                "seeds": seeds,
+            }
+        )
+
+        main(methods, benchmark_definitions)
+
+        expected_call_count = len(methods) * len(benchmark_definitions) * len(seeds)
+        assert mock_tuner.call_count == expected_call_count

--- a/tst/schedulers/multiobjective/test_simple_scalarizer.py
+++ b/tst/schedulers/multiobjective/test_simple_scalarizer.py
@@ -81,7 +81,7 @@ def test_scalarization(scheduler: LinearScalarizedScheduler, make_metric: Callab
     assert scalarized == 321 - 321
 
 
-def test_resukls_gathering(scheduler: LinearScalarizedScheduler, make_metric: Callable):
+def test_results_gathering(scheduler: LinearScalarizedScheduler, make_metric: Callable):
     trialid = 123
     trial = Trial(
         trial_id=trialid,


### PR DESCRIPTION
Add initial multiobjective benchmarking logic. This is to support the ongoing development and evaluation of multiobjective methods in Syne Tune.

This is based on the approach taken in `benchmarking/examples/benchmark_dehb`, re-using existing logic where possible.

New unit test added.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
