### PR TITLE
feat: Allow to skip initial jobs in remote launching

### DIFF
--- a/benchmarking/commons/hpo_main_common.py
+++ b/benchmarking/commons/hpo_main_common.py
@@ -131,6 +131,12 @@ class ConfigDict:
             default=False,
             help=f"Internal argument, do not use",
         ),
+        Parameter(
+            name="skip_initial_jobs",
+            type=int,
+            default=0,
+            help="Skip this number of initial jobs to be launched (for remote launching only)",
+        ),
     ]
     __base_parameters = __base_cl_parameters + [
         Parameter(

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -132,7 +132,10 @@ def launch_remote(
         command line arguments
     :param extra_args: Extra arguments for command line parser, optional
     """
-    configuration = config_from_argparse(extra_args, LOCAL_BACKEND_EXTRA_PARAMETERS)
+    configuration = config_from_argparse(
+        extra_args=extra_args,
+        benchmark_specific_args=LOCAL_BACKEND_EXTRA_PARAMETERS,
+    )
     launch_remote_experiments(
         configuration, entry_point, methods, benchmark_definitions
     )
@@ -160,7 +163,6 @@ def launch_remote_experiments(
     If you like to control the Syne Tune requirements (the default ones are
     ``"extra"``, which can be a lot), place a file ``requirements_synetune.txt`` in
     ``entry_point.parent``.
-
 
     :param configuration: ConfigDict with parameters of the benchmark.
             Must contain all parameters from
@@ -220,7 +222,13 @@ def _launch_experiment_remotely(
     experiment_tag = configuration.experiment_tag
     suffix = random_string(4)
     combinations = list(itertools.product(method_names, configuration.seeds))
-    for method, seed in tqdm(combinations):
+    if configuration.skip_initial_jobs > 0:
+        print(
+            f"The first {configuration.skip_initial_jobs} tuning jobs will be skipped"
+        )
+    for job_no, (method, seed) in enumerate(tqdm(combinations)):
+        if job_no < configuration.skip_initial_jobs:
+            continue  # Skip initial number of jobs
         tuner_name = f"{method}-{seed}"
         sm_args = sagemaker_estimator_args(
             entry_point=entry_point,
@@ -241,7 +249,7 @@ def _launch_experiment_remotely(
             sm_args["environment"] = environment
         sm_args["hyperparameters"] = hyperparameters
         print(
-            f"{experiment_tag}-{tuner_name}\n"
+            f"Launch tuning job {job_no}: {experiment_tag}-{tuner_name}\n"
             f"hyperparameters = {hyperparameters}\n"
             f"Results written to {sm_args['checkpoint_s3_uri']}"
         )

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -63,7 +63,10 @@ def launch_remote(
         command line arguments
     :param extra_args: Extra arguments for command line parser, optional
     """
-    configuration = config_from_argparse(extra_args, SAGEMAKER_BACKEND_EXTRA_PARAMETERS)
+    configuration = config_from_argparse(
+        extra_args=extra_args,
+        benchmark_specific_args=SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
+    )
     launch_remote_experiments_sagemaker(
         configuration, entry_point, methods, benchmark_definitions
     )

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -172,6 +172,9 @@ local backend. Instances of this type have 4 GPUs, so we can use ``n_workers``
 up to 4 (the default being 4). Results are written to S3, using paths such as
 ``syne-tune/{experiment_tag}/ASHA-3/`` for method ``ASHA`` and seed 3.
 
+You can use ``--skip_initial_jobs`` to skip initial jobs, as is explained
+`here <bm_simulator.html#skipping-initial-jobs>`__.
+
 Finally, some readers may be puzzled why Syne Tune dependencies are defined in
 ``benchmarking/examples/launch_local/requirements-synetune.txt``, and not in
 ``requirements.txt`` instead. The reason is that dependencies of the SageMaker

--- a/docs/source/tutorials/benchmarking/bm_sagemaker.rst
+++ b/docs/source/tutorials/benchmarking/bm_sagemaker.rst
@@ -106,6 +106,9 @@ metrics are published to the SageMaker training job console (this feature can
 be switched off with ``--remote_tuning_metrics 0``). This is detailed
 `here <bm_local.html#visualizing-tuning-metrics-in-the-sagemaker-training-job-console>`_.
 
+You can use ``--skip_initial_jobs`` to skip initial jobs, as is explained
+`here <bm_simulator.html#skipping-initial-jobs>`__.
+
 Using SageMaker Managed Warm Pools
 ----------------------------------
 

--- a/docs/source/tutorials/benchmarking/bm_simulator.rst
+++ b/docs/source/tutorials/benchmarking/bm_simulator.rst
@@ -273,6 +273,25 @@ In this case, experiments are sliced along the axis
 ``("nas201", "fcnet", "lcbench")`` to be run in parallel in different SageMaker
 training jobs.
 
+Skipping Initial Jobs
+~~~~~~~~~~~~~~~~~~~~~
+
+When running a remote launching command which starts many SageMaker training
+jobs, it can happen that the loop breaks after a certain number of jobs have
+been started. In this case, you can restart the command, asking it to skip the
+jobs which have already been launched. To this end, you need to know the number
+of the last recent job which was launched successfully. Look for outputs of
+the form
+
+.. code:: python
+
+   f"Launch tuning job {job_no}: {experiment_tag}-{tuner_name}"
+
+Add one to this number to obtain ``num_jobs_launched``. Then, run the command
+again, appending the option ``--skip_initial_jobs <num_jobs_launched>``. For
+example, if the last recent job successfully launched is 4, append
+``skip_initial_jobs 5``.
+
 Pitfalls of Experiments from Tabulated Blackboxes
 -------------------------------------------------
 


### PR DESCRIPTION
Does what #662 was supposed to do. We can add options only used by `launch_remote.py`, they'll just be ignored when used for `hpo_main.py`.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
