### PR TITLE
feat: Multi Surrogate Multi Objective Searcher

### DIFF
--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -119,6 +119,13 @@ jobs:
       additional-command: pip install matplotlib
       script-path: examples/launch_asha_yahpo.py
 
+
+  launch_mb_mo_optimization:
+    uses: ./.github/workflows/run-syne-tune.yml
+    with:
+      extras-require: gpsearchers
+      script-path: examples/launch_mb_mo_optimization.py
+
   launch_height_config_json:
     uses: ./.github/workflows/run-syne-tune.yml
     with:

--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ Syne Tune also supports [BoTorch](https://github.com/awslabs/syne-tune/blob/main
 
 ## Supported multi-objective optimization methods
 
-Method | Reference | Searcher | Asynchronous? | Multi-fidelity? | Transfer?
-:--- | :---: | :---: | :---: | :---: | :---: 
-Constrained Bayesian Optimization | Gardner, et al. (2014) | model-based | yes | no | no
-MOASHA | Schmucker, et al. (2021) | random | yes | yes | no
-NSGA-2 | Deb, et al. (2002) | evolutionary | no | no | no
+Method |          Reference          |   Searcher   | Asynchronous? | Multi-fidelity? | Transfer?
+:--- |:---------------------------:|:------------:| :---: | :---: | :---: 
+Constrained Bayesian Optimization |   Gardner, et al. (2014)    | model-based  | yes | no | no
+MOASHA |  Schmucker, et al. (2021)   |    random    | yes | yes | no
+NSGA-2 |     Deb, et al. (2002)      | evolutionary | no | no | no
+Multi Objective Multi Surrogate (MSMOS) | Guerrero-Viu, et al. (2021) | model-based  | no | no | no
+MSMOS wihh random scalarization |    Paria, et al. (2018)     | model-based  | no | no | no
 
 HPO methods listed can be used in a multi-objective setting by scalarization or non-dominated sorting. See [multiobjective_priority.py](syne_tune/optimizer/schedulers/multiobjective/multiobjective_priority.py) for details.
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -559,7 +559,7 @@ This is an extension of
 :ref:`launch_ask_tell_scheduler.py <launch_ask_tell_scheduler_script>` to run
 multi-fidelity methods such as Hyperband.
 
-Ask Tell Interface
+Multi Objective Multi Surrogate (MSMOS) Searcher
 ==================
 
 .. literalinclude:: ../../examples/launch_mb_mo_optimization.py
@@ -568,7 +568,7 @@ Ask Tell Interface
    :start-after: # permissions and limitations under the License.
 
 This example shows how to use the multi-objective multi-surrogate (MSMOS) searcher to tune
-a multi-objective problem. In this example, we use two gaussian-process regresors
+a multi-objective problem. In this example, we use two Gaussian process regresors
 as the surrogate models and rely on lower confidence bound random scalarizer
-as the acquisition function. With that in mind, any syne_tune `Estimator` can be
+as the acquisition function. With that in mind, any Syne Tune :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator.Estimator` can be
 used as surrogate.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -558,3 +558,17 @@ Ask Tell interface for Hyperband
 This is an extension of
 :ref:`launch_ask_tell_scheduler.py <launch_ask_tell_scheduler_script>` to run
 multi-fidelity methods such as Hyperband.
+
+Ask Tell Interface
+==================
+
+.. literalinclude:: ../../examples/launch_mb_mo_optimization.py
+   :name: launch_mb_mo_optimization
+   :caption: examples/launch_mb_mo_optimization.py
+   :start-after: # permissions and limitations under the License.
+
+This example shows how to use the multi-objective multi-surrogate (MSMOS) searcher to tune
+a multi-objective problem. In this example, we use two gaussian-process regresors
+as the surrogate models and rely on lower confidence bound random scalarizer
+as the acquisition function. With that in mind, any syne_tune `Estimator` can be
+used as surrogate.

--- a/examples/launch_asha_yahpo.py
+++ b/examples/launch_asha_yahpo.py
@@ -71,7 +71,7 @@ class BenchmarkInfo:
     resource_attr: str
 
 
-if __name__ == "__main__":
+def main():
     logging.getLogger().setLevel(logging.INFO)
 
     benchmark_infos = {

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -1,0 +1,133 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import copy
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+from sklearn.linear_model import BayesianRidge
+
+from syne_tune import Tuner, StoppingCriterion
+from syne_tune.backend import LocalBackend
+from syne_tune.config_space import randint, uniform
+from syne_tune.optimizer.schedulers import FIFOScheduler
+from syne_tune.optimizer.schedulers.multiobjective.multi_surrogate_multi_objective_searcher import (
+    MultiObjectiveMultiSurrogateSearcher,
+)
+from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
+    MultiObjectiveLCBRandomLinearScalarization,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.sklearn_model import (
+    SKLearnEstimatorWrapper,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.sklearn import (
+    SKLearnEstimator,
+    SKLearnPredictor,
+)
+
+
+class BayesianRidgePredictor(SKLearnPredictor):
+    """
+    Base class for the sklearn predictors
+    """
+
+    def __init__(self, ridge: BayesianRidge):
+        self.ridge = ridge
+
+    def predict(
+        self, X: np.ndarray, return_std: bool = True
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Returns signals which are statistics of the predictive distribution at
+        input points ``inputs``.
+
+
+        :param inputs: Input points, shape ``(n, d)``
+        :return: Tuple with the following entries:
+            * "mean": Predictive means in shape of ``(n,)``
+            * "std": Predictive stddevs, shape ``(n,)``
+        """
+        return self.ridge.predict(X, return_std=True)
+
+
+class BayesianRidgeEstimator(SKLearnEstimator):
+    """
+    Base class for the sklearn Estimators
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.ridge = BayesianRidge(*args, **kwargs)
+
+    def fit(
+        self, X: np.ndarray, y: np.ndarray, update_params: bool
+    ) -> BayesianRidgePredictor:
+        """
+        Implements :meth:`fit_from_state`, given transformed data.
+
+        :param X: Training data in ndarray of shape (n_samples, n_features)
+        :param y: Target values in ndarray of shape (n_samples,)
+        :param update_params: Should model (hyper)parameters be updated?
+        :return: Predictor, wrapping the posterior state
+        """
+        self.ridge.fit(X, y.ravel())
+        return BayesianRidgePredictor(ridge=copy.deepcopy(self.ridge))
+
+
+def main():
+    # Hyperparameter configuration space
+    config_space = {
+        "steps": randint(0, 100),
+        "theta": uniform(0, np.pi / 2),
+        "sleep_time": 0.01,
+    }
+    # Scheduler (i.e., HPO algorithm)
+    sklearn_myestimators = {
+        "y1": BayesianRidgeEstimator(),
+        "y2": BayesianRidgeEstimator(),
+    }
+    myestimators = {
+        metric: SKLearnEstimatorWrapper(estim, target_metric=metric)
+        for metric, estim in sklearn_myestimators.items()
+    }
+    searcher = MultiObjectiveMultiSurrogateSearcher(
+        config_space=config_space,
+        metric=["y1", "y2"],
+        estimators=myestimators,
+        scoring_class_and_args=MultiObjectiveLCBRandomLinearScalarization,
+    )
+
+    scheduler = FIFOScheduler(
+        config_space,
+        metric=["y1", "y2"],
+        mode=["min", "min"],
+        searcher=searcher,
+        search_options={"debug_log": False},
+    )
+
+    entry_point = str(
+        Path(__file__).parent
+        / "training_scripts"
+        / "mo_artificial"
+        / "mo_artificial.py"
+    )
+    tuner = Tuner(
+        trial_backend=LocalBackend(entry_point=entry_point),
+        scheduler=scheduler,
+        stop_criterion=StoppingCriterion(max_wallclock_time=30),
+        n_workers=1,  # how many trials are evaluated in parallel
+    )
+    tuner.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -82,6 +82,7 @@ def main():
         scoring_class_and_args=partial(
             MultiObjectiveLCBRandomLinearScalarization, random_seed=123
         ),
+        random_seed=123,
     )
 
     scheduler = FIFOScheduler(

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -90,7 +90,10 @@ def main():
     )
 
     entry_point = str(
-        Path(__file__).parent / "training_scripts" / "mo_artificial" / "mo_artificial.py"
+        Path(__file__).parent
+        / "training_scripts"
+        / "mo_artificial"
+        / "mo_artificial.py"
     )
     tuner = Tuner(
         trial_backend=LocalBackend(entry_point=entry_point),

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -10,6 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+from functools import partial
 from pathlib import Path
 from typing import Dict, Any, Optional
 
@@ -49,7 +50,6 @@ def create_gaussian_process_estimator(
 
     # update the estimator properties
     estimator.active_metric = metric
-    estimator._no_fantasizing = True
     return estimator
 
 
@@ -65,7 +65,7 @@ def main():
     # Create Gaussian process estimators
     # In ``search_options``, the GP model can be configured, see comments
     # of ``GPFIFOSearcher``
-    search_options = {"debug_log": False}
+    search_options = {"debug_log": False, "no_fantasizing": True}
     myestimators = {
         metric: create_gaussian_process_estimator(
             config_space=config_space,
@@ -79,7 +79,9 @@ def main():
         config_space=config_space,
         metric=metrics,
         estimators=myestimators,
-        scoring_class_and_args=MultiObjectiveLCBRandomLinearScalarization,
+        scoring_class_and_args=partial(
+            MultiObjectiveLCBRandomLinearScalarization, random_seed=123
+        ),
     )
 
     scheduler = FIFOScheduler(

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -26,6 +26,7 @@ from syne_tune.optimizer.schedulers.multiobjective.multi_surrogate_multi_objecti
 from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
     MultiObjectiveLCBRandomLinearScalarization,
 )
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import Estimator
 
 
 def create_gaussian_process_estimator(
@@ -34,7 +35,7 @@ def create_gaussian_process_estimator(
     mode: Optional[str] = None,
     random_seed: Optional[int] = None,
     search_options: Optional[Dict[str, Any]] = None,
-):
+) -> Estimator:
     scheduler = BayesianOptimization(
         config_space=config_space,
         metric=metric,

--- a/examples/launch_mb_mo_optimization.py
+++ b/examples/launch_mb_mo_optimization.py
@@ -54,6 +54,7 @@ def create_gaussian_process_estimator(
 
 
 def main():
+    random_seed = 6287623
     # Hyperparameter configuration space
     config_space = {
         "steps": randint(0, 100),
@@ -80,9 +81,9 @@ def main():
         metric=metrics,
         estimators=myestimators,
         scoring_class_and_args=partial(
-            MultiObjectiveLCBRandomLinearScalarization, random_seed=123
+            MultiObjectiveLCBRandomLinearScalarization, random_seed=random_seed
         ),
-        random_seed=123,
+        random_seed=random_seed,
     )
 
     scheduler = FIFOScheduler(

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
@@ -1,0 +1,155 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import logging
+from typing import Optional, List, Dict, Any
+
+from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
+    MultiObjectiveLCBRandomLinearScalarization,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
+    INTERNAL_COST_NAME,
+    TrialEvaluations,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import Estimator
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
+    ScoringClassAndArgs,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.defaults import (
+    DEFAULT_NUM_INITIAL_CANDIDATES,
+    DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
+)
+from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import (
+    decode_state,
+)
+from syne_tune.optimizer.schedulers.searchers.model_based_searcher import (
+    BayesianOptimizationSearcher,
+)
+from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
+
+logger = logging.getLogger(__name__)
+
+
+class MultiObjectiveMultiSurrogateSearcher(BayesianOptimizationSearcher):
+    """Multi Objective Multi Surrogate Searcher for FIFO scheduler
+
+    This searcher must be used with
+    :class:`~syne_tune.optimizer.schedulers.FIFOScheduler`. It provides
+    Bayesian optimization, based on a scikit-learn estimator based surrogate model.
+
+    Additional arguments on top of parent class
+    :class:`~syne_tune.optimizer.schedulers.searchers.StochasticSearcher`:
+
+    :param estimator: Instance of
+        :class:`~syne_tune.optimizer.schedulers.searchers.bayesopt.sklearn.estimator.SKLearnEstimator`
+        to be used as surrogate model
+    :param scoring_class_and_args: The scoring function (or acquisition
+        function) class and any extra parameters used to instantiate it. If
+        ``None``, expected improvement (EI) is used. Note that the acquisition
+        function is not locally optimized with this searcher.
+    :param num_initial_candidates: Number of candidates sampled for scoring with
+        acquisition function.
+    :param num_initial_random_choices: Number of randomly chosen candidates before
+        surrogate model is used.
+    :param allow_duplicates: If ``True``, allow for the same candidate to be
+        selected more than once.
+    :param restrict_configurations: If given, the searcher only suggests
+        configurations from this list. If ``allow_duplicates == False``,
+        entries are popped off this list once suggested.
+    """
+
+    def __init__(
+        self,
+        config_space: Dict[str, Any],
+        metric: List[str],
+        estimators: Dict[str, Estimator],
+        mode: List[str] = None,
+        points_to_evaluate: Optional[List[Dict[str, Any]]] = None,
+        scoring_class_and_args: Optional[ScoringClassAndArgs] = None,
+        num_initial_candidates: int = DEFAULT_NUM_INITIAL_CANDIDATES,
+        num_initial_random_choices: int = DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
+        allow_duplicates: bool = False,
+        restrict_configurations: Optional[List[Dict[str, Any]]] = None,
+        clone_from_state: bool = False,
+        **kwargs,
+    ):
+        if mode is None:
+            mode = ["min" for item in metric]
+
+        super().__init__(
+            config_space,
+            metric=metric,
+            mode=mode,
+            points_to_evaluate=points_to_evaluate,
+            random_seed_generator=kwargs.get("random_seed_generator"),
+            random_seed=kwargs.get("random_seed"),
+        )
+        self.estimator = estimators
+        if scoring_class_and_args is None:
+            scoring_class_and_args = MultiObjectiveLCBRandomLinearScalarization
+
+        if not clone_from_state:
+            hp_ranges = make_hyperparameter_ranges(self.config_space)
+            self._create_internal(
+                hp_ranges=hp_ranges,
+                estimator=self.estimator,
+                acquisition_class=scoring_class_and_args,
+                num_initial_candidates=num_initial_candidates,
+                num_initial_random_choices=num_initial_random_choices,
+                initial_scoring="acq_func",
+                skip_local_optimization={name: True for name in self.estimator.keys()},
+                allow_duplicates=allow_duplicates,
+                restrict_configurations=restrict_configurations,
+                **kwargs,
+            )
+        else:
+            # Internal constructor, bypassing the factory
+            # Note: Members which are part of the mutable state, will be
+            # overwritten in ``_restore_from_state``
+            self._create_internal(**kwargs.copy())
+
+    def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
+        # Gather metrics
+        metrics = {name: result[name] for name in self._metric}
+
+        # Cost value only dealt with here if ``resource_attr`` not given
+        attr = self._cost_attr
+        cost_val = None
+        if attr is not None and attr in result:
+            cost_val = float(result[attr])
+            if self._resource_attr is None:
+                metrics[INTERNAL_COST_NAME] = cost_val
+
+        self.state_transformer.label_trial(
+            TrialEvaluations(trial_id=trial_id, metrics=metrics), config=config
+        )
+        if self.debug_log is not None:
+            _trial_id = self._trial_id_string(trial_id, result)
+            msg = f"Update for trial_id {_trial_id}: metric = {metrics:.3f}"
+            if cost_val is not None:
+                msg += f", cost_val = {cost_val:.2f}"
+            logger.info(msg)
+
+    def clone_from_state(self, state):
+        # Create clone with mutable state taken from 'state'
+        init_state = decode_state(state["state"], self._hp_ranges_in_state())
+        estimator = self.state_transformer.estimator
+        # Call internal constructor
+        new_searcher = MultiObjectiveMultiSurrogateSearcher(
+            **self._new_searcher_kwargs_for_clone(),
+            estimator=estimator,
+            init_state=init_state,
+        )
+        new_searcher._restore_from_state(state)
+        # Invalidate self (must not be used afterwards)
+        self.state_transformer = None
+        return new_searcher

--- a/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/multi_surrogate_multi_objective_searcher.py
@@ -14,13 +14,10 @@ import logging
 from functools import partial
 from typing import Optional, List, Dict, Any
 
-from syne_tune.optimizer.schedulers.searchers.searcher_base import extract_random_seed
-
 from syne_tune.optimizer.schedulers.multiobjective.random_scalarization import (
     MultiObjectiveLCBRandomLinearScalarization,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.datatypes.common import (
-    INTERNAL_COST_NAME,
     TrialEvaluations,
 )
 from syne_tune.optimizer.schedulers.searchers.bayesopt.models.estimator import Estimator
@@ -37,6 +34,7 @@ from syne_tune.optimizer.schedulers.searchers.gp_searcher_utils import (
 from syne_tune.optimizer.schedulers.searchers.model_based_searcher import (
     BayesianOptimizationSearcher,
 )
+from syne_tune.optimizer.schedulers.searchers.searcher_base import extract_random_seed
 from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
 
 logger = logging.getLogger(__name__)

--- a/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
@@ -42,6 +42,7 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
             ...
         }
     :param kappa: Hyperparameter used for the LCM portion of the scoring
+    :param random_seed: The random seed used for default weights_sampler if not provided.
     """
 
     def __init__(

--- a/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
@@ -42,7 +42,7 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
             ...
         }
     :param kappa: Hyperparameter used for the LCM portion of the scoring
-    :param normalize: If True, use rank-normalization on the acquisition function results before weighting.
+    :param normalize_acquisition: If True, use rank-normalization on the acquisition function results before weighting.
     :param random_seed: The random seed used for default weights_sampler if not provided.
     """
 
@@ -52,14 +52,14 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
         active_metric: Optional[List[str]] = None,
         weights_sampler: Optional[Callable[[], Dict[str, float]]] = None,
         kappa: float = 0.5,
-        normalize: bool = True,
+        normalize_acquisition: bool = True,
         random_seed: int = None,
     ):
         super(MultiObjectiveLCBRandomLinearScalarization, self).__init__(
             predictor, active_metric
         )
         self.kappa = kappa
-        self.normalize = normalize
+        self.normalize_acquisition = normalize_acquisition
 
         if weights_sampler is None:
             state = RandomState(random_seed)
@@ -85,7 +85,7 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
             predicted_std = predictions[0]["std"]
 
             metric_score = self._single_objective_score(predicted_mean, predicted_std)
-            if self.normalize:
+            if self.normalize_acquisition:
                 metrics_score_normalized = scipy.stats.rankdata(metric_score)
                 metrics_score_normalized = (
                     metrics_score_normalized / metrics_score_normalized.max()

--- a/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from typing import Dict, Optional, Iterable, List, Callable
+
+import numpy as np
+import scipy.stats
+from numpy.random import RandomState
+
+from syne_tune.optimizer.schedulers.searchers.bayesopt.tuning_algorithms.base_classes import (
+    Predictor,
+    ScoringFunction,
+)
+from syne_tune.optimizer.schedulers.searchers.utils.common import Configuration
+
+
+class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
+    """
+    Note: This is the multi objective random scalarization scoring function based on the work of Biswajit et al. [1].
+    This scoring function uses Lower Confidence Bound as the acquisition for the scalarized objective
+    :math:`h(\mu, \sigma) = \mu - \kappa * \sigma`
+
+        | [1] Paria, Biswajit, Kirthevasan Kandasamy and Barnabás Póczos.
+        | A Flexible Framework for Multi-Objective Bayesian Optimization using Random Scalarizations.
+        | Conference on Uncertainty in Artificial Intelligence (2018).
+
+    :param predictor: Surrogate predictor for statistics of predictive distribution
+    :param weights_sampler: Callable that can generate weights for each objective.
+        Once called it will return a dictionary mapping metric name to scalarization weight as
+        {
+            <name of metric 1> : <weight for metric 1>,
+            <name of metric 2> : <weight for metric 2>,
+            ...
+        }
+    """
+
+    def __init__(
+        self,
+        predictor: Dict[str, Predictor],
+        active_metric: Optional[List[str]] = None,
+        weights_sampler: Optional[Callable[[], Dict[str, float]]] = None,
+        kappa: float = 0.5,
+    ):
+        self.kappa = kappa
+        self.predictor = predictor
+        if active_metric is None:
+            active_metric = [name for name in predictor.keys()]
+        self.active_metric = active_metric
+
+        if weights_sampler is None:
+            state = RandomState(123)
+
+            def weights_sampler():
+                return {name: state.uniform() for name in predictor.keys()}
+
+        self.weights_sampler = weights_sampler
+
+    def score(
+        self,
+        candidates: Iterable[Configuration],
+        predictor: Optional[Dict[str, Predictor]] = None,
+    ) -> List[float]:
+
+        if predictor is None:
+            predictor = self.predictor
+        weights = self.weights_sampler()
+        scores = np.zeros(len(candidates))
+        for metric, metric_predictor in predictor.items():
+            predictions = metric_predictor.predict_candidates(candidates)
+            predicted_mean = predictions[0]["mean"]
+            predicted_std = predictions[0]["std"]
+
+            metric_score = self._single_objective_score(predicted_mean, predicted_std)
+            metrics_score_normalized = scipy.stats.rankdata(metric_score)
+            metrics_score_normalized = (
+                metrics_score_normalized / metrics_score_normalized.max()
+            )
+            scores += metrics_score_normalized * weights[metric]
+        return list(scores)
+
+    def _single_objective_score(self, mean: np.ndarray, std: np.ndarray) -> np.ndarray:
+        """
+        Acquisition function for a single objective
+        """
+        return mean - std * self.kappa

--- a/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
+++ b/syne_tune/optimizer/schedulers/multiobjective/random_scalarization.py
@@ -41,6 +41,7 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
             <name of metric 2> : <weight for metric 2>,
             ...
         }
+    :param kappa: Hyperparameter used for the LCM portion of the scoring
     """
 
     def __init__(
@@ -49,15 +50,15 @@ class MultiObjectiveLCBRandomLinearScalarization(ScoringFunction):
         active_metric: Optional[List[str]] = None,
         weights_sampler: Optional[Callable[[], Dict[str, float]]] = None,
         kappa: float = 0.5,
+        random_seed: int = None,
     ):
+        super(MultiObjectiveLCBRandomLinearScalarization, self).__init__(
+            predictor, active_metric
+        )
         self.kappa = kappa
-        self.predictor = predictor
-        if active_metric is None:
-            active_metric = [name for name in predictor.keys()]
-        self.active_metric = active_metric
 
         if weights_sampler is None:
-            state = RandomState(123)
+            state = RandomState(random_seed)
 
             def weights_sampler():
                 return {name: state.uniform() for name in predictor.keys()}

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/model_transformer.py
@@ -132,7 +132,6 @@ class ModelStateTransformer:
                 f"It is assumed that we are in the multi-output case and that it "
                 f"must be a Dict. No other types are supported. "
             )
-            _assert_same_keys(estimator, skip_optimization)
             # Default: Always refit model parameters for each output model
             if skip_optimization is None:
                 skip_optimization = {
@@ -144,6 +143,7 @@ class ModelStateTransformer:
                     f"{skip_optimization} must be a Dict, consistently "
                     f"with {estimator}."
                 )
+                _assert_same_keys(estimator, skip_optimization)
                 skip_optimization = {
                     output_name: skip_optimization[output_name]
                     if skip_optimization.get(output_name) is not None

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
@@ -82,9 +82,16 @@ class SKLearnEstimatorWrapper(Estimator):
     Wrapper class for sklearn estimators.
     """
 
-    def __init__(self, sklearn_estimator: SKLearnEstimator, *args, **kwargs):
+    def __init__(
+        self,
+        sklearn_estimator: SKLearnEstimator,
+        target_metric: str = None,
+        *args,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.sklearn_estimator = sklearn_estimator
+        self.target_metric = target_metric
 
     def get_params(self) -> Dict[str, Any]:
         return self.sklearn_estimator.get_params()
@@ -121,8 +128,11 @@ class SKLearnEstimatorWrapper(Estimator):
                 trials_evaluations=state.trials_evaluations,
                 failed_trials=state.failed_trials,
             )
+
         data = transform_state_to_data(
-            state=state, normalize_targets=self.sklearn_estimator.normalize_targets
+            state=state,
+            active_metric=self.target_metric,
+            normalize_targets=self.sklearn_estimator.normalize_targets,
         )
         sklearn_predictor = self.sklearn_estimator.fit(
             X=data.features, y=data.targets, update_params=update_params

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/models/sklearn_model.py
@@ -85,13 +85,13 @@ class SKLearnEstimatorWrapper(Estimator):
     def __init__(
         self,
         sklearn_estimator: SKLearnEstimator,
-        target_metric: str = None,
+        active_metric: str = None,
         *args,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.sklearn_estimator = sklearn_estimator
-        self.target_metric = target_metric
+        self.target_metric = active_metric
 
     def get_params(self) -> Dict[str, Any]:
         return self.sklearn_estimator.get_params()

--- a/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
+++ b/syne_tune/optimizer/schedulers/searchers/bayesopt/tuning_algorithms/bo_algorithm_components.py
@@ -140,6 +140,12 @@ class LBFGSOptimizeAcquisition(LocalOptimizer):
 
 
 class NoOptimization(LocalOptimizer):
+    def __init__(self, *args, **kwargs):
+        # In case of no-optimization, no setup is needed.
+        # This is necessary if a single NoOptimization instance is to be used
+        # For multi-objective (multi-metric) optimization
+        pass
+
     def optimize(
         self, candidate: Configuration, predictor: Optional[Predictor] = None
     ) -> Configuration:

--- a/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
@@ -11,7 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 import time
-import random
 from typing import Optional, Type, Dict, Any, List
 import logging
 import numpy as np
@@ -159,9 +158,9 @@ class ModelBasedSearcher(StochasticSearcher):
         self.acquisition_class = acquisition_class
         if isinstance(estimator, dict):
             # If no estimator for INTERNAL_METRIC_NAME can be found,
-            # use the debug log from a randomly selected one
+            # use the debug log from a first metric
             estimator_main = estimator.get(
-                INTERNAL_METRIC_NAME, random.choice(list(estimator.values()))
+                INTERNAL_METRIC_NAME, next(iter(estimator.values()))
             )
         else:
             estimator_main = estimator

--- a/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 import time
+import random
 from typing import Optional, Type, Dict, Any, List
 import logging
 import numpy as np
@@ -157,7 +158,11 @@ class ModelBasedSearcher(StochasticSearcher):
             )
         self.acquisition_class = acquisition_class
         if isinstance(estimator, dict):
-            estimator_main = estimator[INTERNAL_METRIC_NAME]
+            # If no estimator for INTERNAL_METRIC_NAME can be found,
+            # use the debug log from a randomly selected one
+            estimator_main = estimator.get(
+                INTERNAL_METRIC_NAME, random.choice(list(estimator.values()))
+            )
         else:
             estimator_main = estimator
         self._debug_log = estimator_main.debug_log

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -44,6 +44,12 @@ from syne_tune.optimizer.baselines import (
     ASHACQR,
     # ASHACTS,
 )
+from syne_tune.optimizer.schedulers.multiobjective.multi_surrogate_multi_objective_searcher import (
+    MultiObjectiveMultiSurrogateSearcher,
+)
+from syne_tune.optimizer.schedulers.searchers.bayesopt.models.sklearn_model import (
+    SKLearnEstimatorWrapper,
+)
 from syne_tune.optimizer.schedulers.searchers.conformal.surrogate_searcher import (
     SurrogateSearcher,
 )
@@ -437,6 +443,20 @@ list_schedulers_to_test = [
         ),
         metric=metric1,
         mode=mode,
+    ),
+    FIFOScheduler(
+        config_space,
+        searcher=MultiObjectiveMultiSurrogateSearcher(
+            config_space=config_space,
+            metric=[metric1, metric2],
+            mode=[mode, mode],
+            estimators={
+                metric1: SKLearnEstimatorWrapper(TestEstimator()),
+                metric2: SKLearnEstimatorWrapper(TestEstimator()),
+            },
+        ),
+        metric=[metric1, metric2],
+        mode=[mode, mode],
     ),
 ]
 


### PR DESCRIPTION
Adding the Multi Surrogate Multi Objective Searcher to SyneTune. 
To make this happen, added a few small changes:
1. NoOptimization optimizer now does not setup itself, this is necessary to use the same optimizer for multiple metrics
2. If no estimator for INTERNAL_METRIC_NAME can be found, ModelBasedSearcher uses the debug log from a randomly selected one
3. _assert_same_keys check only if skip_optimization is not None. None is the default case where all is skipped.
4. target_metric is passed to SKLearnEstimatorWrapper to differentiate estimators


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
