### PR TITLE
fix: ExperimentResult.best_config() always used max mode

### DIFF
--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -221,7 +221,7 @@ class ExperimentResult:
             )
 
         metric_mode = self.metric_mode()
-        if len(metric_mode) > 1:
+        if isinstance(metric_mode, list):
             metric_mode = metric_mode[metric]
 
         return metric, metric_name, metric_mode

--- a/tst/experiments/test_experiment_result.py
+++ b/tst/experiments/test_experiment_result.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from syne_tune.experiments import ExperimentResult
+
+
+@pytest.mark.parametrize(
+    "metadata,results,expected_result",
+    [
+        pytest.param(
+            dict(metric_names=["loss"], metric_mode="min"),
+            pd.DataFrame({"loss": [0.1, 10]}),
+            dict(loss=0.1),
+            id="single metric - min",
+        ),
+        pytest.param(
+            dict(metric_names=["loss"], metric_mode="max"),
+            pd.DataFrame({"loss": [0.1, 10]}),
+            dict(loss=10),
+            id="single metric - max",
+        ),
+        pytest.param(
+            dict(metric_names=["loss", "some_metric"], metric_mode=["min", "max"]),
+            pd.DataFrame({"loss": [0.1, 10], "some_metric": [0.2, 20]}),
+            dict(loss=0.1, some_metric=0.2),
+            id="multiple metrics",
+        ),
+    ],
+)
+def test_get_best_result(metadata: dict, results: pd.DataFrame, expected_result: dict):
+    exp_result = ExperimentResult(
+        name="some name", results=results, metadata=metadata, tuner=Mock(), path=Mock()
+    )
+    assert exp_result.best_config() == expected_result


### PR DESCRIPTION
 ## Problem
* In [ExperimentResult.best_config()](https://github.com/awslabs/syne-tune/blob/254ad0708703245e51da0b113f1067a2da92039a/syne_tune/experiments/experiment_result.py#L181C26-L181C26) `metric_mode` is resolved by calling `_metric_name_mode`
* In [_metric_name_mode](https://github.com/awslabs/syne-tune/blob/254ad0708703245e51da0b113f1067a2da92039a/syne_tune/experiments/experiment_result.py#L223-L225): in case `metric_mode` has a non-zero length it is replaced by `metric_mode[metric]`. In case `metric_mode` is a string (for example `min`) and not a list, it is replaced by the character in the string at position `metric`, with `metric` defaulting to `0`. In case of `metric_mode = "min"` it is replaced by `m`.
* back in [best_config](https://github.com/awslabs/syne-tune/blob/254ad0708703245e51da0b113f1067a2da92039a/syne_tune/experiments/experiment_result.py#L184), we test whether `metric_mode` equals `min` and otherwise go into the `max` case. In case `metric_mode` was originally a string `"min"` it got replaced by `"m"` and we falsely return the trial that maximized the metric.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
