### PR TITLE
feat: Some extra plotting features

### DIFF
--- a/docs/source/tutorials/visualization/code/plot_learning_curves.py
+++ b/docs/source/tutorials/visualization/code/plot_learning_curves.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     # Also, all methods compared are pause-and-resume
     multi_fidelity_params = MultiFidelityParameters(
         rung_levels=[1, 3, 9, 27, 81, 200],
-        pause_resume_setups=SETUPS_TO_COMPARE,
+        multifidelity_setups={name: True for name in SETUPS_TO_COMPARE},
     )
     # The creation of ``results`` downloads files from S3 (only if
     # ``download_from_s3 == True``), reads the metadata and creates an inverse

--- a/docs/source/tutorials/visualization/comparisons.rst
+++ b/docs/source/tutorials/visualization/comparisons.rst
@@ -249,6 +249,15 @@ for ``plot_params.subplots``:
   subplots only, in which case ``legend_no`` contains a single number.
 * ``xlims``: Use this if your subfigures have x axis ranges. The global
   ``xlim`` is overwritten by ``(0, xlims[subplot_no])``.
+* ``subplot_indices``: Any given plot produced by
+  :meth:`~syne_tune.experiments.ComparativeResults.plot` does not have to
+  contain all subfigures. For example, you may want to group your results
+  into 4 or 8 bins, then create a sequence of plots comparing pairs of them.
+  If ``subplot_indices`` is given, it contains the subplot indices to be shown,
+  and this order. Otherwise, this is :math:`0, 1, 2, \dots`. If this is given,
+  then ``titles`` and ``xlims`` is relative to this list (in that
+  ``xlims[i]`` corresponds to subfigure ``subplot_indices[i]``), but
+  ``legend_no`` is not.
 
 Filtering Experiments by DateTime Bounds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorials/visualization/comparisons.rst
+++ b/docs/source/tutorials/visualization/comparisons.rst
@@ -105,6 +105,8 @@ The figure for benchmark ``nas201-cifar-100`` looks as follows:
   for every benchmark (this is optional).
 * If we pass ``file_name`` as argument to ``results.plot``, the figure is
   stored in this file.
+* ``results.plot`` returns a dictionary, whose entries "fig" and "axs" contain
+  the figure and its axes (subfigures), allowing for further fine-tuning.
 
 .. note::
    If suplots are used, the grouping is w.r.t. ``(subplot, setup)``, not
@@ -313,7 +315,7 @@ used to monitor some internals of the HPO method being used, in which case we
 may be satisfied to see these statistics at the end of experiments. If
 ``extra_results_keys`` is used in
 :meth:`~syne_tune.experiments.ComparativeResults.plot`, the method returns
-a nested dictionary ``extra_results``, so that
+a nested dictionary ``extra_results`` under key "extra_results", so that
 ``extra_results[setup_name][key]`` contains a list of values (one for each
 seed) for setup ``setup_name`` and ``key`` an extra result name from
 ``extra_results_keys``. As `above <#extract-meta-data-values>`__, if

--- a/syne_tune/experiments/plot_per_trial.py
+++ b/syne_tune/experiments/plot_per_trial.py
@@ -82,8 +82,16 @@ class TrialsOfExperimentResults:
     Compared to :class:`~syne_tune.experiments.ComparativeResults`, each subfigure
     uses data from a single experiment (one benchmark, one seed, one setup). Both
     benchmark and seed need to be chosen in :meth:`plot`. If there are different
-    setups, they give rise to subfigures (by default, one row with subfigures as
-    columns, but can be configured).
+    setups, they give rise to subfigures.
+
+    If ``plot_params.subplots`` is not given, the arrangement is one row with
+    columns corresponding to setups, and setup names as titles. Specify
+    ``plot_params.subplots`` in order to change this arrangement (e.g., to have
+    more than one row). Setups can be selected by using
+    ``plot_params.subplots.subplot_indices``. Also, if
+    ``plot_params.subplots.titles`` is not given, we use setup names, and each
+    subplot gets its own title (``plot_params.subplots.title_each_figure`` is
+    ignored).
 
     For ``plot_params``, we use the same
     :class:`~syne_tune.experiments.PlotParameters` as in
@@ -188,8 +196,15 @@ class TrialsOfExperimentResults:
                 nrows=nrows,
                 ncols=ncols,
             )
-            subplot_titles = subplots.titles
-            title_each_figure = subplots.title_each_figure
+            if subplots.titles is not None:
+                subplot_titles = subplots.titles
+                title_each_figure = subplots.title_each_figure
+            else:
+                # If ``plot_params.subplots.titles`` is not given, we use setup
+                # names as titles. In this case, each subfigure has its own
+                # title, not just each column
+                subplot_titles = [self.setups[ind] for ind in subplot_indices]
+                title_each_figure = True
         else:
             nrows = 1
             ncols = len(self.setups)

--- a/syne_tune/experiments/plotting.py
+++ b/syne_tune/experiments/plotting.py
@@ -643,7 +643,7 @@ class ComparativeResults:
         plot_params: Optional[PlotParameters] = None,
         file_name: Optional[str] = None,
         extra_results_keys: Optional[List[str]] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         """
         Create comparative plot from results of all experiments collected at
         construction, for benchmark ``benchmark_name`` (if there is a single
@@ -674,8 +674,8 @@ class ComparativeResults:
             here overwrite values provided at construction.
         :param file_name: If given, the figure is stored in a file of this name
         :param extra_results_keys: See above, optional
-        :return: ``extra_results`` if ``extra_results_keys`` is given, otherwise
-            ``None``
+        :return: Dictionary with "fig", "axs" (for further processing). If
+            ``extra_results_keys``, "extra_results" entry as stated above
         """
         benchmark_name = self._check_benchmark_name(benchmark_name)
         if plot_params is None:
@@ -686,16 +686,22 @@ class ComparativeResults:
             self._reverse_index[benchmark_name]
         )
         logger.info("Aggregate results")
-        result = self._aggregrate_results(
+        aggregate_result = self._aggregrate_results(
             df=results_df,
             plot_params=plot_params,
             extra_results_keys=extra_results_keys,
         )
         fig, axs = self._plot_figure(
-            stats=result["stats"],
+            stats=aggregate_result["stats"],
             plot_params=plot_params,
-            setup_names=result["setup_names"],
+            setup_names=aggregate_result["setup_names"],
         )
         if file_name is not None:
             fig.savefig(file_name, dpi=plot_params.dpi)
-        return None if extra_results_keys is None else result["extra_results"]
+        results = {
+            "fig": fig,
+            "axs": axs,
+        }
+        if extra_results_keys is not None:
+            results["extra_results"] = aggregate_result["extra_results"]
+        return results


### PR DESCRIPTION
Extends plotting in two ways:

* In `TrialsOfExperimentResults`, can now plot single and multi fidelity methods in the same figure
* Can select the subfigures to be plotted. This is useful if you group into (say) 4 or 8 buckets, but then want to create a sequence of plots comparing pairs of these

This is stuff I needed for the ODSC tutorial, they are just coming in now

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
