### PR TITLE
fix: New benchmarks need **kwargs, so that defaults can be overwritte…

### DIFF
--- a/benchmarking/commons/benchmark_definitions/finetune_transformer_glue.py
+++ b/benchmarking/commons/benchmark_definitions/finetune_transformer_glue.py
@@ -10,7 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from typing import Dict, Optional
+from typing import Dict
 from pathlib import Path
 
 from benchmarking.commons.benchmark_definitions.common import RealBenchmarkDefinition

--- a/benchmarking/commons/benchmark_definitions/finetune_transformer_swag.py
+++ b/benchmarking/commons/benchmark_definitions/finetune_transformer_swag.py
@@ -28,19 +28,18 @@ BATCH_SIZE_ATTR = "per_device_train_batch_size"
 
 def finetune_transformer_swag_benchmark(
     sagemaker_backend: bool = False,
-    max_wallclock_time: int = 5 * 3600,
-    n_workers: int = 4,
     num_train_epochs: int = 3,
     per_device_train_batch_size: int = 8,
+    **kwargs,
 ) -> RealBenchmarkDefinition:
     """
     :param sagemaker_backend: Use SageMaker backend? This affects the choice
         of instance type. Defaults to ``False``
-    :param max_wallclock_time: Maximum wall-clock time in secs. Defaults to 1800
-    :param n_workers: Number of workers. Defaults to 4
     :param num_train_epochs: Maximum number of epochs for fine-tuning. Defaults
         to 3
     :param per_device_train_batch_size: Batch size per device. Defaults to 8
+    :param kwargs: Overwrites default params in ``RealBenchmarkDefinition``
+        object returned
     """
     if sagemaker_backend:
         instance_type = DEFAULT_GPU_INSTANCE_1GPU
@@ -71,14 +70,14 @@ def finetune_transformer_swag_benchmark(
         "max_grad_norm": 1.0,
     }
 
-    kwargs = dict(
+    _kwargs = dict(
         script=Path(__file__).parent.parent.parent
         / "training_scripts"
         / "finetune_transformer_swag"
         / "multiple_choice_on_swag.py",
         config_space=config_space,
-        max_wallclock_time=max_wallclock_time,
-        n_workers=n_workers,
+        max_wallclock_time=5 * 3600,
+        n_workers=4,
         instance_type=instance_type,
         metric=METRIC,
         mode=MODE,
@@ -87,4 +86,5 @@ def finetune_transformer_swag_benchmark(
         framework="PyTorch",
         points_to_evaluate=[default_configuration],
     )
-    return RealBenchmarkDefinition(**kwargs)
+    _kwargs.update(kwargs)
+    return RealBenchmarkDefinition(**_kwargs)

--- a/benchmarking/commons/benchmark_definitions/lstm_wikitext2.py
+++ b/benchmarking/commons/benchmark_definitions/lstm_wikitext2.py
@@ -43,7 +43,6 @@ def lstm_wikitext2_default_params(sagemaker_backend: bool) -> Dict[str, Any]:
     }
 
 
-# Note: Latest PyTorch version 1.10 not yet supported with remote launching
 def lstm_wikitext2_benchmark(sagemaker_backend: bool = False, **kwargs):
     params = lstm_wikitext2_default_params(sagemaker_backend)
     config_space = dict(

--- a/benchmarking/commons/benchmark_definitions/resnet_cifar10.py
+++ b/benchmarking/commons/benchmark_definitions/resnet_cifar10.py
@@ -41,7 +41,6 @@ def resnet_cifar10_default_params(sagemaker_backend: bool):
     }
 
 
-# Note: Latest PyTorch version 1.10 not yet supported with remote launching
 def resnet_cifar10_benchmark(sagemaker_backend: bool = False, **kwargs):
     params = resnet_cifar10_default_params(sagemaker_backend)
     config_space = dict(

--- a/benchmarking/commons/benchmark_definitions/transformer_wikitext2.py
+++ b/benchmarking/commons/benchmark_definitions/transformer_wikitext2.py
@@ -41,7 +41,6 @@ def transformer_wikitext2_default_params(sagemaker_backend: bool) -> Dict[str, A
     }
 
 
-# Note: Latest PyTorch version 1.10 not yet supported with remote launching
 def transformer_wikitext2_benchmark(sagemaker_backend: bool = False, **kwargs):
     params = transformer_wikitext2_default_params(sagemaker_backend)
     config_space = dict(

--- a/docs/source/tutorials/benchmarking/bm_local.rst
+++ b/docs/source/tutorials/benchmarking/bm_local.rst
@@ -146,8 +146,11 @@ of ``RealBenchmarkDefinition``. Important arguments are:
 * ``framework``, ``estimator_kwargs``: SageMaker framework and additional
   arguments to SageMaker estimator.
 
-Note that parameters like ``n_workers`` and ``max_wallclock_time`` are defaults,
-which can be overwritten by command line arguments.
+Note that parameters like ``n_workers``, ``max_wallclock_time``, or
+``instance_type`` are given default values here, which can be overwritten
+by command line arguments. This is why the function signature ends with
+``**kwargs``, and we execute ``_kwargs.update(kwargs)`` just before creating
+the ``RealBenchmarkDefinition`` object.
 
 Launching Experiments Remotely
 ------------------------------


### PR DESCRIPTION
…n by CL args



----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
