### PR TITLE
fix: Made scoring function compatible with acquisition function interface

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/base_classes.py
@@ -190,6 +190,14 @@ class ScoringFunction:
     not support gradient computation. Note that scores are always minimized.
     """
 
+    def __init__(
+        self, predictor: OutputPredictor = None, active_metric: Optional[str] = None
+    ):
+        self.predictor = predictor
+        if active_metric is None:
+            active_metric = INTERNAL_METRIC_NAME
+        self.active_metric = active_metric
+
     def score(
         self,
         candidates: Iterable[Configuration],
@@ -210,12 +218,6 @@ class AcquisitionFunction(ScoringFunction):
     :param predictor: Predictor(s) from surrogate model
     :param active_metric: Name of internal metric
     """
-
-    def __init__(self, predictor: OutputPredictor, active_metric: Optional[str] = None):
-        self.predictor = predictor
-        if active_metric is None:
-            active_metric = INTERNAL_METRIC_NAME
-        self.active_metric = active_metric
 
     def compute_acq(
         self, inputs: np.ndarray, predictor: Optional[OutputPredictor] = None
@@ -260,6 +262,10 @@ class AcquisitionFunction(ScoringFunction):
 
 AcquisitionClassAndArgs = Union[
     Type[AcquisitionFunction], Tuple[Type[AcquisitionFunction], Dict[str, Any]]
+]
+
+ScoringClassAndArgs = Union[
+    Type[ScoringFunction], Tuple[Type[ScoringFunction], Dict[str, Any]]
 ]
 
 

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
@@ -47,9 +47,12 @@ class IndependentThompsonSampling(ScoringFunction):
     """
 
     def __init__(
-        self, predictor: Predictor, random_state: Optional[RandomState] = None
+        self,
+        predictor: OutputPredictor = None,
+        active_metric: Optional[str] = None,
+        random_state: Optional[RandomState] = None,
     ):
-        self.predictor = predictor
+        super().__init__(predictor, active_metric)
         if random_state is None:
             random_state = RandomState(31415629)
         self.random_state = random_state


### PR DESCRIPTION
Made scoring function compatible with acquisition function interface. This should not change any functionalities of acquisition function but enable scoring function to be used in a broader context.

1. Moved the __init__ from acquisition function to scoring function.
2. Updated the __init__ of IndependentThompsonSampling accordingly
3. Defined new ScoringClassAndArgs input parameter type

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
