### PR TITLE
revert: Revert "fix: Reject results if metric is NaN or infinite"

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
+++ b/syne_tune/optimizer/schedulers/searchers/model_based_searcher.py
@@ -269,9 +269,6 @@ class ModelBasedSearcher(StochasticSearcher):
 
     def _update(self, trial_id: str, config: Dict[str, Any], result: Dict[str, Any]):
         metric_val = result[self._metric]
-        # Reject NaN or infinite values
-        if np.isnan(metric_val) or np.isinf(metric_val):
-            return
         # Transform to criterion to be minimized
         if self.map_reward is not None:
             crit_val = self.map_reward(metric_val)

--- a/tst/schedulers/test_searchers.py
+++ b/tst/schedulers/test_searchers.py
@@ -263,23 +263,3 @@ def test_restrict_configurations(scheduler_cls, is_multifid, is_bo):
                 break
         if it >= max_resource_val - 1:
             scheduler.on_trial_complete(trial=trial, result=result)
-
-
-def test_reject_nan_inf():
-    config_space = {"a": uniform(0.0, 1.0)}
-    scheduler = BayesianOptimization(
-        config_space,
-        metric="metric",
-        mode="min",
-        max_resource_attr="epochs",
-    )
-    data = [(0, 1), (1, np.nan), (0.5, 2), (0.75, np.inf), (0.8, -np.inf)]
-    for trial_id, (x, y) in enumerate(data):
-        trial = Trial(
-            trial_id=trial_id,
-            config={"a": x},
-            creation_time=datetime.now(),
-        )
-        scheduler.on_trial_complete(trial, result={"metric": y})
-    state = scheduler.searcher.state_transformer.state
-    assert len(state.trials_evaluations) == 2


### PR DESCRIPTION
Reverts awslabs/syne-tune#788

Reverting due to unit test failure after merge