### PR TITLE
fix: Avoid sphinx 7.0.0, since the readthedocs build fails with that

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest-timeout
 # https://github.com/psf/black/issues/2964
 black==22.3.0
 flake8
-sphinx
+sphinx<7.0.0
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 myst-parser


### PR DESCRIPTION
You could investigate more, but fact is our docs do not currently build on readthedocs, and downgrading sphinx to <7.0.0 solves that issue. This is what I found:

https://github.com/readthedocs/readthedocs.org/issues/10279

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
