### PR TITLE
fix: pin traitlets version to fix notebook conversion script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ ipykernel
 pypandoc_binary
 sphinx-rtd-theme
 sphinx-autodoc-typehints
+traitlets==5.11.2
 myst-parser
 sphinx_copybutton
 sphinxcontrib-bibtex

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ ipykernel
 pypandoc_binary
 sphinx-rtd-theme
 sphinx-autodoc-typehints
-traitlets==5.11.2
+traitlets<=5.11.2
 myst-parser
 sphinx_copybutton
 sphinxcontrib-bibtex


### PR DESCRIPTION
**Problem:** The `Run Jupyter Notebooks` GitHub Actions CI workflow is failing

**Solution:** The [traitlets](https://github.com/ipython/traitlets/releases/tag/v5.12.0) package was recently updated from `5.11.2` to `5.12.0` which broke the script. Temporarily pin to `traitlets<=5.11.2`. Opened issue: https://github.com/ipython/traitlets/issues/887

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
