### PR TITLE
feat: Add example to resume tuning from previous experiment and update conf…

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -461,6 +461,14 @@ Plot Results of Tuning Experiment
 Makes use of :ref:`train_height.py <train_height_script>`.
 
 
+Resume a Tuning Job
+===================
+
+.. literalinclude:: ../../examples/launch_resume_tuning.py
+   :caption: examples/launch_resume_tuning.py
+   :start-after: # permissions and limitations under the License.
+
+
 Customize Results Written during an Experiment
 ==============================================
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -219,6 +219,16 @@ at the same time (set by ``n_workers`` when creating the
 :class:`~syne_tune.Tuner`) should account for the capacity of the machine where
 the trials are executed.
 
+Is the tuner checkpointed?
+==========================
+
+Yes. When performing the tuning, the tuner state is regularly saved on the
+experiment path under ``tuner.dill`` (every 10 seconds, which can be configured
+with ``results_update_interval`` when creating the :class:`~syne_tune.Tuner`).
+This allows to use spot-instances when running a tuning remotely with the remote
+launcher. It also allows to resume a past experiment or analyse the state of
+scheduler at any point.
+
 Where can I find the output of the tuning?
 ==========================================
 
@@ -227,6 +237,16 @@ When running locally, the output of the tuning is saved under
 the output of the tuning is saved under ``/opt/ml/checkpoints/`` by default and
 the tuning output is synced regularly to
 ``s3://{sagemaker-default-bucket}/syne-tune/{tuner-name}/``.
+
+Can I resume a previous tuning job?
+===================================
+
+Yes, if you want to resume tuning you can deserialize the tuner that is regularly checkpointed to disk
+possibly after having modified some part of the scheduler
+or adapting the stopping condition to your need.
+See `examples/launch_resume_tuning.py <examples.html#resume-a-tuning-job>`__.
+for an example which resumes a previous tuning after having updated the
+configuration space.
 
 How can I change the default output folder where tuning results are stored?
 ===========================================================================
@@ -431,16 +451,6 @@ A complete example is
 `examples/launch_fashionmnist_checkpoint_removal.py <examples.html#speculative-early-checkpoint-removal>`__.
 For details on speculative checkpoint removal, look at
 :class:`~syne_tune.callbacks.hyperband_remove_checkpoints_callback.HyperbandRemoveCheckpointsCallback`.
-
-Is the tuner checkpointed?
-==========================
-
-Yes. When performing the tuning, the tuner state is regularly saved on the
-experiment path under ``tuner.dill`` (every 10 seconds, which can be configured
-with ``results_update_interval`` when creating the :class:`~syne_tune.Tuner`).
-This allows to use spot-instances when running a tuning remotely with the remote
-launcher. It also allows to resume a past experiment or analyse the state of
-scheduler at any point.
 
 Where can I find the output of my trials?
 =========================================

--- a/examples/launch_resume_tuning.py
+++ b/examples/launch_resume_tuning.py
@@ -1,0 +1,98 @@
+from syne_tune.config_space import randint
+
+import shutil
+from pathlib import Path
+
+from syne_tune import StoppingCriterion
+from syne_tune import Tuner
+from syne_tune.backend import LocalBackend
+from syne_tune.experiments import load_experiment
+from syne_tune.optimizer.baselines import ASHA
+from syne_tune.optimizer.schedulers.searchers.utils import make_hyperparameter_ranges
+from syne_tune.util import random_string
+
+
+def launch_first_tuning(experiment_name: str):
+    max_epochs = 100
+    metric = "mean_loss"
+    mode = "min"
+    config_space = {
+        "steps": max_epochs,
+        "width": randint(0, 10),
+        "height": randint(0, 10),
+    }
+
+    entry_point = (
+        Path(__file__).parent
+        / "training_scripts"
+        / "height_example"
+        / "train_height.py"
+    )
+
+    scheduler = ASHA(
+        config_space=config_space,
+        metric=metric,
+        mode=mode,
+        max_t=max_epochs,
+        search_options={"allow_duplicates": True},
+        resource_attr="epoch",
+    )
+
+    trial_backend = LocalBackend(entry_point=str(entry_point))
+
+    stop_criterion = StoppingCriterion(
+        max_num_trials_started=10,
+    )
+    tuner = Tuner(
+        trial_backend=trial_backend,
+        scheduler=scheduler,
+        stop_criterion=stop_criterion,
+        n_workers=4,
+        tuner_name=experiment_name,
+        suffix_tuner_name=False,
+    )
+
+    tuner.run()
+
+
+if __name__ == "__main__":
+    experiment_name = f"resume-tuning-example-{random_string(5)}"
+
+    # Launch a tuning, tuning results and checkpoints are written to disk
+    launch_first_tuning(experiment_name)
+
+    # Later loads an experiment from disk given the experiment name,
+    # in particular sets `load_tuner` to True to deserialize the Tuner
+    tuning_experiment = load_experiment(experiment_name, load_tuner=True)
+
+    # Copy the tuner as it will be modified when retuning
+    shutil.copy(
+        tuning_experiment.path / "tuner.dill",
+        tuning_experiment.path / "tuner-backup.dill",
+    )
+
+    # Update stop criterion to run the tuning a couple more trials than before
+    tuning_experiment.tuner.stop_criterion = StoppingCriterion(
+        max_num_trials_started=20
+    )
+
+    # Define a new config space for instance favoring a new part of the space based on data analysis
+    new_config_space = {
+        "steps": 100,
+        "width": randint(10, 20),
+        "height": randint(1, 10),
+    }
+
+    # Update scheduler with random searcher to use new configuration space,
+    # For now we modify internals, adding a method `update_config_space` to RandomSearcher would be a cleaner option.
+    tuning_experiment.tuner.scheduler.config_space = new_config_space
+    tuning_experiment.tuner.scheduler.searcher._hp_ranges = make_hyperparameter_ranges(
+        new_config_space
+    )
+    tuning_experiment.tuner.scheduler.searcher.configure_scheduler(
+        tuning_experiment.tuner.scheduler
+    )
+
+    # Resume the tuning with the modified search space and stopping criterion
+    # The scheduler will now explore the updated search space
+    tuning_experiment.tuner.run()


### PR DESCRIPTION
…ig space


Addresses issue https://github.com/awslabs/syne-tune/issues/773 by adding an example explaining how to resume a tuning and also add an item in the FAQ.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
