### PR TITLE
Kill subprocesses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "scikit-learn",
     "xgboost",
     "tqdm",
+    "psutil",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We were not killing subprocesses in the local backend which prevents from using DDP on multiple GPUs as the subworkers are not killed which leads to runtime OOMs errors.

Downside: we require psutil as an extra-dependency but it has no dependency, is widely used across the ecosystem. I considered also supporting killing subprocesses in a synetune util but it seems involved if we want to make it crossplatform.