### PR TITLE
chore: Sklearn estimator now fits the surrogate model without considering pending evaluations.

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_estimator.py
@@ -59,11 +59,22 @@ class SklearnEstimatorWrapper(Estimator):
         If your surrogate model is not Bayesian, or does not have hyperparameters,
         you can ignore the ``update_params`` argument,
 
+        If ``self.state.pending_evaluations`` is not empty, we compute posterior for state without pending evals.
+        This method can be overriten for any other behaviour such as one found in
+        ``syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model.GaussProcEstimator.fit_from_state``
+
         :param state: Current data model parameters are to be fit on, and the
             posterior state is to be computed from
         :param update_params: See above
         :return: Predictor, wrapping the posterior state
         """
+        if state.pending_evaluations:
+            state = TuningJobState(
+                hp_ranges=state.hp_ranges,
+                config_for_trial=state.config_for_trial,
+                trials_evaluations=state.trials_evaluations,
+                failed_trials=state.failed_trials,
+            )
         data = transform_state_to_data(
             state=state, normalize_targets=self.normalize_targets
         )

--- a/tst/schedulers/bayesopt/test_sklearn_surrogate.py
+++ b/tst/schedulers/bayesopt/test_sklearn_surrogate.py
@@ -36,6 +36,7 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import (
     create_tuning_job_state,
+    tuples_to_configs,
 )
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
     make_hyperparameter_ranges,
@@ -69,7 +70,7 @@ def tuning_job_state() -> TuningJobState:
     return create_tuning_job_state(hp_ranges=hp_ranges1, cand_tuples=X1, metrics=Y1)
 
 
-def test_estimator_wrapper_interface(tuning_job_state):
+def test_estimator_wrapper_interface(tuning_job_state: TuningJobState):
     estimator = SklearnEstimatorWrapper(contributed_estimator=TestEstimator())
     predictor = estimator.fit_from_state(tuning_job_state)
 
@@ -79,10 +80,25 @@ def test_estimator_wrapper_interface(tuning_job_state):
     assert isinstance(estimator.contributed_estimator, TestEstimator)
 
 
-def test_predictor_wrapper_interface(tuning_job_state):
+def test_predictor_wrapper_interface(tuning_job_state: TuningJobState):
     estimator = SklearnEstimatorWrapper(contributed_estimator=TestEstimator())
     predictor = estimator.fit_from_state(tuning_job_state)
     predictions = predictor.predict(np.random.uniform(size=(10, 3)))
 
     np.testing.assert_allclose(predictions[0]["mean"], np.ones(shape=10))
     np.testing.assert_allclose(predictions[0]["std"], np.zeros(shape=10))
+
+
+def test_pending_evaluations(tuning_job_state: TuningJobState):
+    pending = tuples_to_configs(
+        [(1.0, "a")],
+        make_hyperparameter_ranges(
+            {"a1_hp_1": uniform(-5.0, 5.0), "a1_hp_2": choice(["a", "b", "c"])}
+        ),
+    )
+    tuning_job_state.append_pending("123", pending.pop())
+    estimator = SklearnEstimatorWrapper(contributed_estimator=TestEstimator())
+    predictor = estimator.fit_from_state(tuning_job_state)
+
+    assert isinstance(predictor, SklearnPredictorWrapper)
+    assert isinstance(predictor.contributed_predictor, TestPredictor)


### PR DESCRIPTION
The behaviour for `syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model.GaussProcEstimator.fit_from_state` is 

If ``self.state.pending_evaluations`` is not empty, we proceed as follows:
* Compute posterior for state without pending evals
* Draw fantasy values for pending evals
* Recompute posterior (without fitting)


In the case of Sklearn Estimators we do not support fantasizing therefore the process should stop at step 1. The method can be later overriden if fantasizing is to be added.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
