### PR TITLE
chore: enable caching for unit tests, fix README typo

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Constrained Bayesian Optimization | Gardner, et al. (2014) | model-based | yes |
 MOASHA | Schmucker, et al. (2021) | random | yes | yes | no
 NSGA-2 | Deb, et al. (2002) | evolutionary | no | no | no
 
-HPO methods listed can be used in a multi-objective setting by scalarization or non-dominated sorting. See [multiobjective_priority.py](syne_tune/optimizers/schedulers/multiobjective/multiobjective_priority.py) for details.
+HPO methods listed can be used in a multi-objective setting by scalarization or non-dominated sorting. See [multiobjective_priority.py](syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py) for details.
 
 ## Examples
 


### PR DESCRIPTION
Two small changes: 
1. Enable caching for unit tests, this should make them run faster. This setting is already enabled for our integ and end-to-end tests, see https://github.com/awslabs/syne-tune/blob/main/.github/workflows/run-syne-tune.yml#L51
2. Fix broken link in README


Before this change, duration of most recent 3 test runs: 12m 10s, 14m 55s, 19m 7s.

After this change: 8m 37s, 7m 54s, 7m 12s

Roughly 30% improvement. 

Confounding factors: 
1. Sometimes there's a delay until a machine is available to pick up the new job
2. If there's a cache-miss with a new library version, it will download it from the internet 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
