### PR TITLE
fix: Remote launcher must not pass extra params to hpo_main

### DIFF
--- a/benchmarking/commons/hpo_main_local.py
+++ b/benchmarking/commons/hpo_main_local.py
@@ -246,7 +246,9 @@ def start_benchmark_local_backend(
         random_seed = effective_random_seed(master_random_seed, seed)
         np.random.seed(random_seed)
         print(
-            f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}"
+            f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}\n"
+            f"  max_wallclock_time = {benchmark.max_wallclock_time}, "
+            f"  n_workers = {benchmark.n_workers}"
         )
         trial_backend = LocalBackend(
             entry_point=str(benchmark.script),

--- a/benchmarking/commons/hpo_main_sagemaker.py
+++ b/benchmarking/commons/hpo_main_sagemaker.py
@@ -148,7 +148,11 @@ def start_benchmark_sagemaker_backend(
     benchmark = get_benchmark(
         configuration, benchmark_definitions, sagemaker_backend=True
     )
-    print(f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}")
+    print(
+        f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}"
+        f"  max_wallclock_time = {benchmark.max_wallclock_time}, "
+        f"  n_workers = {benchmark.n_workers}"
+    )
 
     sm_args = sagemaker_estimator_args(
         entry_point=benchmark.script,

--- a/benchmarking/commons/hpo_main_simulator.py
+++ b/benchmarking/commons/hpo_main_simulator.py
@@ -256,6 +256,8 @@ def start_benchmark_simulated_backend(
             )
         print(
             f"Starting experiment ({method}/{benchmark_name}/{seed}) of {experiment_tag}"
+            f"  max_wallclock_time = {benchmark.max_wallclock_time}, "
+            f"  n_workers = {benchmark.n_workers}"
         )
 
         max_resource_attr = benchmark.max_resource_attr

--- a/benchmarking/commons/launch_remote_common.py
+++ b/benchmarking/commons/launch_remote_common.py
@@ -77,3 +77,10 @@ REMOTE_LAUNCHING_EXTRA_PARAMETERS = [
         help="Skip this number of initial jobs which would be launched",
     )
 ]
+
+
+def remove_remote_launching_parameters(
+    hyperparameters: Dict[str, Any]
+) -> Dict[str, Any]:
+    remove_keys = [x["name"] for x in REMOTE_LAUNCHING_EXTRA_PARAMETERS]
+    return {k: v for k, v in hyperparameters.items() if k not in remove_keys}

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -35,6 +35,7 @@ from benchmarking.commons.hpo_main_local import (
 from benchmarking.commons.launch_remote_common import (
     sagemaker_estimator_args,
     REMOTE_LAUNCHING_EXTRA_PARAMETERS,
+    remove_remote_launching_parameters,
 )
 from benchmarking.commons.utils import (
     filter_none,
@@ -249,6 +250,7 @@ def _launch_experiment_remotely(
             configuration=configuration,
         )
         hyperparameters.update(extra_sagemaker_hyperparameters)
+        hyperparameters = remove_remote_launching_parameters(hyperparameters)
         if environment is not None:
             sm_args["environment"] = environment
         sm_args["hyperparameters"] = hyperparameters

--- a/benchmarking/commons/launch_remote_simulator.py
+++ b/benchmarking/commons/launch_remote_simulator.py
@@ -32,6 +32,7 @@ from benchmarking.commons.hpo_main_simulator import (
 from benchmarking.commons.launch_remote_common import (
     sagemaker_estimator_args,
     REMOTE_LAUNCHING_EXTRA_PARAMETERS,
+    remove_remote_launching_parameters,
 )
 from benchmarking.commons.utils import (
     filter_none,
@@ -241,6 +242,7 @@ def launch_remote_experiments_simulator(
         )
         if benchmark_key is not None:
             hyperparameters["benchmark_key"] = benchmark_key
+        hyperparameters = remove_remote_launching_parameters(hyperparameters)
         sm_args["hyperparameters"] = hyperparameters
         print(
             f"Launch tuning job {job_no}: {experiment_tag}-{tuner_name}\n"


### PR DESCRIPTION
The script remote_launch.py has some args which must not be passed to hpo_main.py, since they are specific to remote launching. Currently, remote launching fails because of that.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
