### PR TITLE
chore: Uncommented test which needs SageMaker. It is still commented out

### DIFF
--- a/tst/remote_launcher/test_remote_launcher_path.py
+++ b/tst/remote_launcher/test_remote_launcher_path.py
@@ -1,65 +1,67 @@
-# # Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License").
-# # You may not use this file except in compliance with the License.
-# # A copy of the License is located at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # or in the "license" file accompanying this file. This file is distributed
-# # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# # express or implied. See the License for the specific language governing
-# # permissions and limitations under the License.
-# import logging
-# from pathlib import Path
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# import pytest
-# from sagemaker.pytorch import PyTorch
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
 #
-# from syne_tune.backend import SageMakerBackend
-# from syne_tune.backend.sagemaker_backend.sagemaker_utils import get_execution_role
-# from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
-# from syne_tune.remote.remote_launcher import RemoteLauncher
-# from syne_tune import StoppingCriterion
-# from syne_tune import Tuner
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# root = Path(__file__).parent
-# sm_estimator = PyTorch(
-#     entry_point="folder2/main.py",
-#     source_dir=str(root / "folder1"),
-#     instance_type="local",
-#     instance_count=1,
-#     py_version="py3",
-#     framework_version="1.7.1",
-#     role="dummy",
-# )
-#
-# backend = SageMakerBackend(sm_estimator=sm_estimator)
-# remote_launcher = RemoteLauncher(
-#     tuner=Tuner(
-#         backend=backend,
-#         scheduler=FIFOScheduler({}, searcher='random', metric="dummy"),
-#         stop_criterion=StoppingCriterion(max_wallclock_time=600),
-#         n_workers=4,
-#     )
-# )
-# remote_launcher.prepare_upload()
-#
-#
-# def test_check_paths():
-#     # for now, we only check that sm_estimator source_dir, endpoint script is correct
-#     # todo check that dependencies are correct
-#     remote_sm_estimator = remote_launcher.tuner.backend.sm_estimator
-#
-#     assert remote_sm_estimator.source_dir == "tuner"
-#     assert (remote_launcher.upload_dir() / "folder2" / "main.py").exists()
-#     assert (remote_launcher.upload_dir() / "requirements.txt").exists()
-#     assert (remote_launcher.upload_dir() / "tuner.dill").exists()
-#
-#
-# @pytest.mark.skip("this test is skipped currently as it takes ~15s and requires docker installed locally.")
-# def test_estimator():
-#     tuner = Tuner.load(remote_launcher.upload_dir())
-#     remote_sm_estimator = tuner.backend.sm_estimator
-#     remote_sm_estimator.source_dir = str(remote_launcher.upload_dir())
-#     remote_sm_estimator.fit()
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from pathlib import Path
+
+import pytest
+from sagemaker.pytorch import PyTorch
+
+from syne_tune.backend import SageMakerBackend
+from syne_tune.optimizer.schedulers.fifo import FIFOScheduler
+from syne_tune.remote.remote_launcher import RemoteLauncher
+from syne_tune import StoppingCriterion
+from syne_tune import Tuner
+
+
+root = Path(__file__).parent
+sm_estimator = PyTorch(
+    entry_point="folder2/main.py",
+    source_dir=str(root / "folder1"),
+    instance_type="local",
+    instance_count=1,
+    py_version="py3",
+    framework_version="1.7.1",
+    role="dummy",
+)
+
+backend = SageMakerBackend(sm_estimator=sm_estimator)
+remote_launcher = RemoteLauncher(
+    tuner=Tuner(
+        trial_backend=backend,
+        scheduler=FIFOScheduler({}, searcher="random", metric="dummy"),
+        stop_criterion=StoppingCriterion(max_wallclock_time=600),
+        n_workers=4,
+    )
+)
+remote_launcher.prepare_upload()
+
+
+@pytest.mark.skip("this test needs sagemaker")
+def test_check_paths():
+    # for now, we only check that sm_estimator source_dir, endpoint script is correct
+    # todo check that dependencies are correct
+    remote_sm_estimator = remote_launcher.tuner.trial_backend.sm_estimator
+
+    assert remote_sm_estimator.source_dir == "tuner"
+    assert (remote_launcher.upload_dir() / "folder2" / "main.py").exists()
+    assert (remote_launcher.upload_dir() / "requirements.txt").exists()
+    assert (remote_launcher.upload_dir() / "tuner.dill").exists()
+
+
+@pytest.mark.skip(
+    "this test is skipped currently as it takes ~15s and requires docker installed locally."
+)
+def test_estimator():
+    tuner = Tuner.load(str(remote_launcher.upload_dir()))
+    remote_sm_estimator = tuner.backend.sm_estimator
+    remote_sm_estimator.source_dir = str(remote_launcher.upload_dir())
+    remote_sm_estimator.fit()

--- a/tst/schedulers/test_schedulers_api.py
+++ b/tst/schedulers/test_schedulers_api.py
@@ -39,7 +39,7 @@ from syne_tune.optimizer.baselines import (
     SyncMOBSTER,
     ZeroShotTransfer,
     MOREA,
-    # NSGA2,
+    NSGA2,
     CQR,
     ASHACQR,
     MOLinearScalarizationBayesOpt,
@@ -261,13 +261,12 @@ list_schedulers_to_test = [
         population_size=1,
         sample_size=2,
     ),
-    # DISABLED: PyMOO seems to have a bug?
-    # NSGA2(
-    #     config_space=config_space,
-    #     metric=[metric1, metric2],
-    #     mode=[mode, mode],
-    #     population_size=10,
-    # ),
+    NSGA2(
+        config_space=config_space,
+        metric=[metric1, metric2],
+        mode=[mode, mode],
+        population_size=10,
+    ),
     ASHA(
         config_space=config_space,
         metric=metric1,


### PR DESCRIPTION
This is to close an issue. We currently do not execute unit tests which require SageMaker. We run code in `examples/` which uses SageMaker, but not tests.

Closes #476.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
