### PR TITLE
fix: typos in "Getting started" code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ if __name__ == '__main__':
     root = logging.getLogger()
     root.setLevel(logging.INFO)
     parser = ArgumentParser()
-    parser.add_argument('--steps', type=int)
+    parser.add_argument('--epochs', type=int)
     parser.add_argument('--width', type=float)
     parser.add_argument('--height', type=float)
     args, _ = parser.parse_known_args()
     report = Reporter()
-    for step in range(args.steps):
+    for step in range(args.epochs):
         time.sleep(0.1)
         dummy_score = 1.0 / (0.1 + args.width * step / 100) + args.height * 0.1
         # Feed the score back to Syne Tune.
@@ -93,7 +93,7 @@ config_space = {
 }
 
 tuner = Tuner(
-    trial_backend=LocalBackend(entry_point='train_height.py'),
+    trial_backend=LocalBackend(entry_point='train_height_simple.py'),
     scheduler=ASHA(
         config_space,
         metric='mean_loss',


### PR DESCRIPTION
Fix the following typos in the example code in the Getting Started section from the README:

* `train_height_simple` expects parameter `--steps` but `launch_height_simple.py` defines `epochs` as HPO parameter only and not `steps` -> rename `steps` to `epochs` in `train_height_simple`
* in `launch_height_simple.py`: `entry_point` set to `train_height.py` which does not match the name `launch_height_simple.py` from the first comment in the previous code cell -> changed `entry_point` to `launch_height_simple.py`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
