### PR TITLE
fix: correctly pass do_minimize

### DIFF
--- a/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/transfer_learning_mixin.py
@@ -21,7 +21,7 @@ class TransferLearningMixin:
         :param metric_names: name of the metric to be optimized.
         """
         super().__init__(
-            config_space=config_space, random_seed=random_seed, metric=metric
+            config_space=config_space, random_seed=random_seed, metric=metric, **kwargs
         )
         self.metric = metric
         self._check_consistency(

--- a/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
+++ b/syne_tune/optimizer/schedulers/transfer_learning/zero_shot.py
@@ -34,7 +34,7 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
 
     :param transfer_learning_evaluations: Dictionary from task name to
         offline evaluations.
-    :param mode: Whether to minimize ("min", default) or maximize ("max")
+    :param do_minimize: Whether to minimize (True, default) or maximize (False)
     :param sort_transfer_learning_evaluations: Use ``False`` if the
         hyperparameters for each task in ``transfer_learning_evaluations`` are
         already in the same order. If set to ``True``, hyperparameters are sorted.
@@ -62,7 +62,9 @@ class ZeroShotTransfer(TransferLearningMixin, SingleObjectiveScheduler):
             metric=metric,
             transfer_learning_evaluations=transfer_learning_evaluations,
             random_seed=random_seed,
+            do_minimize=do_minimize,
         )
+
         if use_surrogates and len(transfer_learning_evaluations) <= 1:
             use_surrogates = False
             sort_transfer_learning_evaluations = False


### PR DESCRIPTION
`do_minimize `is now correctly passed through the MRO chain when calling `super().__init__()`.
Also changed class description to our new naming convention for optimization direction.

Closes #1023 .

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
