### PR TITLE
fix: added parameter and checks for multi-objective in searcher factory

### DIFF
--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -33,13 +33,17 @@ def searcher_cls(searcher_name: str, is_multi_objective: bool = False):
         return RandomSearcher
     elif searcher_name == "bore":
         if is_multi_objective:
-            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
+            raise ValueError(
+                f"Searcher '{searcher_name}' does not support multi-objective optimization."
+            )
         from syne_tune.optimizer.schedulers.searchers.bore import Bore
 
         return Bore
     elif searcher_name == "kde":
         if is_multi_objective:
-            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
+            raise ValueError(
+                f"Searcher '{searcher_name}' does not support multi-objective optimization."
+            )
         from syne_tune.optimizer.schedulers.searchers.kde import (
             KernelDensityEstimator,
         )
@@ -55,7 +59,9 @@ def searcher_cls(searcher_name: str, is_multi_objective: bool = False):
         return RegularizedEvolution
     elif searcher_name == "cqr":
         if is_multi_objective:
-            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
+            raise ValueError(
+                f"Searcher '{searcher_name}' does not support multi-objective optimization."
+            )
         from syne_tune.optimizer.schedulers.searchers.conformal.conformal_quantile_regression_searcher import (
             ConformalQuantileRegression,
         )
@@ -63,7 +69,9 @@ def searcher_cls(searcher_name: str, is_multi_objective: bool = False):
         return ConformalQuantileRegression
     elif searcher_name == "botorch":
         if is_multi_objective:
-            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
+            raise ValueError(
+                f"Searcher '{searcher_name}' does not support multi-objective optimization."
+            )
         from syne_tune.optimizer.schedulers.searchers.botorch.botorch_searcher import (
             BoTorchSearcher,
         )
@@ -74,6 +82,11 @@ def searcher_cls(searcher_name: str, is_multi_objective: bool = False):
 
 
 def searcher_factory(
-    searcher_name: str, config_space: dict[str, Any], is_multi_objective: bool = False, **searcher_kwargs
+    searcher_name: str,
+    config_space: dict[str, Any],
+    is_multi_objective: bool = False,
+    **searcher_kwargs,
 ) -> BaseSearcher:
-    return searcher_cls(searcher_name, is_multi_objective=is_multi_objective)(config_space=config_space, **searcher_kwargs)
+    return searcher_cls(searcher_name, is_multi_objective=is_multi_objective)(
+        config_space=config_space, **searcher_kwargs
+    )

--- a/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
+++ b/syne_tune/optimizer/schedulers/searchers/searcher_factory.py
@@ -17,32 +17,53 @@ searchers = [
 ]
 
 
-def searcher_cls(searcher_name: str):
+def searcher_cls(searcher_name: str, is_multi_objective: bool = False):
     """
     :param searcher_name:
+    :param is_multi_objective: Whether the searcher needs to support multi-objective optimization
     :return: the class associated to the searcher string
     """
     if searcher_name == "random_search":
+        if is_multi_objective:
+            from syne_tune.optimizer.schedulers.searchers.random_searcher import (
+                MultiObjectiveRandomSearcher,
+            )
+
+            return MultiObjectiveRandomSearcher
         return RandomSearcher
     elif searcher_name == "bore":
+        if is_multi_objective:
+            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
         from syne_tune.optimizer.schedulers.searchers.bore import Bore
 
         return Bore
     elif searcher_name == "kde":
+        if is_multi_objective:
+            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
         from syne_tune.optimizer.schedulers.searchers.kde import (
             KernelDensityEstimator,
         )
 
         return KernelDensityEstimator
     elif searcher_name == "regularized_evolution":
+        if is_multi_objective:
+            from syne_tune.optimizer.schedulers.multiobjective.multi_objective_regularized_evolution import (
+                MultiObjectiveRegularizedEvolution,
+            )
+
+            return MultiObjectiveRegularizedEvolution
         return RegularizedEvolution
     elif searcher_name == "cqr":
+        if is_multi_objective:
+            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
         from syne_tune.optimizer.schedulers.searchers.conformal.conformal_quantile_regression_searcher import (
             ConformalQuantileRegression,
         )
 
         return ConformalQuantileRegression
     elif searcher_name == "botorch":
+        if is_multi_objective:
+            raise ValueError(f"Searcher '{searcher_name}' does not support multi-objective optimization.")
         from syne_tune.optimizer.schedulers.searchers.botorch.botorch_searcher import (
             BoTorchSearcher,
         )
@@ -53,6 +74,6 @@ def searcher_cls(searcher_name: str):
 
 
 def searcher_factory(
-    searcher_name: str, config_space: dict[str, Any], **searcher_kwargs
+    searcher_name: str, config_space: dict[str, Any], is_multi_objective: bool = False, **searcher_kwargs
 ) -> BaseSearcher:
-    return searcher_cls(searcher_name)(config_space=config_space, **searcher_kwargs)
+    return searcher_cls(searcher_name, is_multi_objective=is_multi_objective)(config_space=config_space, **searcher_kwargs)

--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -62,7 +62,12 @@ class SingleFidelityScheduler(TrialScheduler):
             if searcher_kwargs is None:
                 searcher_kwargs = {}
 
-            self.searcher = searcher_factory(searcher, config_space, **searcher_kwargs)
+            self.searcher = searcher_factory(
+                searcher,
+                config_space,
+                is_multi_objective=len(self.metrics) > 1,
+                **searcher_kwargs
+            )
         else:
             self.searcher = searcher
 

--- a/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
+++ b/syne_tune/optimizer/schedulers/single_fidelity_scheduler.py
@@ -66,7 +66,7 @@ class SingleFidelityScheduler(TrialScheduler):
                 searcher,
                 config_space,
                 is_multi_objective=len(self.metrics) > 1,
-                **searcher_kwargs
+                **searcher_kwargs,
             )
         else:
             self.searcher = searcher


### PR DESCRIPTION
Added a new parameter `is_multi_objective` in `searcher_factory.py` and `single_fidelity_scheduler.py`, to make multi-objective optimization possible. Throws errors when running >1 metrics and single-objective methods.

Closes #888 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
