### PR TITLE
fix: Command line arguments of benchmarking

### DIFF
--- a/benchmarking/commons/hpo_main_sagemaker.py
+++ b/benchmarking/commons/hpo_main_sagemaker.py
@@ -28,6 +28,7 @@ from benchmarking.commons.hpo_main_local import (
     RealBenchmarkDefinitions,
     get_benchmark,
     create_objects_for_tuner,
+    LOCAL_AND_SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
 )
 from benchmarking.commons.launch_remote_common import sagemaker_estimator_args
 from benchmarking.commons.utils import (
@@ -46,13 +47,9 @@ from syne_tune.tuner import Tuner
 # Maximum time a warm pool instance is kept alive, waiting to be associated with
 # a new job. Setting this too large may lead to extra costs.
 WARM_POOL_KEEP_ALIVE_PERIOD_IN_SECONDS = 10 * 60
-SAGEMAKER_BACKEND_EXTRA_PARAMETERS = [
-    dict(
-        name="benchmark",
-        type=str,
-        default="resnet_cifar10",
-        help="Benchmark to run",
-    ),
+
+
+SAGEMAKER_BACKEND_ONLY_EXTRA_PARAMETERS = [
     dict(
         name="max_failures",
         type=int,
@@ -70,11 +67,6 @@ SAGEMAKER_BACKEND_EXTRA_PARAMETERS = [
         ),
     ),
     dict(
-        name="instance_type",
-        type=str,
-        help="AWS SageMaker instance type (overwrites default of benchmark)",
-    ),
-    dict(
         name="start_jobs_without_delay",
         type=str2bool,
         default=False,
@@ -86,21 +78,13 @@ SAGEMAKER_BACKEND_EXTRA_PARAMETERS = [
             "feature not working optimal."
         ),
     ),
-    dict(
-        name="delete_checkpoints",
-        type=str2bool,
-        default=True,
-        help=(
-            "If 1, checkpoints files on S3 are removed at the end of the experiment."
-        ),
-    ),
-    dict(
-        name="remote_tuning_metrics",
-        type=str2bool,
-        default=True,
-        help="Remote tuning publishes metrics to Sagemaker console?",
-    ),
 ]
+
+
+SAGEMAKER_BACKEND_EXTRA_PARAMETERS = (
+    LOCAL_AND_SAGEMAKER_BACKEND_EXTRA_PARAMETERS
+    + SAGEMAKER_BACKEND_ONLY_EXTRA_PARAMETERS
+)
 
 
 def start_benchmark_sagemaker_backend(

--- a/benchmarking/commons/launch_remote_local.py
+++ b/benchmarking/commons/launch_remote_local.py
@@ -164,7 +164,6 @@ def launch_remote_experiments(
     ``"extra"``, which can be a lot), place a file ``requirements_synetune.txt`` in
     ``entry_point.parent``.
 
-
     :param configuration: ConfigDict with parameters of the benchmark.
             Must contain all parameters from
             hpo_main_local.LOCAL_LOCAL_BENCHMARK_REQUIRED_PARAMETERS

--- a/benchmarking/commons/launch_remote_sagemaker.py
+++ b/benchmarking/commons/launch_remote_sagemaker.py
@@ -14,9 +14,6 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from benchmarking.commons.hpo_main_sagemaker import (
-    SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
-)
 from syne_tune.try_import import try_import_aws_message
 
 try:
@@ -28,6 +25,9 @@ from benchmarking.commons.hpo_main_common import (
     ExtraArgsType,
     ConfigDict,
     config_from_argparse,
+)
+from benchmarking.commons.hpo_main_sagemaker import (
+    SAGEMAKER_BACKEND_EXTRA_PARAMETERS,
 )
 from benchmarking.commons.hpo_main_local import (
     RealBenchmarkDefinitions,


### PR DESCRIPTION
Command line arguments did not work. I also pulled together common CL args between local and sagemaker

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
