### PR TITLE
feat: Add method to get the best configuration directly from Tuner, add com…

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -337,6 +337,14 @@ You can take a look at this example
 `examples/launch_checkpoint_example.py <examples.html#retrieving-the-best-checkpoint>`__
 which shows how to retrieve the best checkpoint obtained after tuning an XGBoost model.
 
+How can I retrain the best model found after tuning?
+====================================================
+
+You can call ``tuner.trial_backend.start_trial(config=tuner.best_config())`` after tuning to retrain the best config,
+you can take a look at this example
+`examples/launch_plot_example.py <examples.html#plot-results-of-tuning-experiment>`__
+which shows how to retrain the best model found while tuning.
+
 Which schedulers make use of checkpointing?
 ===========================================
 

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -72,5 +72,5 @@ if __name__ == "__main__":
     tuning_experiment.plot()
 
     # Print the best configuration found from the tuner and retrain it
-    best_config, trial_id = tuner.best_config()
+    trial_id, best_config = tuner.best_config()
     tuner.trial_backend.start_trial(config=best_config)

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -76,4 +76,3 @@ if __name__ == "__main__":
 
     # plots values found by all trials over time
     tuning_experiment.plot_trials_over_time()
-

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -63,6 +63,9 @@ if __name__ == "__main__":
 
     tuner.run()
 
+    # shows how to print the best configuration found from the tuner and retrains it
+    trial_id, best_config = tuner.best_config()
+
     tuning_experiment = load_experiment(tuner.name)
 
     # prints the best configuration found from experiment-results
@@ -73,8 +76,4 @@ if __name__ == "__main__":
 
     # plots values found by all trials over time
     tuning_experiment.plot_trials_over_time()
-
-    # prints the best configuration found from the tuner and retrains it
-    trial_id, best_config = tuner.best_config()
-    tuner.trial_backend.start_trial(config=best_config)
 

--- a/examples/launch_plot_results.py
+++ b/examples/launch_plot_results.py
@@ -25,7 +25,7 @@ from examples.training_scripts.height_example.train_height import (
 )
 
 if __name__ == "__main__":
-    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger().setLevel(logging.INFO)
 
     random_seed = 31415927
     max_steps = 100
@@ -64,8 +64,13 @@ if __name__ == "__main__":
     tuner.run()
 
     tuning_experiment = load_experiment(tuner.name)
-    print(tuning_experiment)
 
+    # Print the best configuration found from experiment-results
     print(f"best result found: {tuning_experiment.best_config()}")
 
+    # Plot the best value found over time
     tuning_experiment.plot()
+
+    # Print the best configuration found from the tuner and retrain it
+    best_config, trial_id = tuner.best_config()
+    tuner.trial_backend.start_trial(config=best_config)

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -21,6 +21,7 @@ from typing import List, Dict, Callable, Optional, Union, Any, Tuple
 import numpy as np
 import pandas as pd
 
+from syne_tune import Tuner
 from syne_tune.constants import (
     ST_METADATA_FILENAME,
     ST_RESULTS_DATAFRAME_FILENAME,
@@ -29,7 +30,7 @@ from syne_tune.constants import (
     ST_TUNER_TIME,
 )
 from syne_tune.try_import import try_import_aws_message, try_import_visual_message
-from syne_tune.util import experiment_path, s3_experiment_path
+from syne_tune.util import experiment_path, s3_experiment_path, metric_name_mode
 
 try:
     import boto3
@@ -60,7 +61,7 @@ class ExperimentResult:
     name: str
     results: pd.DataFrame
     metadata: Dict[str, Any]
-    tuner: "Tuner"
+    tuner: Tuner
     path: Path
 
     def __str__(self):
@@ -97,7 +98,7 @@ class ExperimentResult:
             len(metrics_to_plot) > 1
         ), "Only one metric defined, cannot compute hypervolume"
 
-        metrics, metric_names, metric_modes = zip(
+        metric_names, metric_modes = zip(
             *[self._metric_name_mode(metric) for metric in metrics_to_plot]
         )
         assert np.all(
@@ -138,8 +139,8 @@ class ExperimentResult:
             If None, the figure is shown
         :param plt_kwargs: Arguments to :func:`matplotlib.pyplot.plot`
         """
-        metric, metric_name, metric_mode = self._metric_name_mode(
-            metric_to_plot, verbose=True
+        metric_name, metric_mode = self._metric_name_mode(
+            metric_to_plot
         )
 
         df = self.results
@@ -177,7 +178,7 @@ class ExperimentResult:
             default to 0 - first metric defined in the Scheduler
         :return: Configuration corresponding to best metric value
         """
-        metric, metric_name, metric_mode = self._metric_name_mode(metric, verbose=True)
+        metric_name, metric_mode = self._metric_name_mode(metric)
 
         # locate best result
         if metric_mode == "min":
@@ -190,40 +191,18 @@ class ExperimentResult:
         return {k: v for k, v in res.items() if not k.startswith("st_")}
 
     def _metric_name_mode(
-        self, metric: Union[str, int], verbose: bool = False
-    ) -> Tuple[int, str, str]:
+        self, metric: Union[str, int]
+    ) -> Tuple[str, str]:
         """
-        Determine the metric, name and its mode given ambiguous input.
+        Determine the name and its mode given ambiguous input.
         :param metric: Index or name of the selected metric
-        :param verbose: If True, prints a warning message when only one metric is selected from many
         """
-        if isinstance(metric, str):
-            assert (
-                metric in self.metric_names()
-            ), f"Attempted to use {metric} while available metrics are {self.metric_names()}"
-            metric_name = metric
-            metric = self.metric_names().index(metric)
-        elif isinstance(metric, int):
-            assert metric < len(
-                self.metric_names()
-            ), f"Attempted to use metric index={metric} with {len(self.metric_names())} available metrics"
-            metric_name = self.metric_names()[metric]
-        else:
-            raise AttributeError(
-                f"metric must be <int> or <str> but {type(metric)} was provided"
-            )
+        return metric_name_mode(
+            metric_names=self.metric_names(),
+            metric_mode=self.metric_mode(),
+            metric=metric,
+        )
 
-        if len(self.metric_names()) > 1 and verbose:
-            logger.warning(
-                "Several metrics exists, this will "
-                f"use metric={metric_name} (index={metric}) out of {self.metric_names()}."
-            )
-
-        metric_mode = self.metric_mode()
-        if isinstance(metric_mode, list):
-            metric_mode = metric_mode[metric]
-
-        return metric, metric_name, metric_mode
 
 
 def download_single_experiment(

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -21,7 +21,6 @@ from typing import List, Dict, Callable, Optional, Union, Any, Tuple
 import numpy as np
 import pandas as pd
 
-from syne_tune import Tuner
 from syne_tune.constants import (
     ST_METADATA_FILENAME,
     ST_RESULTS_DATAFRAME_FILENAME,
@@ -61,7 +60,7 @@ class ExperimentResult:
     name: str
     results: pd.DataFrame
     metadata: Dict[str, Any]
-    tuner: Tuner
+    tuner: "Tuner"
     path: Path
 
     def __str__(self):
@@ -201,17 +200,17 @@ class ExperimentResult:
         if isinstance(metric, str):
             assert (
                 metric in self.metric_names()
-            ), f"Attepted to use {metric} while available metrics are {self.metric_names()}"
+            ), f"Attempted to use {metric} while available metrics are {self.metric_names()}"
             metric_name = metric
             metric = self.metric_names().index(metric)
         elif isinstance(metric, int):
             assert metric < len(
                 self.metric_names()
-            ), f"Attepted to use metric index={metric} with {len(self.metric_names())} availale metrics"
+            ), f"Attempted to use metric index={metric} with {len(self.metric_names())} available metrics"
             metric_name = self.metric_names()[metric]
         else:
             raise AttributeError(
-                f"metic must be <int> or <str> but {type(metric)} was provided"
+                f"metric must be <int> or <str> but {type(metric)} was provided"
             )
 
         if len(self.metric_names()) > 1 and verbose:

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -139,9 +139,7 @@ class ExperimentResult:
             If None, the figure is shown
         :param plt_kwargs: Arguments to :func:`matplotlib.pyplot.plot`
         """
-        metric_name, metric_mode = self._metric_name_mode(
-            metric_to_plot
-        )
+        metric_name, metric_mode = self._metric_name_mode(metric_to_plot)
 
         df = self.results
         if df is not None and len(df) > 0:
@@ -190,9 +188,7 @@ class ExperimentResult:
         # Don't include internal fields
         return {k: v for k, v in res.items() if not k.startswith("st_")}
 
-    def _metric_name_mode(
-        self, metric: Union[str, int]
-    ) -> Tuple[str, str]:
+    def _metric_name_mode(self, metric: Union[str, int]) -> Tuple[str, str]:
         """
         Determine the name and its mode given ambiguous input.
         :param metric: Index or name of the selected metric
@@ -202,7 +198,6 @@ class ExperimentResult:
             metric_mode=self.metric_mode(),
             metric=metric,
         )
-
 
 
 def download_single_experiment(

--- a/syne_tune/experiments/experiment_result.py
+++ b/syne_tune/experiments/experiment_result.py
@@ -171,9 +171,7 @@ class ExperimentResult:
             If None, the figure is shown
         :param figsize: width and height of figure
         """
-        _, metric_name, metric_mode = self._metric_name_mode(
-            metric_to_plot, verbose=True
-        )
+        metric_name, metric_mode = self._metric_name_mode(metric_to_plot)
         df = self.results
 
         fig, ax = plt.subplots(1, 1, figsize=figsize if figsize else (12, 4))

--- a/syne_tune/tuner.py
+++ b/syne_tune/tuner.py
@@ -43,7 +43,8 @@ from syne_tune.util import (
     check_valid_sagemaker_name,
     experiment_path,
     name_from_base,
-    dump_json_with_numpy, metric_name_mode,
+    dump_json_with_numpy,
+    metric_name_mode,
 )
 
 logger = logging.getLogger(__name__)
@@ -684,7 +685,9 @@ class Tuner:
         """
         return StoreResultsCallback()
 
-    def best_config(self, metric: Optional[Union[str, int]] = 0) -> Tuple[int, Dict[str, Any]]:
+    def best_config(
+        self, metric: Optional[Union[str, int]] = 0
+    ) -> Tuple[int, Dict[str, Any]]:
         """
         :param metric: Indicates which metric to use, can be the index or a name of the metric.
             default to 0 - first metric defined in the Scheduler

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -324,8 +324,9 @@ def find_first_of_type(a: Iterable[Any], typ) -> Optional[Any]:
     except StopIteration:
         return None
 
+
 def metric_name_mode(
-        metric_names: List[str], metric_mode: Union[str, List[str]], metric: Union[str, int]
+    metric_names: List[str], metric_mode: Union[str, List[str]], metric: Union[str, int]
 ) -> Tuple[str, str]:
     """
     Retrieve the metric mode given a metric queried by either index or name.
@@ -336,7 +337,7 @@ def metric_name_mode(
     """
     if isinstance(metric, str):
         assert (
-                metric in metric_names
+            metric in metric_names
         ), f"Attempted to use {metric} while available metrics are {metric_names}"
         metric_name = metric
     elif isinstance(metric, int):
@@ -356,7 +357,9 @@ def metric_name_mode(
         )
 
     if isinstance(metric_mode, list):
-        metric_index = metric_names.index(metric_name) if isinstance(metric, str) else metric
+        metric_index = (
+            metric_names.index(metric_name) if isinstance(metric, str) else metric
+        )
         metric_mode = metric_mode[metric_index]
 
     return metric_name, metric_mode

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Optional, List, Union, Dict, Any, Iterable
 from time import perf_counter
 from contextlib import contextmanager
+from typing import Tuple, Union, List
+import logging
 
 import numpy as np
 
@@ -30,6 +32,8 @@ from syne_tune.constants import (
     ST_DATETIME_FORMAT,
 )
 from syne_tune.try_import import try_import_aws_message
+
+logger = logging.getLogger(__name__)
 
 try:
     import sagemaker
@@ -319,3 +323,40 @@ def find_first_of_type(a: Iterable[Any], typ) -> Optional[Any]:
         return next(x for x in a if isinstance(x, typ))
     except StopIteration:
         return None
+
+def metric_name_mode(
+        metric_names: List[str], metric_mode: Union[str, List[str]], metric: Union[str, int]
+) -> Tuple[str, str]:
+    """
+    Retrieve the metric mode given a metric queried by either index or name.
+    :param metric_names: metrics names defined in a scheduler
+    :param metric_mode: metric mode or modes of a scheduler
+    :param metric: Index or name of the selected metric
+    :return the name and the mode of the queried metric
+    """
+    if isinstance(metric, str):
+        assert (
+                metric in metric_names
+        ), f"Attempted to use {metric} while available metrics are {metric_names}"
+        metric_name = metric
+    elif isinstance(metric, int):
+        assert metric < len(
+            metric_names
+        ), f"Attempted to use metric index={metric} with {len(metric_names)} available metrics"
+        metric_name = metric_names[metric]
+    else:
+        raise AttributeError(
+            f"metric must be <int> or <str> but {type(metric)} was provided"
+        )
+
+    if len(metric_names) > 1:
+        logger.warning(
+            "Several metrics exists, this will "
+            f"use metric={metric_name} (index={metric}) out of {metric_names}."
+        )
+
+    if isinstance(metric_mode, list):
+        metric_index = metric_names.index(metric_name) if isinstance(metric, str) else metric
+        metric_mode = metric_mode[metric_index]
+
+    return metric_name, metric_mode

--- a/syne_tune/util.py
+++ b/syne_tune/util.py
@@ -352,7 +352,7 @@ def metric_name_mode(
 
     if len(metric_names) > 1:
         logger.warning(
-            "Several metrics exists, this will "
+            "Several metrics exist, this will "
             f"use metric={metric_name} (index={metric}) out of {metric_names}."
         )
 

--- a/tst/experiments/test_metric_name_mode.py
+++ b/tst/experiments/test_metric_name_mode.py
@@ -3,6 +3,8 @@ import pytest
 from syne_tune.util import metric_name_mode
 
 metric_names = ["m1", "m2", "m3"]
+
+
 @pytest.mark.parametrize(
     "metric_mode, query_metric, expected_metric, expected_mode,",
     [
@@ -14,12 +16,11 @@ metric_names = ["m1", "m2", "m3"]
         ("min", 1, "m2", "min"),
         (["max", "min", "max"], 1, "m2", "min"),
         (["max", "min", "max"], 2, "m3", "max"),
-
     ],
 )
 def test_metric_name_mode(metric_mode, query_metric, expected_metric, expected_mode):
-    metric_name, metric_mode = metric_name_mode(metric_names=metric_names, metric_mode=metric_mode, metric=query_metric)
+    metric_name, metric_mode = metric_name_mode(
+        metric_names=metric_names, metric_mode=metric_mode, metric=query_metric
+    )
     assert metric_name == expected_metric
     assert metric_mode == expected_mode
-
-

--- a/tst/experiments/test_metric_name_mode.py
+++ b/tst/experiments/test_metric_name_mode.py
@@ -1,0 +1,25 @@
+import pytest
+
+from syne_tune.util import metric_name_mode
+
+metric_names = ["m1", "m2", "m3"]
+@pytest.mark.parametrize(
+    "metric_mode, query_metric, expected_metric, expected_mode,",
+    [
+        ("max", "m2", "m2", "max"),
+        ("min", "m2", "m2", "min"),
+        (["max", "min", "max"], "m2", "m2", "min"),
+        (["max", "min", "max"], "m3", "m3", "max"),
+        ("max", 1, "m2", "max"),
+        ("min", 1, "m2", "min"),
+        (["max", "min", "max"], 1, "m2", "min"),
+        (["max", "min", "max"], 2, "m3", "max"),
+
+    ],
+)
+def test_metric_name_mode(metric_mode, query_metric, expected_metric, expected_mode):
+    metric_name, metric_mode = metric_name_mode(metric_names=metric_names, metric_mode=metric_mode, metric=query_metric)
+    assert metric_name == expected_metric
+    assert metric_mode == expected_mode
+
+


### PR DESCRIPTION
…ments on how to rerun the best configuration found

Also updates `metric_name_mode` to:
1) test the logic as it is quite tricky with union types
2) stop returning `metric` argument which is an input
3) don’t pass `verbose` which is always set to true and overlaps logging verbosity
4) move to an util where it can be imported to multiple places without creating import conflicts



----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
