### PR TITLE
fix: Sklearn estimator now fits the surrogate model without considering pending evaluations.

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_estimator.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_estimator.py
@@ -55,15 +55,26 @@ class SklearnEstimatorWrapper(Estimator):
         If the model also has hyperparameters, these are learned iff
         ``update_params == True``. Otherwise, these parameters are not changed,
         but only the posterior state is computed.
-
         If your surrogate model is not Bayesian, or does not have hyperparameters,
-        you can ignore the ``update_params`` argument,
+        you can ignore the ``update_params`` argument.
+
+        If ``self.state.pending_evaluations`` is not empty, we compute posterior for state without pending evals.
+        This method can be overriten for any other behaviour such as one found in
+        ``syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model.GaussProcEstimator.fit_from_state``
 
         :param state: Current data model parameters are to be fit on, and the
             posterior state is to be computed from
         :param update_params: See above
         :return: Predictor, wrapping the posterior state
         """
+        if state.pending_evaluations:
+            state = TuningJobState(
+                hp_ranges=state.hp_ranges,
+                config_for_trial=state.config_for_trial,
+                trials_evaluations=state.trials_evaluations,
+                failed_trials=state.failed_trials,
+            )
+
         data = transform_state_to_data(
             state=state, normalize_targets=self.normalize_targets
         )

--- a/tst/schedulers/bayesopt/test_sklearn_surrogate.py
+++ b/tst/schedulers/bayesopt/test_sklearn_surrogate.py
@@ -35,7 +35,8 @@ from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.tuning_job_stat
     TuningJobState,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.utils.test_objects import (
-    create_tuning_job_state, tuples_to_configs,
+    create_tuning_job_state,
+    tuples_to_configs,
 )
 from syne_tune.optimizer.schedulers.searchers.utils.hp_ranges_factory import (
     make_hyperparameter_ranges,
@@ -86,6 +87,7 @@ def test_predictor_wrapper_interface(tuning_job_state: TuningJobState):
 
     np.testing.assert_allclose(predictions[0]["mean"], np.ones(shape=10))
     np.testing.assert_allclose(predictions[0]["std"], np.zeros(shape=10))
+
 
 def test_pending_evaluations(tuning_job_state: TuningJobState):
     pending = tuples_to_configs(


### PR DESCRIPTION
This replaces: https://github.com/awslabs/syne-tune/pull/677

The behaviour for `syne_tune.optimizer.schedulers.searchers.bayesopt.models.gp_model.GaussProcEstimator.fit_from_state` is 

If ``self.state.pending_evaluations`` is not empty, we proceed as follows:
* Compute posterior for state without pending evals
* Draw fantasy values for pending evals
* Recompute posterior (without fitting)


In the case of Sklearn Estimators we do not support fantasizing therefore the process should stop at step 1. The method can be later overriden if fantasizing is to be added.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
